### PR TITLE
chore(spectrogram): add benchmark harness

### DIFF
--- a/packages/spectrogram/package.json
+++ b/packages/spectrogram/package.json
@@ -23,7 +23,8 @@
     "project:build": "tsc --build",
     "check:ts": "tsc --build",
     "check:lint": "eslint . --cache --cache-strategy content",
-    "fix:lint": "eslint . --fix --cache --cache-strategy content"
+    "fix:lint": "eslint . --fix --cache --cache-strategy content",
+    "bench": "node --import tsx ./scripts/bench.ts"
   },
   "peerDependencies": {
     "@musetric/fft": "workspace:*",

--- a/packages/spectrogram/scripts/bench.ts
+++ b/packages/spectrogram/scripts/bench.ts
@@ -1,0 +1,66 @@
+import { dirname, resolve } from 'node:path';
+import { Writable } from 'node:stream';
+import { fileURLToPath } from 'node:url';
+import { experimental_getRunnerTask, startVitest } from 'vitest/node';
+import { type SpectrogramBenchSummary } from '../src/__test__/bench.es.js';
+import { writeBendReports } from './genBenchReport.js';
+
+declare module '@vitest/runner' {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+  interface TaskMeta {
+    bench?: SpectrogramBenchSummary;
+  }
+}
+
+const startTime = performance.now();
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = resolve(currentDir, '..');
+
+const devNull = new Writable({
+  write: (_chunk, _encoding, callback) => {
+    callback();
+  },
+});
+
+const benchReporter = {
+  onUserConsoleLog: (log: { content: string; type: string }) => {
+    const stream = log.type === 'stderr' ? process.stderr : process.stdout;
+    stream.write(log.content + '\n');
+  },
+};
+
+const runVitest = async (): Promise<SpectrogramBenchSummary[]> => {
+  const vitest = await startVitest(
+    'test',
+    [],
+    {
+      config: resolve(packageRoot, 'vitest.bench.config.ts'),
+      watch: false,
+      reporters: [benchReporter],
+    },
+    undefined,
+    { stdout: devNull, stderr: devNull },
+  );
+
+  const summaries: SpectrogramBenchSummary[] = [];
+
+  for (const module of vitest.state.getTestModules()) {
+    for (const testCase of module.children.allTests()) {
+      const task = experimental_getRunnerTask(testCase);
+      const { bench } = task.meta;
+      if (bench !== undefined) {
+        summaries.push(bench);
+      }
+    }
+  }
+
+  await vitest.close();
+  return summaries;
+};
+
+const webgpuResults = await runVitest();
+writeBendReports(webgpuResults);
+
+const elapsed = ((performance.now() - startTime) / 1000).toFixed(2);
+console.log(`Total script time: ${elapsed}s`);

--- a/packages/spectrogram/scripts/genBenchReport.ts
+++ b/packages/spectrogram/scripts/genBenchReport.ts
@@ -1,0 +1,63 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  formatBenchMarkdown,
+  formatBenchTimestamp,
+  type SpectrogramBenchSummary,
+} from '../src/__test__/bench.es.js';
+
+const cwd = process.cwd();
+const outputDirectory = resolve(cwd, 'tmp/bench');
+
+const writeBandReport = (
+  bandCount: number,
+  summaries: SpectrogramBenchSummary[],
+): void => {
+  if (summaries.length < 1) {
+    return;
+  }
+  const [first] = summaries;
+  const filePath = resolve(
+    outputDirectory,
+    `bend${bandCount}_${formatBenchTimestamp(first.timestamp)}.md`,
+  );
+  writeFileSync(filePath, formatBenchMarkdown(summaries), 'utf-8');
+  console.log(`Wrote ${filePath}`);
+};
+
+export const writeBendReports = (
+  summaries: SpectrogramBenchSummary[],
+): void => {
+  if (summaries.length < 1) {
+    console.log('No benchmark summaries collected');
+    return;
+  }
+
+  mkdirSync(outputDirectory, { recursive: true });
+
+  const byBand = new Map<number, SpectrogramBenchSummary[]>();
+  for (const summary of summaries) {
+    const list = byBand.get(summary.bandCount) ?? [];
+    list.push(summary);
+    byBand.set(summary.bandCount, list);
+  }
+
+  const bandCounts = [...byBand.keys()].sort((a, b) => a - b);
+  for (const bandCount of bandCounts) {
+    const bandSummaries = byBand.get(bandCount);
+    if (bandSummaries !== undefined) {
+      writeBandReport(bandCount, bandSummaries);
+    }
+  }
+};
+
+if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
+  try {
+    writeBendReports([]);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error('Failed:', message);
+    process.exit(1);
+  }
+}

