### PR TITLE
chore(format): add editorconfig-checker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text=auto eol=lf
+
+# Generated: collapse in GitHub diffs and exclude from language stats
+yarn.lock linguist-generated=true

--- a/.github/prTitle.config.yml
+++ b/.github/prTitle.config.yml
@@ -58,7 +58,7 @@ scopes:
   - agent # agent guidance & config (AGENTS.md, AI tooling)
   - bench # benchmarks & perf measurement (packages/performance)
   - deps # dependency add / update / remove
-  - format # Prettier formatting
+  - format # Prettier formatting and editorconfig
   - github # repo & GitHub Actions settings (workflows, templates)
   - lint # ESLint rules / packages/eslint-config
   - ts # TypeScript config & strictness (tsconfig, types)

--- a/.github/workflows/codeQuality.yml
+++ b/.github/workflows/codeQuality.yml
@@ -36,4 +36,5 @@ jobs:
       - run: yarn check:lint
       - run: yarn check:translations
       - run: yarn check:format
+      - run: yarn check:editor
       - run: yarn test

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -46,6 +46,7 @@ catalog:
   'axios': '1.18.1'
   'cpx2': '9.0.0'
   'date-fns': '4.1.0'
+  'editorconfig-checker': '6.1.1'
   'eslint': '10.5.0'
   'eslint-plugin-react-hooks': '7.1.1'
   'eslint-plugin-react-refresh': '0.5.3'

--- a/constraints.pro
+++ b/constraints.pro
@@ -4,7 +4,7 @@ gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, Dependen
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, _, DependencyType),
   WorkspaceCwd \= OtherWorkspaceCwd.
 
-% Ensure consistent peer dependency versions across workspaces  
+% Ensure consistent peer dependency versions across workspaces
 gen_enforced_dependency(WorkspaceCwd, DependencyIdent, DependencyRange, peerDependencies) :-
   workspace_has_dependency(OtherWorkspaceCwd, DependencyIdent, DependencyRange, peerDependencies),
   workspace_has_dependency(WorkspaceCwd, DependencyIdent, _, peerDependencies),

--- a/package.json
+++ b/package.json
@@ -24,9 +24,11 @@
     "fix:translations": "yarn workspaces foreach --all --parallel --interlaced run fix:translations",
     "check:format": "prettier --check .",
     "fix:format": "prettier . --write --list-different",
