### PR TITLE
Implement simple project player

### DIFF
--- a/packages/api/src/routes/sound.ts
+++ b/packages/api/src/routes/sound.ts
@@ -5,6 +5,26 @@ import { axiosRequest } from './common/axiosRequest';
 export const typeSchema = z.enum(['original', 'vocal', 'instrumental']);
 export type Type = z.infer<typeof typeSchema>;
 
+export namespace get {
+  export const base = createApiRoute({
+    method: 'get',
+    path: '/api/sound/project/:projectId/:type',
+    paramsSchema: z.object({
+      projectId: z.number(),
+      type: typeSchema,
+    }),
+    requestSchema: z.void(),
+    responseSchema: z.instanceof(Uint8Array<ArrayBufferLike>),
+  });
+  export const url = (projectId: number, type: Type) =>
+    base.endpoint({ projectId, type });
+  export const route = fastifyRoute(base);
+  export const request = axiosRequest(base);
+  export type Params = z.infer<typeof base.paramsSchema>;
+  export type Request = z.infer<typeof base.requestSchema>;
+  export type Response = z.infer<typeof base.responseSchema>;
+}
+
 export namespace upload {
   export const base = createApiRoute({
     method: 'post',

--- a/packages/backend/src/routers/index.ts
+++ b/packages/backend/src/routers/index.ts
@@ -1,8 +1,10 @@
 import { FastifyInstance } from 'fastify';
 import { previewRouter } from './preview';
 import { projectRouter } from './project';
+import { soundRouter } from './sound';
 
 export const registerRouters = async (app: FastifyInstance) => {
   app.register(previewRouter);
   app.register(projectRouter);
+  app.register(soundRouter);
 };

--- a/packages/backend/src/routers/preview.ts
+++ b/packages/backend/src/routers/preview.ts
@@ -1,5 +1,6 @@
 import crypto from 'crypto';
 import { api } from '@musetric/api';
+import { Prisma } from '@prisma/client';
 import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
 import { prisma } from '../common/prisma';
 
@@ -11,7 +12,7 @@ export const previewRouter: FastifyPluginAsyncZod = async (app) => {
   app.route({
     ...api.preview.get.route,
     handler: (request, reply) =>
-      prisma.$transaction(async (tx) => {
+      prisma.$transaction(async (tx: Prisma.TransactionClient) => {
         const { previewId } = request.params;
         const preview = await tx.preview.findUnique({
           where: { id: previewId },

--- a/packages/backend/src/routers/sound.ts
+++ b/packages/backend/src/routers/sound.ts
@@ -1,0 +1,45 @@
+import crypto from 'crypto';
+import { api } from '@musetric/api';
+import { Prisma } from '@prisma/client';
+import { FastifyPluginAsyncZod } from 'fastify-type-provider-zod';
+import { prisma } from '../common/prisma';
+
+export const soundRouter: FastifyPluginAsyncZod = async (app) => {
+  app.addHook('onRoute', (opts) => {
+    if (opts.schema) opts.schema.tags = ['sound'];
+  });
+
+  app.route({
+    ...api.sound.get.route,
+    handler: (request, reply) =>
+      prisma.$transaction(async (tx: Prisma.TransactionClient) => {
+        const { projectId, type } = request.params;
+        const sound = await tx.sound.findFirst({
+          where: { projectId, type },
+        });
+
+        if (!sound) {
+          reply.code(404);
+          return {
+            message: `Sound for project ${projectId} with type ${type} not found`,
+          };
+        }
+
+        const etag = crypto.createHash('md5').update(sound.data).digest('hex');
+
+        reply.headers({
+          'content-type': sound.contentType,
+          'content-disposition': `attachment; filename*=UTF-8''${encodeURIComponent(sound.filename)}`,
+          'cache-control': 'public, max-age=86400',
+          etag,
+        });
+
+        if (request.headers['if-none-match'] === etag) {
+          reply.code(304);
+          return;
+        }
+
+        return sound.data;
+      }),
+  });
+};

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -40,5 +40,8 @@
     "vite-plugin-static-copy": "3.0.0",
     "zod": "3.25.64",
     "zustand": "5.0.5"
+  },
+  "dependencies": {
+    "wavesurfer.js": "7.9.5"
   }
 }

--- a/packages/frontend/src/api/endpoints/sound.ts
+++ b/packages/frontend/src/api/endpoints/sound.ts
@@ -1,4 +1,5 @@
 import { api } from '@musetric/api';
+import { queryOptions } from '@tanstack/react-query';
 import axios from 'axios';
 import { mutationOptions } from '../queryClient';
 
@@ -9,5 +10,14 @@ export const addOriginalSoundApi = (projectId: number) =>
       api.sound.upload.request(axios, {
         params: { projectId },
         data: { file },
+      }),
+  });
+
+export const getSoundApi = (projectId: number, type: api.sound.Type) =>
+  queryOptions({
+    queryKey: ['getSoundApi', projectId, type],
+    queryFn: () =>
+      api.sound.get.request(axios, {
+        params: { projectId, type },
       }),
   });

--- a/packages/frontend/src/pages/project/Player.tsx
+++ b/packages/frontend/src/pages/project/Player.tsx
@@ -1,0 +1,50 @@
+import PauseIcon from '@mui/icons-material/Pause';
+import PlayArrowIcon from '@mui/icons-material/PlayArrow';
+import { Box, IconButton, Stack } from '@mui/material';
+import { FC, useEffect, useRef, useState } from 'react';
+import WaveSurfer from 'wavesurfer.js';
+
+export type PlayerProps = {
+  blob: Blob;
+};
+
+export const Player: FC<PlayerProps> = (props) => {
+  const { blob } = props;
+  const containerRef = useRef<HTMLDivElement>(null);
+  const wavesurferRef = useRef<WaveSurfer | null>(null);
+  const [playing, setPlaying] = useState(false);
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const ws = WaveSurfer.create({
+      container: containerRef.current,
+      height: 64,
+      waveColor: '#9e9e9e',
+      progressColor: '#1976d2',
+    });
+    wavesurferRef.current = ws;
+    ws.loadBlob(blob);
+    ws.on('finish', () => setPlaying(false));
+    return () => {
+      ws.destroy();
+    };
+  }, [blob]);
+
+  const toggle = () => {
+    const ws = wavesurferRef.current;
+    if (!ws) return;
+    ws.playPause();
+    setPlaying(ws.isPlaying());
+  };
+
+  return (
+    <Stack direction='row' alignItems='center' gap={1} sx={{ width: '100%' }}>
+      <Box sx={{ flex: 1 }}>
+        <div ref={containerRef} />
+      </Box>
+      <IconButton onClick={toggle}>
+        {playing ? <PauseIcon /> : <PlayArrowIcon />}
+      </IconButton>
+    </Stack>
+  );
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1236,6 +1236,7 @@ __metadata:
     typescript: "npm:5.8.3"
     vite: "npm:6.3.5"
     vite-plugin-static-copy: "npm:3.0.0"
+    wavesurfer.js: "npm:7.9.5"
     zod: "npm:3.25.64"
     zustand: "npm:5.0.5"
   languageName: unknown
@@ -7407,6 +7408,13 @@ __metadata:
     matcher-collection: "npm:^2.0.0"
     minimatch: "npm:^3.0.4"
   checksum: 10c0/45fe284ffa28440f0d3d0a136b3c3fe2a0f55bf207db22c481eea9e7ab7cef6d820491485d76e9f1af9dab7489c6d7a0efbd1ebf45b43dbf871f046f0b4760bd
+  languageName: node
+  linkType: hard
+
+"wavesurfer.js@npm:7.9.5":
+  version: 7.9.5
+  resolution: "wavesurfer.js@npm:7.9.5"
+  checksum: 10c0/ec1703c7b49b51e1ac75712588054276a0275604bd47ac576ecfa4f3f274c5a174d77391833b16b3e73b9aecd87374741daed5951d85276f6502cd18709e927c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- add sound fetch endpoint to api package
- support /sound route in backend
- fetch sound on project page and show wave player
- implement WaveSurfer-based player component
- install wavesurfer.js in frontend

## Testing
- `yarn check:ts`
- `yarn check:lint`
- `yarn check:format`

------
https://chatgpt.com/codex/tasks/task_e_68580f5db4348322b7941b974ba07654