--- a/packages/spectrogram/src/__test__/bench.es.ts
+++ b/packages/spectrogram/src/__test__/bench.es.ts
@@ -1,0 +1,221 @@
+import {
+  type BenchStatsConfig,
+  defaultBenchStatsConfig,
+} from '@musetric/utils';
+
+export const spectrogramBenchConfig: BenchStatsConfig = {
+  ...defaultBenchStatsConfig,
+  batchSize: 16,
+  maxTries: 6,
+  stableSampleWindow: 48,
+};
+export const benchBatchSize = spectrogramBenchConfig.batchSize;
+export const benchMaxTries = spectrogramBenchConfig.maxTries;
+export const benchStableCvPercent = spectrogramBenchConfig.stableSampleWindow;
+export const warmupIters = 8;
+
+export type BenchBand = {
+  label: string;
+  windowSize: number;
+  minFrequency: number;
+  fullMinFrequency: number;
+  fullMaxFrequency: number;
+  maxFrequency: number;
+};
+
+export type SpectrogramBenchPreset = {
+  label: string;
+  width: number;
+  height: number;
+  windowSize: number;
+  bandCount: 1 | 3;
+};
+
+export type SpectrogramBenchScenarioKind = 'full' | 'playback' | 'recording';
+
+export type SpectrogramBenchScenario = {
+  label: string;
+  kind: SpectrogramBenchScenarioKind;
+  sampleSeconds: number;
+  framesPerRender: number;
+  invalidatedFrames: number;
+  invalidatedChunkCount?: number;
+  invalidatedChunkGapFrames?: number;
+  coalesceInvalidations?: boolean;
+};
+
+export type SpectrogramBenchCase = SpectrogramBenchPreset & {
+  scenario: SpectrogramBenchScenario;
+};
+
+export const fullMount: SpectrogramBenchScenario = {
+  label: 'full-mount',
+  kind: 'full',
+  sampleSeconds: 260,
+  framesPerRender: 0,
+  invalidatedFrames: 0,
+};
+
+export const playback60Fps: SpectrogramBenchScenario = {
+  label: 'playback-60fps',
+  kind: 'playback',
+  sampleSeconds: 260,
+  framesPerRender: 735,
+  invalidatedFrames: 0,
+};
+
+export const playback30Fps: SpectrogramBenchScenario = {
+  label: 'playback-30fps',
+  kind: 'playback',
+  sampleSeconds: 260,
+  framesPerRender: 1470,
+  invalidatedFrames: 0,
+};
+
+export const recording60Fps: SpectrogramBenchScenario = {
+  label: 'recording-60fps',
+  kind: 'recording',
+  sampleSeconds: 260,
+  framesPerRender: 735,
+  invalidatedFrames: 735,
+};
+
+export const recording30Fps: SpectrogramBenchScenario = {
+  label: 'recording-30fps',
+  kind: 'recording',
+  sampleSeconds: 260,
+  framesPerRender: 1470,
+  invalidatedFrames: 1470,
+};
+
+export const createBenchBands = (
+  windowSize: number,
+  bandCount: 1 | 3,
+): BenchBand[] => {
+  if (bandCount === 1) {
+    return [
+      {
+        label: `${windowSize}`,
+        windowSize,
+        minFrequency: 20,
+        fullMinFrequency: 20,
+        fullMaxFrequency: 20_000,
+        maxFrequency: 20_000,
+      },
+    ];
+  }
+  const half = windowSize / 2;
+  const quarter = windowSize / 4;
+  return [
+    {
+      label: `${windowSize}`,
+      windowSize,
+      minFrequency: 20,
+      fullMinFrequency: 20,
+      fullMaxFrequency: 300,
+      maxFrequency: 900,
+    },
+    {
+      label: `${half}`,
+      windowSize: half,
+      minFrequency: 300,
+      fullMinFrequency: 900,
+      fullMaxFrequency: 2200,
+      maxFrequency: 4200,
+    },
+    {
+      label: `${quarter}`,
+      windowSize: quarter,
+      minFrequency: 2200,
+      fullMinFrequency: 4200,
+      fullMaxFrequency: 20_000,
+      maxFrequency: 20_000,
+    },
+  ];
+};
+
+export type SpectrogramBenchMetric = {
+  label: string;
+  mean: number;
+  cv: number;
+};
+
+export type SpectrogramBenchSummary = {
+  timestamp: string;
+  caseLabel: string;
+  preset: string;
+  scenario: string;
+  windowSize: number;
+  bandCount: number;
+  sampleSeconds: number;
+  framesPerRender: number;
+  invalidatedFrames: number;
+  metrics: SpectrogramBenchMetric[];
+  sampleCount: number;
+};
+
+export const benchStageOrder = [
+  'sliceSamples',
+  'fourierTransform',
+  'magnitudify',
+  'decibelify',
+  'fundamentalFrequency',
+  'remap',
+  'draw',
+  'gpuCompute',
+  'gpuWork',
+  'configure',
+  'writeBuffers',
+  'createCommand',
+  'submitCommand',
+  'other',
+  'total',
+  'wall',
+] as const;
+
+const padTimestamp = (value: number): string => String(value).padStart(2, '0');
+
+export const createBenchTimestamp = (value: Date = new Date()): string =>
+  `${value.getFullYear()}${padTimestamp(value.getMonth() + 1)}${padTimestamp(value.getDate())}T${padTimestamp(value.getHours())}${padTimestamp(value.getMinutes())}${padTimestamp(value.getSeconds())}`;
+
+export const formatBenchTimestamp = (timestamp: string): string =>
+  `${timestamp.slice(0, 4)}-${timestamp.slice(4, 6)}-${timestamp.slice(6, 8)}T${timestamp.slice(9, 11)}-${timestamp.slice(11, 13)}-${timestamp.slice(13, 15)}`;
+
+const metricMap = (
+  summary: SpectrogramBenchSummary,
+): Map<string, SpectrogramBenchMetric> =>
+  new Map(summary.metrics.map((metric) => [metric.label, metric]));
+
+export const formatBenchMarkdown = (
+  summaries: SpectrogramBenchSummary[],
+): string => {
+  if (summaries.length < 1) {
+    return '';
+  }
+
+  const headers = summaries.map((summary) => summary.scenario);
+  const header = `| stage | ${headers.join(' | ')} |`;
+  const separator = `| --- | ${summaries.map(() => '---').join(' | ')} |`;
+  const maps = summaries.map(metricMap);
+  const meanRows = [header, separator];
+  const cvRows = [header, separator];
+
+  for (const stage of benchStageOrder) {
+    const meanCells: string[] = [stage];
+    const cvCells: string[] = [stage];
+    for (const map of maps) {
+      const metric = map.get(stage);
+      if (!metric || !Number.isFinite(metric.mean)) {
+        meanCells.push('-');
+        cvCells.push('-');
+        continue;
+      }
+      meanCells.push(`${metric.mean.toFixed(3)}ms`);
+      cvCells.push(`${metric.cv.toFixed(2)}%`);
+    }
+    meanRows.push(`| ${meanCells.join(' | ')} |`);
+    cvRows.push(`| ${cvCells.join(' | ')} |`);
+  }
+
+  return `${meanRows.join('\n')}\n\n### CV (%)\n\n${cvRows.join('\n')}\n`;
+};

