### PR TITLE
refactor(spectrogram): invalidateSamples and Fourier dispatch range

### DIFF
--- a/packages/engine/src/decoder/runtime.worker.ts
+++ b/packages/engine/src/decoder/runtime.worker.ts
@@ -55,12 +55,19 @@ export const createDecoderRuntime = (options: CreateDecoderRuntimeOptions) => {
   let recordingChannels: Float32Array<SharedArrayBuffer>[] | undefined =
     undefined;
 
-  const notifyRecordingSamplesChanged = (frameCount: number) => {
-    if (frameCount <= 0) {
+  const notifyRecordingSamplesChanged = (change: {
+    frameIndex: number;
+    frameCount: number;
+  }) => {
+    if (change.frameCount <= 0) {
       return;
     }
 
-    spectrogramPort.methods.samplesChanged({ trackKey: 'recording' });
+    spectrogramPort.methods.samplesChanged({
+      trackKey: 'recording',
+      frameIndex: change.frameIndex,
+      frameCount: change.frameCount,
+    });
   };
 
   const getRecordingFrameCount = (): number => {
@@ -76,15 +83,15 @@ export const createDecoderRuntime = (options: CreateDecoderRuntimeOptions) => {
   const writeRecordingSamples = (
     frameIndex: number,
     samples: Float32Array,
-  ): number => {
+  ): { frameIndex: number; frameCount: number } => {
     const channels = recordingChannels;
     if (!channels) {
-      return 0;
+      return { frameIndex, frameCount: 0 };
     }
 
     const recordingFrameCount = getRecordingFrameCount();
     if (recordingFrameCount <= 0) {
-      return 0;
+      return { frameIndex, frameCount: 0 };
     }
 
     const skippedFrameCount = Math.max(0, -frameIndex);
@@ -93,7 +100,7 @@ export const createDecoderRuntime = (options: CreateDecoderRuntimeOptions) => {
       targetFrameIndex >= recordingFrameCount ||
       skippedFrameCount >= samples.length
     ) {
-      return 0;
+      return { frameIndex: targetFrameIndex, frameCount: 0 };
     }
 
     const frameCount = Math.min(
@@ -107,7 +114,7 @@ export const createDecoderRuntime = (options: CreateDecoderRuntimeOptions) => {
     for (const channel of channels) {
       channel.set(patch, targetFrameIndex);
     }
-    return frameCount;
+    return { frameIndex: targetFrameIndex, frameCount };
   };
 
   return {
@@ -158,11 +165,8 @@ export const createDecoderRuntime = (options: CreateDecoderRuntimeOptions) => {
       };
     },
     patchRecordingSamples: (message) => {
-      const frameCount = writeRecordingSamples(
-        message.frameIndex,
-        message.samples,
-      );
-      notifyRecordingSamplesChanged(frameCount);
+      const change = writeRecordingSamples(message.frameIndex, message.samples);
+      notifyRecordingSamplesChanged(change);
     },
     unmount: () => {
       recordingChannels = undefined;

--- a/packages/engine/src/spectrogram/protocol.cross.ts
+++ b/packages/engine/src/spectrogram/protocol.cross.ts
@@ -2,10 +2,6 @@ import { type SpectrogramConfig, type TrackKey } from '@musetric/spectrogram';
 import { createMessageChannel } from '@musetric/utils/cross/messageChannel';
 import { type EmptyPortMethods } from '@musetric/utils/cross/messagePort';
 
-// Shared playback position written by the player worklet. Slot 0 holds the
-// current frameIndex (see playhead.cross.ts for the layout).
-// The worker polls it instead of receiving a setTrackProgress postMessage per
-// frame while playing.
 export type SpectrogramPlayhead = Int32Array<SharedArrayBuffer>;
 
 export type SpectrogramOutboundMethods = {
@@ -61,7 +57,11 @@ export type SpectrogramLaneSamples = Partial<
 export type SpectrogramDataMethods = {
   mount: (message: { samples: SpectrogramLaneSamples }) => void;
   unmount: () => void;
-  samplesChanged: (message: { trackKey: TrackKey }) => void;
+  samplesChanged: (message: {
+    trackKey: TrackKey;
+    frameIndex: number;
+    frameCount: number;
+  }) => void;
 };
 
 export const spectrogramDataChannel = createMessageChannel<

--- a/packages/engine/src/spectrogram/runtime.worker.ts
+++ b/packages/engine/src/spectrogram/runtime.worker.ts
@@ -1,9 +1,10 @@
-import { allTrackKeys, type TrackKey } from '@musetric/spectrogram';
+import { allTrackKeys } from '@musetric/spectrogram';
 import {
   averageMetrics,
   createSpectrogramProcessor,
   getGpuDevice,
   type SpectrogramProcessorMetrics,
+  type SpectrogramSampleInvalidation,
 } from '@musetric/spectrogram/gpu';
 import { createAnimationFrameLoop } from '@musetric/utils/cross/animationFrameLoop';
 import { createThrottleTime } from '@musetric/utils/cross/throttleTime';
@@ -23,8 +24,6 @@ export type CreateSpectrogramRuntimeOptions = {
   profiling?: boolean;
 };
 
-// Slot 0 of the shared playhead holds the current frameIndex (layout owned by
-// playhead.cross.ts).
 const playheadFrameIndexSlot = 0;
 
 const emptySamples = (): SpectrogramLaneSamples =>
@@ -33,15 +32,18 @@ const emptySamples = (): SpectrogramLaneSamples =>
     return acc;
   }, {});
 
+const playheadAdvanceInvalidations: readonly SpectrogramSampleInvalidation[] =
+  allTrackKeys.map((trackKey) => ({
+    trackKey,
+    frameIndex: 0,
+    frameCount: 0,
+  }));
+
 export const createSpectrogramRuntime = async (
   options: CreateSpectrogramRuntimeOptions,
 ) => {
   const { port, dataPort, playhead, profiling } = options;
 
-  // The status is posted to the main thread after every render, but it almost
-  // never changes between frames. Posting an identical 'success' ~60 times per
-  // second was the dominant worker cost (cross-thread postMessage + main-thread
-  // store churn), so only post when the status actually transitions.
   let lastStatus: 'pending' | 'error' | 'success' | undefined = undefined;
   const setStatus = (status: 'pending' | 'error' | 'success') => {
     if (status === lastStatus) {
@@ -79,26 +81,16 @@ export const createSpectrogramRuntime = async (
   const hasAnySamples = () =>
     allTrackKeys.some((key) => samplesByLane[key] !== undefined);
 
-  const render = async (renderOptions?: {
-    dirtyTracks?: readonly TrackKey[];
-    contentChangedTracks?: readonly TrackKey[];
-  }) => {
+  const render = async () => {
     if (!hasAnySamples()) {
       return;
     }
-
-    const ok = await processor.render(samplesByLane, trackProgress, {
-      dirtyTracks: renderOptions?.dirtyTracks,
-      contentChangedTracks: renderOptions?.contentChangedTracks,
-    });
+    const ok = await processor.render(samplesByLane, trackProgress);
     if (!ok) {
       return;
     }
     setStatus('success');
   };
-
-  const presentTrackKeys = (): TrackKey[] =>
-    allTrackKeys.filter((key) => samplesByLane[key] !== undefined);
 
   const playheadTrackProgress = () => {
     if (frameCount <= 0) {
@@ -108,8 +100,6 @@ export const createSpectrogramRuntime = async (
     return Math.min(1, Math.max(0, frameIndex / frameCount));
   };
 
-  // While playing, the worker reads the shared playhead on its own interval and
-  // re-renders, so the main thread no longer pushes setTrackProgress per frame.
   const renderFromPlayhead = async () => {
     if (rendering) {
       return;
@@ -117,6 +107,7 @@ export const createSpectrogramRuntime = async (
     rendering = true;
     try {
       trackProgress = playheadTrackProgress();
+      processor.invalidateSamples(playheadAdvanceInvalidations);
       await render();
     } finally {
       rendering = false;
@@ -128,17 +119,20 @@ export const createSpectrogramRuntime = async (
   dataPort.bindHandlers({
     mount: async (message) => {
       samplesByLane = { ...emptySamples(), ...message.samples };
-      await render({ contentChangedTracks: presentTrackKeys() });
+      await render();
     },
     unmount: () => {
       samplesByLane = emptySamples();
       setStatus('pending');
     },
     samplesChanged: (message) => {
-      void render({
-        dirtyTracks: [message.trackKey],
-        contentChangedTracks: [message.trackKey],
-      });
+      processor.invalidateSamples([
+        {
+          trackKey: message.trackKey,
+          frameIndex: message.frameIndex,
+          frameCount: message.frameCount,
+        },
+      ]);
     },
   });
 
@@ -179,6 +173,7 @@ export const createSpectrogramRuntime = async (
         renderLoop.start();
       } else {
         renderLoop.stop();
+        void render();
       }
     },
     updateConfig: (message) => {

--- a/packages/fft/src/fourier/types.ts
+++ b/packages/fft/src/fourier/types.ts
@@ -12,9 +12,14 @@ export type FourierArg = {
   config: FourierConfig;
 };
 
+export type FourierDispatchRange = {
+  slotOffset: number;
+  columnCount: number;
+};
+
 export type Fourier = {
   run: (encoder: GPUCommandEncoder) => void;
-  dispatch: (pass: GPUComputePassEncoder) => void;
+  dispatch: (pass: GPUComputePassEncoder, range?: FourierDispatchRange) => void;
 };
 
 export type CreateFourier = (

--- a/packages/performance/src/runPipeline.ts
+++ b/packages/performance/src/runPipeline.ts
@@ -126,12 +126,7 @@ export const runPipeline = async (
     onMetrics: (metrics) => metricsArray.push(metrics),
   });
 
-  const renderOptions =
-    params.trackScope === 'all'
-      ? undefined
-      : { dirtyTracks: [params.trackScope] };
-
-  if (renderOptions) {
+  if (params.trackScope !== 'all') {
     await processor.render(
       { lead: samples, recording: recordingSamples },
       progress,
@@ -139,21 +134,32 @@ export const runPipeline = async (
     metricsArray.length = 0;
   }
 
+  const scopeInvalidation =
+    params.trackScope === 'all'
+      ? []
+      : [
+          {
+            trackKey: params.trackScope,
+            frameIndex: 0,
+            frameCount: 0,
+          },
+        ];
+
   for (let i = 0; i < warmupIters; i++) {
+    processor.invalidateSamples(scopeInvalidation);
     await processor.render(
       { lead: samples, recording: recordingSamples },
       progress,
-      renderOptions,
     );
   }
   metricsArray.length = 0;
 
   for (let tryIndex = 0; tryIndex < benchMaxTries; tryIndex++) {
     for (let i = 0; i < benchBatchSize; i++) {
+      processor.invalidateSamples(scopeInvalidation);
       await processor.render(
         { lead: samples, recording: recordingSamples },
         progress,
-        renderOptions,
       );
     }
 

--- a/packages/spectrogram/src/processor.ts
+++ b/packages/spectrogram/src/processor.ts
@@ -18,22 +18,20 @@ import { type SpectrogramLaneWork } from './lane/index.js';
 
 export type SpectrogramSamples = Partial<Record<TrackKey, Float32Array>>;
 
-export type SpectrogramRenderOptions = {
-  dirtyTracks?: readonly TrackKey[];
-  /**
-   * Tracks whose underlying PCM content changed since the last render (e.g. a
-   * recording write into the shared sample buffer). These force a full re-upload
-   * of the sample ring instead of an incremental playhead-slide upload.
-   */
-  contentChangedTracks?: readonly TrackKey[];
+export type SpectrogramSampleInvalidation = {
+  trackKey: TrackKey;
+  frameIndex: number;
+  frameCount: number;
 };
 
 export type SpectrogramProcessor = {
   render: (
     samples: SpectrogramSamples,
     trackProgress: number,
-    options?: SpectrogramRenderOptions,
   ) => Promise<boolean>;
+  invalidateSamples: (
+    invalidations: readonly SpectrogramSampleInvalidation[],
+  ) => void;
   updateConfig: (config: Partial<SpectrogramConfig>) => void;
   dispose: () => void;
 };
@@ -53,22 +51,6 @@ const createTrackFlags = (): Record<TrackKey, boolean> =>
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     {} as Record<TrackKey, boolean>,
   );
-
-const createTrackSelection = (
-  dirtyTracks?: readonly TrackKey[],
-): Record<TrackKey, boolean> => {
-  const selection = createTrackFlags();
-  if (!dirtyTracks) {
-    for (const key of allTrackKeys) {
-      selection[key] = true;
-    }
-    return selection;
-  }
-  for (const key of dirtyTracks) {
-    selection[key] = true;
-  }
-  return selection;
-};
 
 const createTrackWork = (
   runtime: SpectrogramRuntime,
@@ -306,23 +288,46 @@ export const createSpectrogramProcessor = (
   );
 
   const lastRendered: Record<TrackKey, boolean> = createTrackFlags();
+  const pendingDirty = new Set<TrackKey>();
+  const pendingContentChanged = new Set<TrackKey>();
+  const lastSamples: Record<TrackKey, Float32Array | undefined> =
+    allTrackKeys.reduce(
+      (acc, key) => {
+        acc[key] = undefined;
+        return acc;
+      },
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+      {} as Record<TrackKey, Float32Array | undefined>,
+    );
 
   const render = markers.total(
-    async (
-      samples: SpectrogramSamples,
-      trackProgress: number,
-      renderOptions?: SpectrogramRenderOptions,
-    ) => {
+    async (samples: SpectrogramSamples, trackProgress: number) => {
       const runtime = configurator.configure();
       if (!runtime) {
         return false;
       }
       timer.configure();
       const work = createTrackWork(runtime);
-      const dirty = createTrackSelection(renderOptions?.dirtyTracks);
-      const contentChanged = createTrackSelection(
-        renderOptions?.contentChangedTracks ?? [],
-      );
+      for (const key of allTrackKeys) {
+        const current = samples[key];
+        if (current !== undefined && lastSamples[key] !== current) {
+          pendingContentChanged.add(key);
+          pendingDirty.add(key);
+        }
+      }
+      const dirty = createTrackFlags();
+      const contentChanged = createTrackFlags();
+      const noExplicitDirty = pendingDirty.size === 0;
+      for (const key of allTrackKeys) {
+        if (noExplicitDirty) {
+          dirty[key] = samples[key] !== undefined;
+        } else if (pendingDirty.has(key)) {
+          dirty[key] = samples[key] !== undefined;
+        }
+        if (pendingContentChanged.has(key)) {
+          contentChanged[key] = samples[key] !== undefined;
+        }
+      }
       const presence: Record<TrackKey, boolean> = createTrackFlags();
       const clearMissing: Record<TrackKey, boolean> = createTrackFlags();
       for (const key of allTrackKeys) {
@@ -349,20 +354,19 @@ export const createSpectrogramProcessor = (
       for (const key of allTrackKeys) {
         if (dirty[key] || clearMissing[key]) {
           lastRendered[key] = presence[key];
+          lastSamples[key] = samples[key];
         }
       }
+      pendingDirty.clear();
+      pendingContentChanged.clear();
       return true;
     },
   );
 
   return {
     render: createCallLatest(
-      async (
-        samples: SpectrogramSamples,
-        trackProgress: number,
-        renderOptions?: SpectrogramRenderOptions,
-      ) => {
-        const ok = await render(samples, trackProgress, renderOptions);
+      async (samples: SpectrogramSamples, trackProgress: number) => {
+        const ok = await render(samples, trackProgress);
         if (!ok) {
           return false;
         }
@@ -370,6 +374,14 @@ export const createSpectrogramProcessor = (
         return true;
       },
     ),
+    invalidateSamples: (invalidations) => {
+      for (const invalidation of invalidations) {
+        pendingDirty.add(invalidation.trackKey);
+        if (invalidation.frameCount > 0) {
+          pendingContentChanged.add(invalidation.trackKey);
+        }
+      }
+    },
     updateConfig: configurator.updateConfig,
     dispose: () => {
       timer.dispose();


### PR DESCRIPTION
- SpectrogramProcessor.render drops its options argument; per-track dirty and contentChanged flags are queued via a new invalidateSamples ({trackKey, frameIndex, frameCount}) method and consumed by the next render. frameCount > 0 marks the track as contentChanged so the slice-samples ring does a full re-upload; frameCount === 0 only widens the dirty set for playhead-driven re-renders. A fresh sample reference on a track also queues both flags, preserving the mount-time full re-upload.
- Fourier.dispatch gains an optional range: {slotOffset, columnCount}. Existing implementations accept the parameter without narrowing the transform yet.
- SpectrogramDataMethods.samplesChanged now carries frameIndex and frameCount. The decoder's writeRecordingSamples returns the same change object so the worker can forward the precise range downstream.
- The spectrogram runtime worker renders via the RAF loop while playing. Each tick calls invalidateSamples with frameCount: 0 for every track to widen the dirty set, then renders. samplesChanged is a pure signal that only queues flags for the next render.