### PR TITLE
Fix preview API response schema

### DIFF
--- a/packages/api/src/routes/preview.ts
+++ b/packages/api/src/routes/preview.ts
@@ -9,8 +9,10 @@ export namespace get {
   export const endpoint = (previewId: number) =>
     endpointify(route, { previewId });
   export const paramsSchema = z.object({ previewId: z.coerce.number() });
-  export const responseSchema = z.object({ id: z.number() });
-  export type Response = z.infer<typeof responseSchema>;
+  // Server returns the preview file data directly, so the response schema
+  // should match the uploaded item schema instead of an object with an id.
+  export const responseSchema = itemSchema;
+  export type Response = Item;
 }
 
 export namespace upload {


### PR DESCRIPTION
## Summary
- fix incorrect preview response schema to match server behavior

## Testing
- `yarn lint` *(fails: Couldn't find node_modules state file)*
- `python -m py_compile packages/python-backend/musetric/**/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6842aa31964c83229087bb9c6a2f734d