+    "check:editor": "editorconfig-checker",
     "test": "yarn workspaces foreach --all --parallel --interlaced run test"
   },
   "devDependencies": {
+    "editorconfig-checker": "catalog:",
     "grep-cli": "catalog:",
     "ncp": "catalog:",
     "prettier": "catalog:"

--- a/packages/eslint-config/src/config/js.ts
+++ b/packages/eslint-config/src/config/js.ts
@@ -1,4 +1,4 @@
-﻿import eslint from '@eslint/js';
+import eslint from '@eslint/js';
 import { type ESLint, type Linter } from 'eslint';
 import importX from 'eslint-plugin-import-x';
 import simpleImportSort from 'eslint-plugin-simple-import-sort';

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/multiPassPairStageShader.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/multiPassPairStageShader.ts
@@ -1,4 +1,4 @@
-﻿// Fused pair of Stockham DIT radix stages: one kernel applies stage A
+// Fused pair of Stockham DIT radix stages: one kernel applies stage A
 // (factor1 at stageStride) and stage B (factor2 at stageStride * factor1)
 // through workgroup shared memory, halving the global-memory round trips.
 // A group of factor1 * factor2 points is closed under both stages: the

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/multiPassStageShader.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/multiPassStageShader.ts
@@ -1,4 +1,4 @@
-﻿export const multiPassStageShader = `
+export const multiPassStageShader = `
 override packedWindowSize: u32 = 2560u;
 override factor: u32 = 5u;
 override stageStride: u32 = 1u;

--- a/packages/fft/src/fourier/fftPackedTiledR2c/firstPassMixedShader.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/firstPassMixedShader.ts
@@ -1,4 +1,4 @@
-﻿export const firstPassMixedShader = `
+export const firstPassMixedShader = `
 override packedWindowSize: u32 = 2560u;
 override tileSize: u32 = 64u;
 override rowSize: u32 = 64u;

--- a/packages/fft/src/fourier/fftPackedTiledR2c/secondPassMixedShader.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/secondPassMixedShader.ts
@@ -1,4 +1,4 @@
-﻿export const secondPassMixedShader = `
+export const secondPassMixedShader = `
 override packedWindowSize: u32 = 2560u;
 override positiveWindowSize: u32 = 2560u;
 override tileSize: u32 = 64u;

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/multiPassPairStageShader.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/multiPassPairStageShader.ts
@@ -1,4 +1,4 @@
-﻿// Fused pair of inverse Stockham DIT radix stages (see the forward
+// Fused pair of inverse Stockham DIT radix stages (see the forward
 // multiPassPairStageShader for the group structure). The first kernel can
 // additionally fuse the C2R prepack read.
 export const multiPassPairStageShader = `

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/multiPassStageShader.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/multiPassStageShader.ts
@@ -1,4 +1,4 @@
-﻿export const multiPassStageShader = `
+export const multiPassStageShader = `
 override packedWindowSize: u32 = 2560u;
 override factor: u32 = 5u;
 override stageStride: u32 = 1u;

--- a/packages/fft/src/windowing/shader.ts
+++ b/packages/fft/src/windowing/shader.ts
@@ -15,7 +15,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let windowSize = params.windowSize;
   let signalStride = params.signalStride;
   let windowCount = params.windowCount;
-  
+
   let sampleIndex = gid.x;
   let windowIndex = gid.y;
   if (sampleIndex >= windowSize || windowIndex >= windowCount) {

--- a/packages/spectrogram/src/decibelify/runShader.ts
+++ b/packages/spectrogram/src/decibelify/runShader.ts
@@ -21,7 +21,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let windowCount = params.windowCount;
   let decibelFactor = params.decibelFactor;
   let gainOverReferenceMagnitude = params.gainOverReferenceMagnitude;
-  
+
   let sampleIndex = gid.x;
   let windowIndex = gid.y;
   if (sampleIndex >= halfSize || windowIndex >= windowCount) {

--- a/packages/spectrogram/tsconfig.test.json
+++ b/packages/spectrogram/tsconfig.test.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "extends": "../../tsconfigs/tsconfig.test.json",
   "references": [{ "path": "./tsconfig.src.json" }],
   "compilerOptions": {

--- a/packages/spectrogram/vitest.bench.config.ts
+++ b/packages/spectrogram/vitest.bench.config.ts
@@ -1,4 +1,4 @@
-﻿import { defineConfig } from 'vitest/config';
+import { defineConfig } from 'vitest/config';
 import defaultConfig from './vitest.config.js';
 
 export default defineConfig({

--- a/packages/spectrogram/vitest.config.ts
+++ b/packages/spectrogram/vitest.config.ts
@@ -1,4 +1,4 @@
-﻿import { playwright } from '@vitest/browser-playwright';
+import { playwright } from '@vitest/browser-playwright';
 import { defineConfig } from 'vitest/config';
 
 const isSkip = process.platform === 'linux';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,6 +1779,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@musetric/monorepo@workspace:."
   dependencies:
+    editorconfig-checker: "catalog:"
     grep-cli: "catalog:"
     ncp: "catalog:"
     prettier: "catalog:"
@@ -3652,6 +3653,16 @@ __metadata:
     readable-stream: "npm:^3.1.1"
     stream-shift: "npm:^1.0.2"
   checksum: 10c0/8a7621ae95c89f3937f982fe36d72ea997836a708471a75bb2a0eecde3330311b1e128a6dad510e0fd64ace0c56bff3484ed2e82af0e465600c82117eadfbda5
+  languageName: node
+  linkType: hard
+
+"editorconfig-checker@npm:6.1.1":
+  version: 6.1.1
+  resolution: "editorconfig-checker@npm:6.1.1"
+  bin:
+    ec: dist/index.js
+    editorconfig-checker: dist/index.js
+  checksum: 10c0/0a46ce93e2821041c4b4bbf2ab9dc30e1b4eb03d3f20e5b14bbe45767f6f2aafd5e1310ea737c15402d8e193f702a421a814041e072584250e8a7d5e63d83741
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add editorconfig-checker as the check:editor script (catalog + devDep) and run it in the Code Quality workflow. It enforces charset, end_of_line, insert_final_newline and trim_trailing_whitespace across all git-tracked files - filling the gap Prettier leaves (it never strips a BOM).

indent_style/indent_size and max_line_length are intentionally left out: Prettier owns code indentation and width, and enforcing them here false-positives on SQL/WGSL template literals and floods prose/CI.

Make the repo pass: strip a UTF-8 BOM from 10 tracked files, add a final newline to .gitattributes, drop trailing whitespace in constraints.pro and two shader files.

Also mark yarn.lock as linguist-generated (collapse in GitHub diffs, drop from language stats).