--- a/packages/spectrogram/src/__test__/benchRunner.ts
+++ b/packages/spectrogram/src/__test__/benchRunner.ts
@@ -1,0 +1,356 @@
+import { computeBenchStats } from '@musetric/utils';
+import { createGpuContext } from '@musetric/utils/gpu';
+import { type SpectrogramSampleRange } from '../common/extConfig.js';
+import { type SpectrogramProcessorMetrics } from '../common/processorTimer.js';
+import { type SpectrogramConfig } from '../config.cross.js';
+import { defaultSpectrogramConfig } from '../defaultConfig.cross.js';
+import {
+  createSpectrogramProcessor,
+  type SpectrogramProcessor,
+} from '../processor.js';
+import {
+  benchBatchSize,
+  benchMaxTries,
+  benchStableCvPercent,
+  createBenchBands,
+  type SpectrogramBenchCase,
+  type SpectrogramBenchMetric,
+  type SpectrogramBenchSummary,
+  warmupIters,
+} from './bench.es.js';
+import { buildConfig, createTone } from './common.js';
+
+const profiledContext = await createGpuContext(true);
+const wallContext = await createGpuContext();
+const profiledDevice = profiledContext.device;
+const wallDevice = wallContext.device;
+
+const progressStart = 0.2;
+
+const getInvalidatedChunkCount = (benchCase: SpectrogramBenchCase): number =>
+  benchCase.scenario.invalidatedChunkCount ?? 1;
+
+type BenchDriver = {
+  config: SpectrogramConfig;
+  framesPerRender: number;
+  invalidatedFrames: number;
+  prime: (processor: SpectrogramProcessor) => Promise<void>;
+  render: (processor: SpectrogramProcessor) => Promise<void>;
+  sampleSeconds: number;
+};
+
+const buildPresetConfig = (
+  benchCase: SpectrogramBenchCase,
+): SpectrogramConfig =>
+  buildConfig({
+    windowSize: benchCase.windowSize,
+    zeroPaddingFactor: 2,
+    spectralBands: createBenchBands(benchCase.windowSize, benchCase.bandCount),
+    viewSize: { width: benchCase.width, height: benchCase.height },
+    lanes: {
+      lead: {
+        ...defaultSpectrogramConfig.lanes.lead,
+        showSpectrogram: true,
+        showFundamental: true,
+      },
+      recording: {
+        ...defaultSpectrogramConfig.lanes.recording,
+        showSpectrogram: false,
+        showFundamental: true,
+      },
+    },
+  });
+
+const aggregate = (
+  metricsArray: SpectrogramProcessorMetrics[],
+): SpectrogramBenchMetric[] => {
+  const labels = new Set<string>();
+  for (const metrics of metricsArray) {
+    for (const label of Object.keys(metrics)) {
+      labels.add(label);
+    }
+  }
+  return [...labels].map((label) => {
+    const values = metricsArray.map((metrics) => metrics[label] ?? Number.NaN);
+    const { mean, cv } = computeBenchStats(values);
+    return { label, mean, cv };
+  });
+};
+
+const gpuComputeLabels = [
+  'sliceSamples',
+  'fourierTransform',
+  'magnitudify',
+  'decibelify',
+  'fundamentalFrequency',
+  'remap',
+] as const;
+
+const addDerivedMetrics = (
+  metrics: SpectrogramProcessorMetrics,
+): SpectrogramProcessorMetrics => {
+  const gpuCompute = gpuComputeLabels.reduce(
+    (sum, label) => sum + (metrics[label] ?? 0),
+    0,
+  );
+  return {
+    ...metrics,
+    gpuCompute,
+    gpuWork: gpuCompute + metrics.draw,
+  };
+};
+
+const createRecordingInvalidations = (
+  scenario: SpectrogramBenchCase['scenario'],
+  frameIndex: number,
+): SpectrogramSampleRange[] => {
+  const chunkCount = scenario.invalidatedChunkCount ?? 1;
+  const gap = scenario.invalidatedChunkGapFrames ?? scenario.invalidatedFrames;
+  return Array.from({ length: chunkCount }, (_, index) => ({
+    frameIndex: Math.max(0, frameIndex - index * gap),
+    frameCount: scenario.invalidatedFrames,
+  }));
+};
+
+const coalesceInvalidations = (
+  invalidations: readonly SpectrogramSampleRange[],
+): SpectrogramSampleRange[] => {
+  const sorted = [...invalidations].sort((a, b) => a.frameIndex - b.frameIndex);
+  const merged: SpectrogramSampleRange[] = [];
+  for (const invalidation of sorted) {
+    if (invalidation.frameCount <= 0) {
+      continue;
+    }
+    const nextStart = invalidation.frameIndex;
+    const nextEnd = invalidation.frameIndex + invalidation.frameCount;
+    if (merged.length > 0) {
+      const previous = merged[merged.length - 1];
+      const previousEnd = previous.frameIndex + previous.frameCount;
+      if (nextStart <= previousEnd) {
+        previous.frameCount =
+          Math.max(previousEnd, nextEnd) - previous.frameIndex;
+        continue;
+      }
+    }
+    merged.push({ ...invalidation });
+  }
+  return merged;
+};
+
+const toRenderInvalidations = (
+  scenario: SpectrogramBenchCase['scenario'],
+  invalidations: readonly SpectrogramSampleRange[],
+): SpectrogramSampleRange[] =>
+  scenario.coalesceInvalidations
+    ? coalesceInvalidations(invalidations)
+    : [...invalidations];
+
+const writeRecordingChunk = (
+  samples: Float32Array,
+  frameIndex: number,
+  frameCount: number,
+  sampleRate: number,
+  renderIndex: number,
+): number => {
+  const start = Math.max(0, Math.min(samples.length, frameIndex));
+  const end = Math.max(start, Math.min(samples.length, start + frameCount));
+  const phase = renderIndex * 0.13;
+  for (let index = start; index < end; index += 1) {
+    samples[index] = Math.sin(
+      phase + (2 * Math.PI * 440 * (index - start)) / sampleRate,
+    );
+  }
+  return end - start;
+};
+
+const createDriver = (benchCase: SpectrogramBenchCase): BenchDriver => {
+  const config = buildPresetConfig(benchCase);
+  const { scenario } = benchCase;
+  const sampleCount = Math.round(config.sampleRate * scenario.sampleSeconds);
+  const lead = createTone(sampleCount, 1000, config.sampleRate, 0.8);
+  const recording = createTone(sampleCount, 440, config.sampleRate, 0.55);
+  const samples = { lead, recording };
+  const { framesPerRender } = scenario;
+  const progressStep = framesPerRender / sampleCount;
+
+  let progress = progressStart;
+  let renderIndex = 0;
+
+  const prime = async (processor: SpectrogramProcessor): Promise<void> => {
+    await processor.render(samples, progress);
+  };
+
+  const render = async (processor: SpectrogramProcessor): Promise<void> => {
+    renderIndex += 1;
+
+    if (scenario.kind === 'full') {
+      await processor.render(
+        { lead: lead.subarray(0), recording: recording.subarray(0) },
+        progress,
+      );
+      return;
+    }
+
+    if (scenario.kind === 'recording') {
+      progress += progressStep;
+      const frameIndex = Math.round(progress * sampleCount);
+      const chunks = createRecordingInvalidations(scenario, frameIndex);
+      const writtenChunks = chunks
+        .map((invalidation, invalidationIndex) => ({
+          frameIndex: invalidation.frameIndex,
+          frameCount: writeRecordingChunk(
+            recording,
+            invalidation.frameIndex,
+            invalidation.frameCount,
+            config.sampleRate,
+            renderIndex + invalidationIndex,
+          ),
+        }))
+        .filter((invalidation) => invalidation.frameCount > 0);
+      const renderInvalidations = toRenderInvalidations(
+        scenario,
+        writtenChunks,
+      );
+      processor.invalidateSamples(
+        renderInvalidations.map((invalidation) => ({
+          trackKey: 'recording',
+          frameIndex: invalidation.frameIndex,
+          frameCount: invalidation.frameCount,
+        })),
+      );
+      await processor.render(samples, progress);
+      return;
+    }
+
+    progress += progressStep;
+    await processor.render(samples, progress);
+  };
+
+  return {
+    config,
+    framesPerRender,
+    invalidatedFrames:
+      scenario.invalidatedFrames * getInvalidatedChunkCount(benchCase),
+    prime,
+    render,
+    sampleSeconds: scenario.sampleSeconds,
+  };
+};
+
+const warmup = async (
+  driver: BenchDriver,
+  processor: SpectrogramProcessor,
+): Promise<void> => {
+  await driver.prime(processor);
+  for (let i = 0; i < warmupIters; i += 1) {
+    await driver.render(processor);
+  }
+};
+
+const measureProfiled = async (
+  benchCase: SpectrogramBenchCase,
+): Promise<{
+  metrics: SpectrogramBenchMetric[];
+  sampleCount: number;
+}> => {
+  const driver = createDriver(benchCase);
+  const metricsArray: SpectrogramProcessorMetrics[] = [];
+  const processor = createSpectrogramProcessor({
+    device: profiledDevice,
+    config: driver.config,
+    onMetrics: (metrics) => metricsArray.push(addDerivedMetrics(metrics)),
+  });
+
+  try {
+    await warmup(driver, processor);
+    metricsArray.length = 0;
+
+    for (let tryIndex = 0; tryIndex < benchMaxTries; tryIndex += 1) {
+      for (let i = 0; i < benchBatchSize; i += 1) {
+        await driver.render(processor);
+      }
+      const totals = metricsArray.map((metrics) => metrics.total);
+      const { cv } = computeBenchStats(totals);
+      if (cv <= benchStableCvPercent) {
+        break;
+      }
+    }
+
+    return {
+      metrics: aggregate(metricsArray),
+      sampleCount: metricsArray.length,
+    };
+  } finally {
+    processor.dispose();
+  }
+};
+
+const measureWall = async (
+  benchCase: SpectrogramBenchCase,
+): Promise<SpectrogramBenchMetric> => {
+  const driver = createDriver(benchCase);
+  const durations: number[] = [];
+  const processor = createSpectrogramProcessor({
+    device: wallDevice,
+    config: driver.config,
+  });
+
+  try {
+    await warmup(driver, processor);
+
+    for (let tryIndex = 0; tryIndex < benchMaxTries; tryIndex += 1) {
+      for (let i = 0; i < benchBatchSize; i += 1) {
+        const start = performance.now();
+        await driver.render(processor);
+        durations.push(performance.now() - start);
+      }
+      const { cv } = computeBenchStats(durations);
+      if (cv <= benchStableCvPercent) {
+        break;
+      }
+    }
+
+    const { mean, cv } = computeBenchStats(durations);
+    return {
+      label: 'wall',
+      mean,
+      cv,
+    };
+  } finally {
+    processor.dispose();
+  }
+};
+
+const measureCase = async (
+  benchCase: SpectrogramBenchCase,
+  timestamp: string,
+): Promise<SpectrogramBenchSummary> => {
+  const driver = createDriver(benchCase);
+  const wallMetric = await measureWall(benchCase);
+  const profiled = await measureProfiled(benchCase);
+  const metrics = [wallMetric, ...profiled.metrics];
+  const totalMetric = metrics.find((metric) => metric.label === 'total');
+  const caseLabel = `${benchCase.label}/${benchCase.scenario.label}`;
+  console.log(
+    `${benchCase.bandCount}band ${benchCase.scenario.label} total=${totalMetric?.mean.toFixed(3) ?? 'n/a'}ms`,
+  );
+
+  return {
+    timestamp,
+    caseLabel,
+    preset: benchCase.label,
+    scenario: benchCase.scenario.label,
+    windowSize: benchCase.windowSize,
+    bandCount: benchCase.bandCount,
+    sampleSeconds: driver.sampleSeconds,
+    framesPerRender: driver.framesPerRender,
+    invalidatedFrames: driver.invalidatedFrames,
+    metrics,
+    sampleCount: profiled.sampleCount,
+  };
+};
+
+export const runSingleBench = async (
+  benchCase: SpectrogramBenchCase,
+  timestamp: string,
+): Promise<SpectrogramBenchSummary> => measureCase(benchCase, timestamp);

--- a/packages/spectrogram/src/__test__/common.ts
+++ b/packages/spectrogram/src/__test__/common.ts
@@ -1,0 +1,130 @@
+import { createGpuBufferReader } from '@musetric/utils/gpu';
+import { expect } from 'vitest';
+import { type SpectrogramConfig } from '../config.cross.js';
+import { defaultSpectrogramConfig } from '../defaultConfig.cross.js';
+
+export const buildConfig = (
+  overrides: Partial<SpectrogramConfig> = {},
+): SpectrogramConfig => {
+  const viewSize = overrides.viewSize ?? { width: 256, height: 128 };
+  const canvas = new OffscreenCanvas(viewSize.width, viewSize.height);
+  return {
+    ...defaultSpectrogramConfig,
+    ...overrides,
+    canvas,
+    viewSize,
+  };
+};
+
+export const readFloats = async (
+  device: GPUDevice,
+  buffer: GPUBuffer,
+  count: number,
+): Promise<Float32Array> => {
+  const reader = createGpuBufferReader({ device, typeSize: 4, size: count });
+  try {
+    return new Float32Array(await reader.read(buffer));
+  } finally {
+    reader.destroy();
+  }
+};
+
+export const readCanvas = async (
+  canvas: OffscreenCanvas,
+): Promise<Uint8ClampedArray> => {
+  const bitmap = await createImageBitmap(canvas);
+  try {
+    const target = new OffscreenCanvas(canvas.width, canvas.height);
+    const context = target.getContext('2d');
+    if (!context) {
+      throw new Error('2d context unavailable for canvas readback');
+    }
+    context.drawImage(bitmap, 0, 0);
+    return context.getImageData(0, 0, canvas.width, canvas.height).data;
+  } finally {
+    bitmap.close();
+  }
+};
+
+export const maxRed = (pixels: Uint8ClampedArray): number => {
+  let max = 0;
+  for (let i = 0; i < pixels.length; i += 4) {
+    if (pixels[i] > max) {
+      max = pixels[i];
+    }
+  }
+  return max;
+};
+
+export const brightestRow = (
+  pixels: Uint8ClampedArray,
+  width: number,
+  height: number,
+): number => {
+  let bestRow = -1;
+  let bestValue = -1;
+  for (let y = 0; y < height; y += 1) {
+    let rowMax = 0;
+    for (let x = 0; x < width; x += 1) {
+      const red = pixels[(y * width + x) * 4];
+      if (red > rowMax) {
+        rowMax = red;
+      }
+    }
+    if (rowMax > bestValue) {
+      bestValue = rowMax;
+      bestRow = y;
+    }
+  }
+  return bestRow;
+};
+
+export const rowAtFrequency = (
+  frequency: number,
+  config: SpectrogramConfig,
+): number => {
+  const { minFrequency, maxFrequency, viewSize } = config;
+  const logMin = Math.log(minFrequency);
+  const logRange = Math.log(maxFrequency) - logMin;
+  const ratio = (Math.log(frequency) - logMin) / logRange;
+  return (1 - ratio) * (viewSize.height - 1);
+};
+
+export const createSilence = (length: number): Float32Array =>
+  new Float32Array(length);
+
+export const createConstant = (length: number, value: number): Float32Array =>
+  new Float32Array(length).fill(value);
+
+export const createRamp = (length: number): Float32Array =>
+  Float32Array.from({ length }, (_, index) => index);
+
+export const createImpulse = (length: number, at = 0): Float32Array => {
+  const samples = new Float32Array(length);
+  samples[at] = 1;
+  return samples;
+};
+
+export const createTone = (
+  length: number,
+  frequency: number,
+  sampleRate: number,
+  amplitude = 1,
+): Float32Array =>
+  Float32Array.from(
+    { length },
+    (_, index) =>
+      amplitude * Math.sin((2 * Math.PI * frequency * index) / sampleRate),
+  );
+
+export const assertClose = (
+  name: string,
+  received: Float32Array,
+  expected: Float32Array,
+  digits = 3,
+): void => {
+  expect(received.length, `${name} length`).toBe(expected.length);
+  for (let i = 0; i < expected.length; i += 1) {
+    expect(received[i], `${name}[${i}]`).toBeCloseTo(expected[i], digits);
+  }
+};

--- a/packages/spectrogram/src/__test__/processor.bench.ts
+++ b/packages/spectrogram/src/__test__/processor.bench.ts
@@ -1,0 +1,66 @@
+import { describe, it } from 'vitest';
+import {
+  createBenchTimestamp,
+  fullMount,
+  playback30Fps,
+  playback60Fps,
+  recording30Fps,
+  recording60Fps,
+  type SpectrogramBenchCase,
+  type SpectrogramBenchPreset,
+} from './bench.es.js';
+import { runSingleBench } from './benchRunner.js';
+
+const hd1Band: SpectrogramBenchPreset = {
+  label: 'hd-1band',
+  width: 1280,
+  height: 720,
+  windowSize: 4096,
+  bandCount: 1,
+};
+
+const hd3Band: SpectrogramBenchPreset = {
+  label: 'hd-3band',
+  width: 1280,
+  height: 720,
+  windowSize: 4096,
+  bandCount: 3,
+};
+
+const hd1BandBenchCases: SpectrogramBenchCase[] = [
+  { ...hd1Band, scenario: fullMount },
+  { ...hd1Band, scenario: playback60Fps },
+  { ...hd1Band, scenario: playback30Fps },
+  { ...hd1Band, scenario: recording60Fps },
+  { ...hd1Band, scenario: recording30Fps },
+];
+
+const hd3BandBenchCases: SpectrogramBenchCase[] = [
+  { ...hd3Band, scenario: fullMount },
+  { ...hd3Band, scenario: playback60Fps },
+  { ...hd3Band, scenario: playback30Fps },
+  { ...hd3Band, scenario: recording60Fps },
+  { ...hd3Band, scenario: recording30Fps },
+];
+
+const benchTimestamp = createBenchTimestamp();
+
+describe('spectrogram benchmarks', () => {
+  describe('hd-1band', () => {
+    for (const benchCase of hd1BandBenchCases) {
+      it(`render ${benchCase.scenario.label}`, async (context) => {
+        const summary = await runSingleBench(benchCase, benchTimestamp);
+        Object.assign(context.task.meta, { bench: summary });
+      });
+    }
+  });
+
+  describe('hd-3band', () => {
+    for (const benchCase of hd3BandBenchCases) {
+      it(`render ${benchCase.scenario.label}`, async (context) => {
+        const summary = await runSingleBench(benchCase, benchTimestamp);
+        Object.assign(context.task.meta, { bench: summary });
+      });
+    }
+  });
+});

--- a/packages/spectrogram/src/common/extConfig.ts
+++ b/packages/spectrogram/src/common/extConfig.ts
@@ -3,3 +3,8 @@ import { type SpectrogramConfig } from '../config.cross.js';
 export type ExtSpectrogramConfig = SpectrogramConfig & {
   windowCount: number;
 };
+
+export type SpectrogramSampleRange = {
+  frameIndex: number;
+  frameCount: number;
+};


### PR DESCRIPTION
Lifts the spectrogram benchmark harness — scenarios, profiled and wall-clock measurement, vitest cases, and a node script that collects results into per-band markdown reports — so the current branch can produce perf numbers against the pre-optimisation processor.