### PR TITLE
feat(fft): batch-range dispatch backed by a params slot ring

### DIFF
--- a/packages/fft/src/fourier/__test__/batchRange.bench.ts
+++ b/packages/fft/src/fourier/__test__/batchRange.bench.ts
@@ -1,0 +1,92 @@
+import { describe, it } from 'vitest';
+import { allFourierModes } from '../config.es.js';
+import { type FourierBatchRange } from '../types.js';
+import {
+  benchWindowCounts,
+  benchWindowSizes,
+  createFourierRangeBenchMode,
+  type FourierBatchRangeBenchScenario,
+  fourierBatchRangeBenchScenarios,
+  type FourierBenchSummary,
+  fourierModeLabels,
+} from './bench.es.js';
+import { benchTimestamp, measureOne } from './benchHarness.js';
+
+const createBatchRangeBenchRanges = (
+  windowCount: number,
+  scenario: FourierBatchRangeBenchScenario,
+): readonly FourierBatchRange[] => {
+  const totalBatchCount = Math.max(
+    scenario.rangeCount,
+    Math.floor(windowCount / scenario.totalDenominator),
+  );
+  const baseBatchCount = Math.floor(totalBatchCount / scenario.rangeCount);
+  const remainder = totalBatchCount % scenario.rangeCount;
+
+  return Array.from({ length: scenario.rangeCount }, (_, index) => {
+    const batchCount = baseBatchCount + (index < remainder ? 1 : 0);
+    const segmentStart = Math.floor(
+      (index * windowCount) / scenario.rangeCount,
+    );
+    const segmentEnd = Math.floor(
+      ((index + 1) * windowCount) / scenario.rangeCount,
+    );
+    const segmentSize = segmentEnd - segmentStart;
+    const batchOffset =
+      segmentStart + Math.max(0, Math.floor((segmentSize - batchCount) / 2));
+
+    return { batchOffset, batchCount };
+  });
+};
+
+describe('FFT batch range benchmarks', () => {
+  for (const windowCount of benchWindowCounts) {
+    for (const mode of allFourierModes) {
+      for (const scenario of fourierBatchRangeBenchScenarios) {
+        const rangeMode = createFourierRangeBenchMode(mode, scenario);
+        const rangeModeLabel = fourierModeLabels[rangeMode];
+
+        it(`forward count ${windowCount} ${rangeModeLabel}`, async (context) => {
+          const { task } = context;
+          const means: number[] = [];
+          const cvs: number[] = [];
+          const sampleCounts: number[] = [];
+          const ranges = createBatchRangeBenchRanges(windowCount, scenario);
+
+          for (const windowSize of benchWindowSizes) {
+            const result = await measureOne(mode, windowSize, windowCount, {
+              logLabel: rangeModeLabel,
+              ranges,
+            });
+
+            if (result) {
+              means.push(result.mean);
+              cvs.push(result.cv);
+              sampleCounts.push(result.sampleCount);
+            } else {
+              means.push(Number.NaN);
+              cvs.push(Number.NaN);
+              sampleCounts.push(0);
+            }
+          }
+
+          const maxSampleCount = Math.max(...sampleCounts);
+
+          const bench: FourierBenchSummary = {
+            timestamp: benchTimestamp,
+            direction: 'forward',
+            count: windowCount,
+            mode: rangeMode,
+            modeLabel: rangeModeLabel,
+            windowSizes: benchWindowSizes,
+            means,
+            cvs,
+            sampleCount: maxSampleCount,
+          };
+
+          Object.assign(task.meta, { bench });
+        });
+      }
+    }
+  }
+});

--- a/packages/fft/src/fourier/__test__/batchRange.test.ts
+++ b/packages/fft/src/fourier/__test__/batchRange.test.ts
@@ -1,0 +1,480 @@
+import { createGpuBufferReader, createGpuContext } from '@musetric/utils/gpu';
+import { describe, expect, it } from 'vitest';
+import { resolveFourierBatchRange } from '../batchRange.js';
+import { createFftPackedStockhamR2c } from '../fftPackedStockhamR2c/index.js';
+import { createFftPackedTiledR2c } from '../fftPackedTiledR2c/index.js';
+import { createIfftPackedStockhamC2r } from '../ifftPackedStockhamC2r/index.js';
+import { getPackedStockhamC2rVariant } from '../ifftPackedStockhamC2r/support.js';
+import { type CreateFourier, type FourierBatchRange } from '../types.js';
+
+const { device } = await createGpuContext();
+
+const windowCount = 6;
+
+const makeInput = (windowSize: number, stride: number): Float32Array => {
+  const data = new Float32Array(stride * windowCount);
+  for (let w = 0; w < windowCount; w += 1) {
+    for (let i = 0; i < windowSize; i += 1) {
+      data[w * stride + i] =
+        Math.sin((2 * Math.PI * (w + 1) * i) / windowSize) + 0.1 * w;
+    }
+  }
+  return data;
+};
+
+const readBuffer = async (
+  buffer: GPUBuffer,
+  size: number,
+): Promise<Float32Array> => {
+  const reader = createGpuBufferReader({ device, typeSize: 4, size });
+  try {
+    return new Float32Array(await reader.read(buffer));
+  } finally {
+    reader.destroy();
+  }
+};
+
+const transform = async (
+  createFourier: CreateFourier,
+  windowSize: number,
+  batchRanges?: readonly FourierBatchRange[],
+): Promise<Float32Array> => {
+  const stride = windowSize + 2;
+  const input = makeInput(windowSize, stride);
+  const buffer = device.createBuffer({
+    label: 'batch-range-in-place',
+    size: input.byteLength,
+    usage:
+      GPUBufferUsage.STORAGE |
+      GPUBufferUsage.COPY_SRC |
+      GPUBufferUsage.COPY_DST,
+  });
+  device.queue.writeBuffer(buffer, 0, input);
+
+  const fourierCell = createFourier(device);
+  const fourier = fourierCell.get({
+    wave: buffer,
+    spectrum: buffer,
+    config: { windowSize, windowCount },
+  });
+  const encoder = device.createCommandEncoder();
+  const pass = encoder.beginComputePass();
+  if (batchRanges) {
+    for (const range of batchRanges) {
+      fourier.dispatch(pass, range);
+    }
+  } else {
+    fourier.dispatch(pass);
+  }
+  pass.end();
+  device.queue.submit([encoder.finish()]);
+  await device.queue.onSubmittedWorkDone();
+
+  try {
+    return await readBuffer(buffer, stride * windowCount);
+  } finally {
+    buffer.destroy();
+    fourierCell.dispose();
+  }
+};
+
+const transformOutOfPlace = async (
+  createFourier: CreateFourier,
+  windowSize: number,
+  rangesPerSubmit?: readonly (readonly FourierBatchRange[])[],
+): Promise<Float32Array> => {
+  const spectrumStride = windowSize + 2;
+  const input = makeInput(windowSize, windowSize);
+  const wave = device.createBuffer({
+    label: 'batch-range-wave',
+    size: input.byteLength,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+  });
+  const spectrum = device.createBuffer({
+    label: 'batch-range-spectrum',
+    size: spectrumStride * windowCount * Float32Array.BYTES_PER_ELEMENT,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+  });
+  device.queue.writeBuffer(wave, 0, input);
+
+  const fourierCell = createFourier(device);
+  const fourier = fourierCell.get({
+    wave,
+    spectrum,
+    config: { windowSize, windowCount },
+  });
+  const submits = rangesPerSubmit ?? [undefined];
+  for (const ranges of submits) {
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    if (ranges) {
+      for (const range of ranges) {
+        fourier.dispatch(pass, range);
+      }
+    } else {
+      fourier.dispatch(pass);
+    }
+    pass.end();
+    device.queue.submit([encoder.finish()]);
+  }
+  await device.queue.onSubmittedWorkDone();
+
+  try {
+    return await readBuffer(spectrum, spectrumStride * windowCount);
+  } finally {
+    wave.destroy();
+    spectrum.destroy();
+    fourierCell.dispose();
+  }
+};
+
+const inverseTransform = async (
+  windowSize: number,
+  batchRanges?: readonly FourierBatchRange[],
+): Promise<Float32Array> => {
+  const spectrumStride = windowSize + 2;
+  const input = makeInput(windowSize, spectrumStride);
+  const spectrum = device.createBuffer({
+    label: 'batch-range-c2r-spectrum',
+    size: input.byteLength,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+  });
+  const wave = device.createBuffer({
+    label: 'batch-range-c2r-wave',
+    size: windowSize * windowCount * Float32Array.BYTES_PER_ELEMENT,
+    usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+  });
+  device.queue.writeBuffer(spectrum, 0, input);
+
+  const fourierCell = createIfftPackedStockhamC2r(device);
+  const fourier = fourierCell.get({
+    wave,
+    spectrum,
+    config: { windowSize, windowCount },
+  });
+  const encoder = device.createCommandEncoder();
+  const pass = encoder.beginComputePass();
+  if (batchRanges) {
+    for (const range of batchRanges) {
+      fourier.dispatch(pass, range);
+    }
+  } else {
+    fourier.dispatch(pass);
+  }
+  pass.end();
+  device.queue.submit([encoder.finish()]);
+  await device.queue.onSubmittedWorkDone();
+
+  try {
+    return await readBuffer(wave, windowSize * windowCount);
+  } finally {
+    wave.destroy();
+    spectrum.destroy();
+    fourierCell.dispose();
+  }
+};
+
+const expectBatchRangeRejected = (
+  createFourier: CreateFourier,
+  windowSize: number,
+  range: FourierBatchRange,
+): void => {
+  const stride = windowSize + 2;
+  const input = makeInput(windowSize, stride);
+  const buffer = device.createBuffer({
+    label: 'batch-range-rejected-in-place',
+    size: input.byteLength,
+    usage:
+      GPUBufferUsage.STORAGE |
+      GPUBufferUsage.COPY_SRC |
+      GPUBufferUsage.COPY_DST,
+  });
+  device.queue.writeBuffer(buffer, 0, input);
+
+  const fourierCell = createFourier(device);
+  const fourier = fourierCell.get({
+    wave: buffer,
+    spectrum: buffer,
+    config: { windowSize, windowCount },
+  });
+  const encoder = device.createCommandEncoder();
+  const pass = encoder.beginComputePass();
+  try {
+    expect(() => {
+      fourier.dispatch(pass, range);
+    }).toThrow(RangeError);
+  } finally {
+    pass.end();
+    buffer.destroy();
+    fourierCell.dispose();
+  }
+};
+
+const targetedBatches = (
+  batchRanges: readonly FourierBatchRange[],
+): Set<number> => {
+  const targeted = new Set<number>();
+  for (const range of batchRanges) {
+    for (let k = 0; k < range.batchCount; k += 1) {
+      targeted.add(range.batchOffset + k);
+    }
+  }
+  return targeted;
+};
+
+const expectOnlyTargetedTransformed = (
+  ranged: Float32Array,
+  full: Float32Array,
+  input: Float32Array,
+  stride: number,
+  targeted: Set<number>,
+): void => {
+  for (let w = 0; w < windowCount; w += 1) {
+    const offset = w * stride;
+    const expected = targeted.has(w) ? full : input;
+    for (let i = 0; i < stride; i += 1) {
+      expect(ranged[offset + i], `window ${w} index ${i}`).toBeCloseTo(
+        expected[offset + i],
+        3,
+      );
+    }
+  }
+};
+
+const batchRanges: FourierBatchRange[] = [
+  { batchOffset: 1, batchCount: 2 },
+  { batchOffset: 3, batchCount: 3 },
+];
+
+const createSingleBatchSubmits = (submitCount: number): FourierBatchRange[][] =>
+  Array.from({ length: submitCount }, (_, index) => [
+    { batchOffset: index % windowCount, batchCount: 1 },
+  ]);
+
+const fourierCases: {
+  label: string;
+  createFourier: CreateFourier;
+}[] = [
+  {
+    label: 'fftPackedStockhamR2c',
+    createFourier: createFftPackedStockhamR2c,
+  },
+  {
+    label: 'fftPackedTiledR2c',
+    createFourier: createFftPackedTiledR2c,
+  },
+];
+
+describe('resolveFourierBatchRange', () => {
+  it('defaults to the full range when no range is given', () => {
+    expect(resolveFourierBatchRange(undefined, 8)).toEqual({
+      batchOffset: 0,
+      batchCount: 8,
+    });
+  });
+
+  it('returns a valid range as-is', () => {
+    const range = { batchOffset: 2, batchCount: 3 };
+    expect(resolveFourierBatchRange(range, 8)).toBe(range);
+  });
+
+  it('allows an empty range at the end of the window span', () => {
+    const resolved = resolveFourierBatchRange(
+      { batchOffset: 8, batchCount: 0 },
+      8,
+    );
+    expect(resolved).toEqual({ batchOffset: 8, batchCount: 0 });
+  });
+
+  it.each([
+    { batchOffset: -1, batchCount: 2 },
+    { batchOffset: 1, batchCount: -2 },
+    { batchOffset: 0.5, batchCount: 2 },
+    { batchOffset: 1, batchCount: 1.5 },
+    { batchOffset: Number.NaN, batchCount: 2 },
+    { batchOffset: 4, batchCount: 5 },
+  ])('rejects ($batchOffset, $batchCount)', (range) => {
+    expect(() => resolveFourierBatchRange(range, 8)).toThrow(RangeError);
+  });
+});
+
+describe.each(fourierCases)('$label batch range', (fourierCase) => {
+  describe.each([64, 1920, 2048, 4096])('size %i', (windowSize) => {
+    const stride = windowSize + 2;
+    const transformCase = async (
+      selectedBatchRanges?: readonly FourierBatchRange[],
+    ): Promise<Float32Array> =>
+      transform(fourierCase.createFourier, windowSize, selectedBatchRanges);
+
+    it.each(batchRanges)(
+      'transforms only the targeted batches ($batchOffset, $batchCount)',
+      async (range) => {
+        const full = await transformCase();
+        const ranged = await transformCase([range]);
+        expectOnlyTargetedTransformed(
+          ranged,
+          full,
+          makeInput(windowSize, stride),
+          stride,
+          targetedBatches([range]),
+        );
+      },
+    );
+
+    it('transforms every disjoint range issued in one submit', async () => {
+      const multiRanges: FourierBatchRange[] = [
+        { batchOffset: 1, batchCount: 2 },
+        { batchOffset: 4, batchCount: 2 },
+      ];
+      const full = await transformCase();
+      const ranged = await transformCase(multiRanges);
+      expectOnlyTargetedTransformed(
+        ranged,
+        full,
+        makeInput(windowSize, stride),
+        stride,
+        targetedBatches(multiRanges),
+      );
+    });
+
+    it('treats a zero-count range as a no-op', async () => {
+      const untouched = await transformCase([
+        { batchOffset: 2, batchCount: 0 },
+      ]);
+      const input = makeInput(windowSize, stride);
+      expectOnlyTargetedTransformed(untouched, input, input, stride, new Set());
+    });
+  });
+
+  describe.each([64, 2048])('size %i out-of-place', (windowSize) => {
+    const stride = windowSize + 2;
+    const zeros = new Float32Array(stride * windowCount);
+
+    it('transforms only the targeted batches', async () => {
+      const range: FourierBatchRange = { batchOffset: 1, batchCount: 3 };
+      const full = await transformOutOfPlace(
+        fourierCase.createFourier,
+        windowSize,
+      );
+      const ranged = await transformOutOfPlace(
+        fourierCase.createFourier,
+        windowSize,
+        [[range]],
+      );
+      expectOnlyTargetedTransformed(
+        ranged,
+        full,
+        zeros,
+        stride,
+        targetedBatches([range]),
+      );
+    });
+
+    it('reuses ring slots correctly across submits', async () => {
+      const rangesPerSubmit = createSingleBatchSubmits(windowCount + 3);
+      const full = await transformOutOfPlace(
+        fourierCase.createFourier,
+        windowSize,
+      );
+      const ranged = await transformOutOfPlace(
+        fourierCase.createFourier,
+        windowSize,
+        rangesPerSubmit,
+      );
+      expectOnlyTargetedTransformed(
+        ranged,
+        full,
+        zeros,
+        stride,
+        targetedBatches(rangesPerSubmit.flat()),
+      );
+    });
+  });
+
+  it('rejects wrapping batch ranges', () => {
+    expectBatchRangeRejected(fourierCase.createFourier, 64, {
+      batchOffset: 4,
+      batchCount: 3,
+    });
+  });
+});
+
+describe('ifftPackedStockhamC2r batch range', () => {
+  const supportedSizes = [64, 1920, 2048, 4096].filter(
+    (windowSize) =>
+      getPackedStockhamC2rVariant(device, { windowSize, windowCount }) !==
+      undefined,
+  );
+
+  it('covers at least one window size on this adapter', () => {
+    expect(supportedSizes.length).toBeGreaterThan(0);
+  });
+
+  describe.each(supportedSizes)('size %i', (windowSize) => {
+    const zeros = new Float32Array(windowSize * windowCount);
+
+    it.each(batchRanges)(
+      'transforms only the targeted batches ($batchOffset, $batchCount)',
+      async (range) => {
+        const full = await inverseTransform(windowSize);
+        const ranged = await inverseTransform(windowSize, [range]);
+        expectOnlyTargetedTransformed(
+          ranged,
+          full,
+          zeros,
+          windowSize,
+          targetedBatches([range]),
+        );
+      },
+    );
+
+    it('transforms every disjoint range issued in one submit', async () => {
+      const multiRanges: FourierBatchRange[] = [
+        { batchOffset: 1, batchCount: 2 },
+        { batchOffset: 4, batchCount: 2 },
+      ];
+      const full = await inverseTransform(windowSize);
+      const ranged = await inverseTransform(windowSize, multiRanges);
+      expectOnlyTargetedTransformed(
+        ranged,
+        full,
+        zeros,
+        windowSize,
+        targetedBatches(multiRanges),
+      );
+    });
+  });
+
+  it('rejects wrapping batch ranges', () => {
+    const [windowSize] = supportedSizes;
+    const spectrumStride = windowSize + 2;
+    const spectrum = device.createBuffer({
+      label: 'batch-range-c2r-rejected-spectrum',
+      size: spectrumStride * windowCount * Float32Array.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
+    });
+    const wave = device.createBuffer({
+      label: 'batch-range-c2r-rejected-wave',
+      size: windowSize * windowCount * Float32Array.BYTES_PER_ELEMENT,
+      usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC,
+    });
+    const fourierCell = createIfftPackedStockhamC2r(device);
+    const fourier = fourierCell.get({
+      wave,
+      spectrum,
+      config: { windowSize, windowCount },
+    });
+    const encoder = device.createCommandEncoder();
+    const pass = encoder.beginComputePass();
+    try {
+      expect(() => {
+        fourier.dispatch(pass, { batchOffset: 4, batchCount: 3 });
+      }).toThrow(RangeError);
+    } finally {
+      pass.end();
+      wave.destroy();
+      spectrum.destroy();
+      fourierCell.dispose();
+    }
+  });
+});

--- a/packages/fft/src/fourier/__test__/bench.es.ts
+++ b/packages/fft/src/fourier/__test__/bench.es.ts
@@ -15,7 +15,31 @@ import { createWindowSizes } from './windowSizes.es.js';
 
 export type FourierBenchDirection = 'forward' | 'inverse';
 
-export type FourierBenchMode = 'cufft' | FourierMode | IFourierMode;
+export type FourierBatchRangeBenchScenario = {
+  readonly label: string;
+  readonly rangeCount: 1 | 2 | 3;
+  readonly totalDenominator: 4;
+};
+
+export const fourierBatchRangeBenchScenarios: readonly FourierBatchRangeBenchScenario[] =
+  [
+    { label: '1 range total 25%', rangeCount: 1, totalDenominator: 4 },
+    { label: '2 ranges total 25%', rangeCount: 2, totalDenominator: 4 },
+    { label: '3 ranges total 25%', rangeCount: 3, totalDenominator: 4 },
+  ];
+
+export type FourierBenchRangeMode = `${FourierMode}:range${1 | 2 | 3}q`;
+
+export const createFourierRangeBenchMode = (
+  mode: FourierMode,
+  scenario: FourierBatchRangeBenchScenario,
+): FourierBenchRangeMode => `${mode}:range${scenario.rangeCount}q`;
+
+export type FourierBenchMode =
+  | 'cufft'
+  | FourierMode
+  | IFourierMode
+  | FourierBenchRangeMode;
 
 export type FourierBenchSummary = {
   timestamp: string;
@@ -50,16 +74,74 @@ export const fourierSelectRunsPerSample = (
 export const fourierComputeStats = (values: readonly number[]): BenchStats =>
   computeBenchStats(values, defaultBenchStatsConfig);
 
-export const fourierModeLabels: Record<FourierBenchMode, string> = {
+const baseFourierModeLabels: Record<
+  'cufft' | FourierMode | IFourierMode,
+  string
+> = {
   cufft: 'cuFFT',
   fftPackedStockhamR2c: 'Stockham',
   fftPackedTiledR2c: 'Tiled',
   ifftPackedStockhamC2r: 'Stockham',
 };
 
+const rangeBenchBaseModes: ReadonlyMap<string, FourierMode> = new Map(
+  allFourierModes.flatMap((mode) =>
+    fourierBatchRangeBenchScenarios.map((scenario): [string, FourierMode] => [
+      createFourierRangeBenchMode(mode, scenario),
+      mode,
+    ]),
+  ),
+);
+
+export const isFourierBenchRangeMode = (
+  mode: FourierBenchMode,
+): mode is FourierBenchRangeMode => rangeBenchBaseModes.get(mode) !== undefined;
+
+export const getFourierRangeBenchBaseMode = (
+  mode: FourierBenchRangeMode,
+): FourierMode => {
+  const baseMode = rangeBenchBaseModes.get(mode);
+  if (baseMode === undefined) {
+    throw new Error(`Unknown Fourier range benchmark mode: ${mode}`);
+  }
+  return baseMode;
+};
+
+export const fourierRangeBenchModes: FourierBenchRangeMode[] =
+  allFourierModes.flatMap((mode) =>
+    fourierBatchRangeBenchScenarios.map((scenario) =>
+      createFourierRangeBenchMode(mode, scenario),
+    ),
+  );
+
+const createFourierModeLabels = (): Record<FourierBenchMode, string> => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const labels = { ...baseFourierModeLabels } as Record<
+    FourierBenchMode,
+    string
+  >;
+
+  for (const mode of allFourierModes) {
+    for (const scenario of fourierBatchRangeBenchScenarios) {
+      labels[createFourierRangeBenchMode(mode, scenario)] =
+        `${baseFourierModeLabels[mode]} ${scenario.label}`;
+    }
+  }
+
+  return labels;
+};
+
+export const fourierModeLabels: Record<FourierBenchMode, string> =
+  createFourierModeLabels();
+
 export const benchModeOrder: FourierBenchMode[] = [
   'cufft',
-  ...allFourierModes,
+  ...allFourierModes.flatMap((mode): FourierBenchMode[] => [
+    mode,
+    ...fourierBatchRangeBenchScenarios.map((scenario) =>
+      createFourierRangeBenchMode(mode, scenario),
+    ),
+  ]),
   ...allIFourierModes,
 ];
 
@@ -101,6 +183,9 @@ export const formatBenchMarkdown = (
   const meanRows = [header, separator];
   const cvRows = [header, separator];
   const cufftSummary = summaries.find((summary) => summary.mode === 'cufft');
+  const hasRangeSummary = summaries.some((summary) =>
+    isFourierBenchRangeMode(summary.mode),
+  );
 
   for (const [index, windowSize] of windowSizes.entries()) {
     const factorization = formatRadixStages(windowSize);
@@ -117,16 +202,20 @@ export const formatBenchMarkdown = (
         continue;
       }
 
-      const cufftMean = cufftSummary?.means[index];
+      const referenceMean = isFourierBenchRangeMode(summary.mode)
+        ? summariesByMode[getFourierRangeBenchBaseMode(summary.mode)]?.means[
+            index
+          ]
+        : cufftSummary?.means[index];
       const hasRatio =
         summary.mode !== 'cufft' &&
-        typeof cufftMean === 'number' &&
-        Number.isFinite(cufftMean) &&
-        cufftMean > 0;
+        typeof referenceMean === 'number' &&
+        Number.isFinite(referenceMean) &&
+        referenceMean > 0;
 
       meanCells.push(
         hasRatio
-          ? `${mean.toFixed(3)}ms x${(mean / cufftMean).toFixed(2)}`
+          ? `${mean.toFixed(3)}ms x${(mean / referenceMean).toFixed(2)}`
           : `${mean.toFixed(3)}ms`,
       );
       cvCells.push(`${cv.toFixed(2)}%`);
@@ -136,5 +225,9 @@ export const formatBenchMarkdown = (
     cvRows.push(`| ${cvCells.join(' | ')} |`);
   }
 
-  return `${meanRows.join('\n')}\n\n### CV (%)\n\n${cvRows.join('\n')}\n`;
+  const rangeNote = hasRangeSummary
+    ? '\n\nRange ratios are relative to the matching full WebGPU mode; non-range WebGPU ratios are relative to cuFFT.'
+    : '';
+
+  return `${meanRows.join('\n')}${rangeNote}\n\n### CV (%)\n\n${cvRows.join('\n')}\n`;
 };

--- a/packages/fft/src/fourier/__test__/benchHarness.ts
+++ b/packages/fft/src/fourier/__test__/benchHarness.ts
@@ -184,6 +184,14 @@ export const measureOne = async (
 
     if (tryIndex === 0) {
       runsPerSample = fourierSelectRunsPerSample(durations);
+      if (options?.ranges) {
+        const dispatchesPerRun =
+          defaultBenchStatsConfig.batchSize * options.ranges.length;
+        runsPerSample = Math.max(
+          1,
+          Math.min(runsPerSample, Math.floor(windowCount / dispatchesPerRun)),
+        );
+      }
       continue;
     }
 

--- a/packages/fft/src/fourier/batchRange.ts
+++ b/packages/fft/src/fourier/batchRange.ts
@@ -1,0 +1,27 @@
+import { type FourierBatchRange } from './types.js';
+
+export const resolveFourierBatchRange = (
+  range: FourierBatchRange | undefined,
+  windowCount: number,
+): FourierBatchRange => {
+  if (!range) {
+    return { batchOffset: 0, batchCount: windowCount };
+  }
+  const { batchOffset, batchCount } = range;
+  if (!Number.isInteger(batchOffset) || batchOffset < 0) {
+    throw new RangeError(
+      `Fourier batch range batchOffset must be a non-negative integer, got ${batchOffset}`,
+    );
+  }
+  if (!Number.isInteger(batchCount) || batchCount < 0) {
+    throw new RangeError(
+      `Fourier batch range batchCount must be a non-negative integer, got ${batchCount}`,
+    );
+  }
+  if (batchOffset + batchCount > windowCount) {
+    throw new RangeError(
+      `Fourier batch range batchOffset (${batchOffset}) + batchCount (${batchCount}) must be <= windowCount (${windowCount}), got ${batchOffset + batchCount}`,
+    );
+  }
+  return range;
+};

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/index.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/index.ts
@@ -1,4 +1,9 @@
-import { type CreateFourier, type Fourier } from '../types.js';
+import { resolveFourierBatchRange } from '../batchRange.js';
+import {
+  type CreateFourier,
+  type Fourier,
+  type FourierBatchRange,
+} from '../types.js';
 import { createStateCell } from './state.js';
 
 export const createFftPackedStockhamR2c: CreateFourier = (device, markers) => {
@@ -8,21 +13,33 @@ export const createFftPackedStockhamR2c: CreateFourier = (device, markers) => {
     get: (arg) => {
       const state = stateCell.get(arg);
 
-      const dispatch = (pass: GPUComputePassEncoder): void => {
+      const dispatch = (
+        pass: GPUComputePassEncoder,
+        range?: FourierBatchRange,
+      ): void => {
+        const { batchOffset, batchCount } = resolveFourierBatchRange(
+          range,
+          state.windowCount,
+        );
+        if (batchCount === 0) {
+          return;
+        }
+        const slot = state.params.reserve(batchOffset);
+
         if (state.kind === 'multiPass') {
+          const stages = state.getStageBindGroups(slot);
           state.pipeline.stages.forEach((pipeline, index) => {
             const kernel = state.variant.kernels[index];
-            const bindGroup = state.bindGroups.stages[index];
             pass.setPipeline(pipeline);
-            pass.setBindGroup(0, bindGroup);
-            pass.dispatchWorkgroups(state.windowCount, kernel.workgroupCount);
+            pass.setBindGroup(0, stages[index]);
+            pass.dispatchWorkgroups(batchCount, kernel.workgroupCount);
           });
           return;
         }
 
         pass.setPipeline(state.pipeline.transform);
-        pass.setBindGroup(0, state.bindGroups.transform);
-        pass.dispatchWorkgroups(state.windowCount);
+        pass.setBindGroup(0, state.getBindGroup(slot));
+        pass.dispatchWorkgroups(batchCount);
       };
 
       const ref: Fourier = {

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/multiPassPairStageShader.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/multiPassPairStageShader.ts
@@ -1,9 +1,3 @@
-// Fused pair of Stockham DIT radix stages: one kernel applies stage A
-// (factor1 at stageStride) and stage B (factor2 at stageStride * factor1)
-// through workgroup shared memory, halving the global-memory round trips.
-// A group of factor1 * factor2 points is closed under both stages: the
-// factor2 stage-A butterflies of a group produce exactly the inputs of its
-// factor1 stage-B butterflies. Eight threads cooperate per group.
 export const multiPassPairStageShader = `
 override packedWindowSize: u32 = 8192u;
 override factor1: u32 = 8u;
@@ -27,6 +21,7 @@ const sin5b: f32 = 0.58778525229247312917;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 override pairSharedSize: u32 = 512u;
@@ -96,8 +91,6 @@ fn writeScratch(index: u32, value: vec2<f32>) {
   }
 }
 
-// Forward DFT of size f (2, 4 or 8) from xv into yv, bin order matching the
-// single-stage Stockham codelets.
 fn runDft(f: u32) {
   if (f == 8u) {
     let e0 = xv[0] + xv[4];
@@ -176,14 +169,12 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }
 
   let t = localId.x;
-  // Consecutive threads take consecutive groups so global reads and writes
-  // stay coalesced; the cooperating role index moves slowly.
   let groupLocal = t % groupsPerWorkgroup;
   let role = t / groupsPerWorkgroup;
   let group = workgroupId.y * groupsPerWorkgroup + groupLocal;
@@ -199,7 +190,6 @@ fn main(
   let scratchOffset = packedWindowSize * windowIndex;
   let shBase = groupLocal * groupSize;
 
-  // Stage A: role = q2 picks one of the factor2 stage-A butterflies.
   if (groupInRange && role < factor2) {
     let blockA = blockB + role * twiddleScaleB;
     let srcBase = blockA * stageStride + kA;
@@ -217,7 +207,6 @@ fn main(
   }
   workgroupBarrier();
 
-  // Stage B: role = r picks one of the factor1 stage-B butterflies.
   if (groupInRange && role < factor1) {
     let kB = role * stageStride + kA;
     for (var q = 0u; q < factor2; q++) {

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/multiPassStageShader.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/multiPassStageShader.ts
@@ -19,6 +19,7 @@ const sin5b: f32 = 0.58778525229247312917;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 @group(0) @binding(0) var<storage, read> wave: array<f32>;
@@ -29,7 +30,6 @@ struct Params {
 @group(0) @binding(5) var<uniform> params: Params;
 @group(0) @binding(6) var<storage, read> r2cTrigTable: array<f32>;
 
-// Output slots for the fused last-stage butterfly (up to radix-8).
 var<private> yOut: array<vec2<f32>, 8>;
 
 fn mul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
@@ -108,8 +108,6 @@ fn writeBin(spectrumOffset: u32, k: u32, value: vec2<f32>) {
   spectrum[index + 1u] = value.y;
 }
 
-// Last-stage butterfly (stageStride == packedWindowSize / factor, twiddle
-// scale 1) for base index k, leaving outputs X[k + m * stageStride] in yOut.
 fn computeLastButterfly(windowIndex: u32, k: u32) {
   let butterflyCount = packedWindowSize / factor;
   let a0 = readStage(windowIndex, k);
@@ -171,7 +169,6 @@ fn computeLastButterfly(windowIndex: u32, k: u32) {
     yOut[4] = b1 + vec2<f32>(-b3.y, b3.x);
     return;
   }
-  // factor == 8
   let a1 = mul(readStage(windowIndex, k + butterflyCount), getFftTwiddle(k));
   let a2 = mul(readStage(windowIndex, k + 2u * butterflyCount),
     getFftTwiddle(2u * k));
@@ -215,9 +212,6 @@ fn computeLastButterfly(windowIndex: u32, k: u32) {
   yOut[7] = E3 - p3;
 }
 
-// Fused final stage + R2C pack. Bins of butterfly k mirror into the bins of
-// butterfly (stageStride - k), so one thread runs both butterflies and packs
-// all their bins, saving the final scratch write plus the pack read pass.
 fn runFusedLastStage(windowIndex: u32, k: u32) {
   let spectrumOffset = complexStride() * windowIndex;
   computeLastButterfly(windowIndex, k);
@@ -254,7 +248,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/params.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/params.ts
@@ -1,30 +1,47 @@
 import { type FourierConfig } from '../config.es.js';
 
-export type PackedStockhamR2cParams = {
-  windowSize: number;
-  windowCount: number;
-};
+const paramsByteLength = 16;
 
-export type Params = {
-  value: PackedStockhamR2cParams;
+export type ParamsRing = {
   buffer: GPUBuffer;
+  binding: (slot: number) => GPUBufferBinding;
+  reserve: (batchOffset: number) => number;
+  destroy: () => void;
 };
 
-export const createParams = (
+export const createParamsRing = (
   device: GPUDevice,
   config: FourierConfig,
-): Params => {
-  const value = {
-    windowSize: config.windowSize,
-    windowCount: config.windowCount,
-  };
-  const array = new Uint32Array([value.windowSize, value.windowCount]);
+): ParamsRing => {
+  const capacity = Math.max(1, config.windowCount);
+  const alignment = device.limits.minUniformBufferOffsetAlignment;
+  const stride = Math.ceil(paramsByteLength / alignment) * alignment;
   const buffer = device.createBuffer({
     label: 'packed-stockham-r2c-params',
-    size: array.byteLength,
+    size: stride * capacity,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   });
-  device.queue.writeBuffer(buffer, 0, array);
+  const scratch = new Uint32Array(paramsByteLength / 4);
+  scratch[0] = config.windowSize;
+  scratch[1] = config.windowCount;
+  let cursor = 0;
 
-  return { value, buffer };
+  return {
+    buffer,
+    binding: (slot) => ({
+      buffer,
+      offset: slot * stride,
+      size: paramsByteLength,
+    }),
+    reserve: (batchOffset) => {
+      const slot = cursor;
+      cursor = (cursor + 1) % capacity;
+      scratch[2] = batchOffset;
+      device.queue.writeBuffer(buffer, slot * stride, scratch);
+      return slot;
+    },
+    destroy: () => {
+      buffer.destroy();
+    },
+  };
 };

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/state.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/state.ts
@@ -1,6 +1,6 @@
 import { createResourceCell, type ResourceCell } from '@musetric/utils';
 import { type FourierArg } from '../types.js';
-import { createParams, type Params } from './params.js';
+import { createParamsRing, type ParamsRing } from './params.js';
 import {
   createPipeline,
   type MultiPassPipeline,
@@ -27,25 +27,12 @@ type ScratchBuffers = {
   buffer1: GPUBuffer;
 };
 
-type SinglePassBindGroups = {
-  kind: 'stockham' | 'inPlaceRadix4' | 'inPlaceMixed';
-  transform: GPUBindGroup;
-};
-
-type MultiPassBindGroups = {
-  kind: 'multiPass';
-  stages: GPUBindGroup[];
-};
-
-type BindGroups = SinglePassBindGroups | MultiPassBindGroups;
-
 type BaseState = {
   kind: PackedStockhamR2cVariant['kind'];
   variant: PackedStockhamR2cVariant;
   pipeline: Pipeline;
   tables: TrigTables;
-  bindGroups: BindGroups;
-  params: Params;
+  params: ParamsRing;
   dummyInput: GPUBuffer;
   windowCount: number;
 };
@@ -54,14 +41,14 @@ type SinglePassState = BaseState & {
   kind: 'stockham' | 'inPlaceRadix4' | 'inPlaceMixed';
   variant: Exclude<PackedStockhamR2cVariant, { kind: 'multiPass' }>;
   pipeline: SinglePassPipeline;
-  bindGroups: SinglePassBindGroups;
+  getBindGroup: (slot: number) => GPUBindGroup;
 };
 
 type MultiPassState = BaseState & {
   kind: 'multiPass';
   variant: Extract<PackedStockhamR2cVariant, { kind: 'multiPass' }>;
   pipeline: MultiPassPipeline;
-  bindGroups: MultiPassBindGroups;
+  getStageBindGroups: (slot: number) => GPUBindGroup[];
   scratch: ScratchBuffers;
 };
 
@@ -131,7 +118,7 @@ const createScratchBuffers = (
   };
 };
 
-const createSinglePassBindGroups = (
+const createSinglePassBindGroup = (
   device: GPUDevice,
   pipeline: Extract<
     Pipeline,
@@ -139,11 +126,10 @@ const createSinglePassBindGroups = (
   >,
   tables: TrigTables,
   arg: FourierArg,
-  params: Params,
+  params: GPUBufferBinding,
   input: GPUBuffer,
-): SinglePassBindGroups => ({
-  kind: pipeline.kind,
-  transform: device.createBindGroup({
+): GPUBindGroup =>
+  device.createBindGroup({
     label: 'packed-stockham-r2c-transform-bind-group',
     layout: pipeline.transform.getBindGroupLayout(0),
     entries: [
@@ -151,33 +137,29 @@ const createSinglePassBindGroups = (
       { binding: 1, resource: { buffer: arg.spectrum } },
       { binding: 2, resource: { buffer: tables.fft } },
       { binding: 3, resource: { buffer: tables.r2c } },
-      { binding: 4, resource: { buffer: params.buffer } },
+      { binding: 4, resource: params },
     ],
-  }),
-});
+  });
 
-const createMultiPassBindGroups = (
+const createMultiPassStageBindGroups = (
   device: GPUDevice,
   variant: Extract<PackedStockhamR2cVariant, { kind: 'multiPass' }>,
   pipeline: Extract<Pipeline, { kind: 'multiPass' }>,
   tables: TrigTables,
   scratch: ScratchBuffers,
   arg: FourierArg,
-  params: Params,
+  params: GPUBufferBinding,
   input: GPUBuffer,
-): MultiPassBindGroups => ({
-  kind: 'multiPass',
-  stages: pipeline.stages.map((stagePipeline, index) => {
+): GPUBindGroup[] =>
+  pipeline.stages.map((stagePipeline, index) => {
     const entries: GPUBindGroupEntry[] = [
       { binding: 0, resource: { buffer: input } },
       { binding: 1, resource: { buffer: arg.spectrum } },
       { binding: 2, resource: { buffer: scratch.buffer0 } },
       { binding: 3, resource: { buffer: scratch.buffer1 } },
       { binding: 4, resource: { buffer: tables.fft } },
-      { binding: 5, resource: { buffer: params.buffer } },
+      { binding: 5, resource: params },
     ];
-    // Pair kernels never pack, so their shader (and auto layout) has no
-    // r2c table binding.
     if (variant.kernels[index].kind === 'single') {
       entries.push({ binding: 6, resource: { buffer: tables.r2c } });
     }
@@ -186,8 +168,21 @@ const createMultiPassBindGroups = (
       layout: stagePipeline.getBindGroupLayout(0),
       entries,
     });
-  }),
-});
+  });
+
+const createSlotCache = <T>(
+  build: (slot: number) => T,
+): ((slot: number) => T) => {
+  const cache = new Map<number, T>();
+  return (slot) => {
+    let cached = cache.get(slot);
+    if (cached === undefined) {
+      cached = build(slot);
+      cache.set(slot, cached);
+    }
+    return cached;
+  };
+};
 
 export const createStateCell = (
   device: GPUDevice,
@@ -201,7 +196,7 @@ export const createStateCell = (
           `fftPackedStockhamR2c does not support windowSize=${arg.config.windowSize}`,
         );
       }
-      const params = createParams(device, arg.config);
+      const params = createParamsRing(device, arg.config);
       const dummyInput = createDummyInputBuffer(device);
       const input = inPlace ? dummyInput : arg.wave;
 
@@ -218,15 +213,17 @@ export const createStateCell = (
           variant,
           pipeline,
           tables,
-          bindGroups: createMultiPassBindGroups(
-            device,
-            variant,
-            pipeline,
-            tables,
-            scratch,
-            arg,
-            params,
-            input,
+          getStageBindGroups: createSlotCache((slot) =>
+            createMultiPassStageBindGroups(
+              device,
+              variant,
+              pipeline,
+              tables,
+              scratch,
+              arg,
+              params.binding(slot),
+              input,
+            ),
           ),
           scratch,
           params,
@@ -242,13 +239,15 @@ export const createStateCell = (
         variant,
         pipeline,
         tables,
-        bindGroups: createSinglePassBindGroups(
-          device,
-          pipeline,
-          tables,
-          arg,
-          params,
-          input,
+        getBindGroup: createSlotCache((slot) =>
+          createSinglePassBindGroup(
+            device,
+            pipeline,
+            tables,
+            arg,
+            params.binding(slot),
+            input,
+          ),
         ),
         params,
         dummyInput,
@@ -256,7 +255,7 @@ export const createStateCell = (
       };
     },
     dispose: (state) => {
-      state.params.buffer.destroy();
+      state.params.destroy();
       state.dummyInput.destroy();
       if (state.kind === 'multiPass') {
         state.scratch.buffer0.destroy();

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/transformInPlaceMixedShader.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/transformInPlaceMixedShader.ts
@@ -18,6 +18,7 @@ const sin5b: f32 = 0.58778525229247312917;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> sm: array<vec2<f32>, packedWindowSize>;
@@ -52,9 +53,6 @@ fn getFactor(stage: u32) -> u32 {
   return 5u;
 }
 
-// Mixed-radix digit reversal for the in-place DIT, processing stage radices in
-// the same order as getFactor (8s, then 4s, 2s, 3s, 5s). The first-stage digit
-// (most significant in the natural index) becomes least significant here.
 fn reverseMixed(index: u32) -> u32 {
   var rev = 0u;
   var placeIn = packedWindowSize;
@@ -87,8 +85,6 @@ fn reverseMixed(index: u32) -> u32 {
   return rev;
 }
 
-// Mixed-radix reversal of the digits that remain after the first radix-8 stage
-// (one fewer radix-8 digit), over the range [0, packedWindowSize/8).
 fn reverseRestMixed(index: u32) -> u32 {
   var rev = 0u;
   var placeIn = packedWindowSize / 8u;
@@ -192,7 +188,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }
@@ -204,9 +200,6 @@ fn main(
   var stride = 1u;
   var firstStage = 0u;
 
-  // Fuse the global load with the twiddle-free first radix-8 stage (stride 1 =>
-  // all twiddles W^0=1): read 8 coalesced inputs, run the radix-8 in registers,
-  // write the 8 contiguous outputs to the block-reversed destination.
   if (radix8StageCount > 0u) {
     let butterflyCount = packedWindowSize / 8u;
     for (var j = t; j < butterflyCount; j += threadCount) {
@@ -390,7 +383,6 @@ fn main(
     workgroupBarrier();
   }
 
-  // R2C unpack (paired bins, halved shared reads).
   if (t == 0u) {
     let z0 = getResult(0u);
     writeBin(spectrumOffset, 0u, vec2<f32>(z0.x + z0.y, 0.0));

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/transformInPlaceRadix4Shader.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/transformInPlaceRadix4Shader.ts
@@ -7,6 +7,7 @@ override threadCount: u32 = 64u;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> smReal: array<f32, packedWindowSize>;
@@ -88,7 +89,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/transformInPlaceRadix8Shader.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/transformInPlaceRadix8Shader.ts
@@ -9,6 +9,7 @@ const sqrt1_2: f32 = 0.70710678118654752440;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> sm: array<vec2<f32>, packedWindowSize>;
@@ -29,7 +30,6 @@ fn reverseRadix8(index: u32) -> u32 {
   return result;
 }
 
-// Reverse the (radix8StageCount - 1) base-8 digits of a stage-0 input group.
 fn reverseRest(index: u32) -> u32 {
   var value = index;
   var result = 0u;
@@ -105,7 +105,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }
@@ -116,10 +116,6 @@ fn main(
 
   let butterflyCount = packedWindowSize / 8u;
 
-  // Fused load + twiddle-free first stage (len == 8). Read 8 coalesced inputs
-  // straight from global, run the radix-8 butterfly in registers, and scatter
-  // the 8 contiguous outputs to the block-reversed destination the in-place DIT
-  // stages expect. Avoids the scatter-load + a full shared round-trip.
   for (var j = t; j < butterflyCount; j += threadCount) {
     let a0 = loadPacked(inputOffset, j);
     let a1 = loadPacked(inputOffset, j + butterflyCount);

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/transformShader.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/transformShader.ts
@@ -19,6 +19,7 @@ const sin5b: f32 = 0.58778525229247312917;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> sm0: array<vec2<f32>, packedWindowSize>;
@@ -143,7 +144,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }
@@ -155,11 +156,6 @@ fn main(
   var stageStride = 1u;
   var firstStage = 0u;
 
-  // Fuse the global load with the first radix-8 stage. That stage has
-  // stageStride == 1 so every twiddle is W^0 = 1 (a twiddle-free radix-8),
-  // letting us read 8 coalesced inputs straight from global into registers and
-  // write the butterfly outputs to shared, skipping one full shared round-trip
-  // and one barrier. Only power-of-two sizes start with a radix-8 stage.
   if (radix8StageCount > 0u) {
     let butterflyCount = packedWindowSize / 8u;
     for (var j = t; j < butterflyCount; j += threadCount) {
@@ -250,7 +246,6 @@ fn main(
           getFftTwiddle(6u * tw));
         let a7 = mul(readStage(base + 7u * butterflyCount, readEven),
           getFftTwiddle(7u * tw));
-        // even-indexed radix-4
         let e0 = a0 + a4;
         let e1 = a0 - a4;
         let e2 = a2 + a6;
@@ -259,7 +254,6 @@ fn main(
         let E1 = e1 + vec2<f32>(e3.y, -e3.x);
         let E2 = e0 - e2;
         let E3 = e1 + vec2<f32>(-e3.y, e3.x);
-        // odd-indexed radix-4
         let f0 = a1 + a5;
         let f1 = a1 - a5;
         let f2 = a3 + a7;
@@ -268,7 +262,6 @@ fn main(
         let O1 = f1 + vec2<f32>(f3.y, -f3.x);
         let O2 = f0 - f2;
         let O3 = f1 + vec2<f32>(-f3.y, f3.x);
-        // combine with W8^r
         let p0 = O0;
         let p1 = vec2<f32>(
           sqrt1_2 * (O1.x + O1.y),
@@ -425,8 +418,6 @@ fn main(
     workgroupBarrier();
   }
 
-  // R2C unpack. Bins k and P-k share the pair {res(k), res(P-k)}, so process
-  // both per iteration over the lower half, halving shared reads and trip count.
   if (t == 0u) {
     let z0 = getResult(0u);
     writeBin(spectrumOffset, 0u, vec2<f32>(z0.x + z0.y, 0.0));

--- a/packages/fft/src/fourier/fftPackedTiledR2c/firstPassMixedShader.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/firstPassMixedShader.ts
@@ -8,8 +8,6 @@ override rowRadix2StageCount: u32 = 0u;
 override rowRadix3StageCount: u32 = 0u;
 override rowRadix5StageCount: u32 = 0u;
 override inPlace: u32 = 1u;
-// Lane stride padding keeps the four lanes of a warp on distinct shared
-// memory banks now that warps span lanes first.
 override smPad: u32 = 8u;
 
 const threadCount: u32 = 64u;
@@ -18,6 +16,7 @@ const batchSize: u32 = 4u;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> smReal0: array<f32, batchSize * (tileSize + smPad)>;
@@ -202,7 +201,7 @@ fn main(
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
   let n1 = workgroupId.x * batchSize + localId.x;
-  let windowIndex = workgroupId.y;
+  let windowIndex = params.batchOffset + workgroupId.y;
   if (windowIndex >= params.windowCount) {
     return;
   }

--- a/packages/fft/src/fourier/fftPackedTiledR2c/firstPassShader.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/firstPassShader.ts
@@ -11,13 +11,12 @@ override inPlace: u32 = 1u;
 const threadCount: u32 = 64u;
 const batchSize: u32 = 4u;
 const sqrt1_2: f32 = 0.70710678118654752440;
-// Lane stride padding keeps the four lanes of a warp on distinct shared
-// memory banks now that warps span lanes first.
 override smPad: u32 = 8u;
 
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> smReal0: array<f32, batchSize * (tileSize + smPad)>;
@@ -96,8 +95,6 @@ fn writeRow(lane: u32, index: u32, readEven: bool, value: vec2<f32>) {
   }
 }
 
-// Small tiles run the original tight scalar radix-2 loops; the generic mixed
-// helpers measurably regress them (~20-30%).
 fn runRowFftRadix2(t: u32, lane: u32) {
   let rowHalfSize = rowSize / 2u;
   for (var stage: u32 = 0u; stage < rowRadix2StageCount; stage++) {
@@ -282,15 +279,13 @@ fn getRowResult(index: u32, lane: u32) -> vec2<f32> {
   );
 }
 
-// Lanes sit on x so a warp spans the batch columns first: per-(lane, i)
-// global accesses of adjacent lanes land in the same 32-byte sector.
 @compute @workgroup_size(4, 64)
 fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
   let n1 = workgroupId.x * batchSize + localId.x;
-  let windowIndex = workgroupId.y;
+  let windowIndex = params.batchOffset + workgroupId.y;
   if (windowIndex >= params.windowCount) {
     return;
   }

--- a/packages/fft/src/fourier/fftPackedTiledR2c/index.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/index.ts
@@ -1,4 +1,9 @@
-import { type CreateFourier, type Fourier } from '../types.js';
+import { resolveFourierBatchRange } from '../batchRange.js';
+import {
+  type CreateFourier,
+  type Fourier,
+  type FourierBatchRange,
+} from '../types.js';
 import { createStateCell } from './state.js';
 
 export const createFftPackedTiledR2c: CreateFourier = (device, markers) => {
@@ -8,16 +13,41 @@ export const createFftPackedTiledR2c: CreateFourier = (device, markers) => {
     get: (arg) => {
       const state = stateCell.get(arg);
 
-      const dispatchFirstPass = (pass: GPUComputePassEncoder): void => {
+      const dispatchFirstPass = (
+        pass: GPUComputePassEncoder,
+        bindGroups: ReturnType<typeof state.getBindGroups>,
+        batchCount: number,
+      ): void => {
         pass.setPipeline(state.pipelines.firstPass);
-        pass.setBindGroup(0, state.bindGroups.firstPass);
-        pass.dispatchWorkgroups(state.firstPassXGroups, state.windowCount);
+        pass.setBindGroup(0, bindGroups.firstPass);
+        pass.dispatchWorkgroups(state.firstPassXGroups, batchCount);
       };
 
-      const dispatchSecondPass = (pass: GPUComputePassEncoder): void => {
+      const dispatchSecondPass = (
+        pass: GPUComputePassEncoder,
+        bindGroups: ReturnType<typeof state.getBindGroups>,
+        batchCount: number,
+      ): void => {
         pass.setPipeline(state.pipelines.secondPass);
-        pass.setBindGroup(0, state.bindGroups.secondPass);
-        pass.dispatchWorkgroups(state.secondPassXGroups, state.windowCount);
+        pass.setBindGroup(0, bindGroups.secondPass);
+        pass.dispatchWorkgroups(state.secondPassXGroups, batchCount);
+      };
+
+      const dispatch = (
+        pass: GPUComputePassEncoder,
+        range?: FourierBatchRange,
+      ): void => {
+        const { batchOffset, batchCount } = resolveFourierBatchRange(
+          range,
+          state.windowCount,
+        );
+        if (batchCount === 0) {
+          return;
+        }
+        const slot = state.params.reserve(batchOffset);
+        const bindGroups = state.getBindGroups(slot);
+        dispatchFirstPass(pass, bindGroups, batchCount);
+        dispatchSecondPass(pass, bindGroups, batchCount);
       };
 
       const ref: Fourier = {
@@ -26,20 +56,19 @@ export const createFftPackedTiledR2c: CreateFourier = (device, markers) => {
             label: 'packed-tiled-r2c-first-pass',
             timestampWrites: markers?.reverse,
           });
-          dispatchFirstPass(firstPass);
+          const slot = state.params.reserve(0);
+          const bindGroups = state.getBindGroups(slot);
+          dispatchFirstPass(firstPass, bindGroups, state.windowCount);
           firstPass.end();
 
           const secondPass = encoder.beginComputePass({
             label: 'packed-tiled-r2c-second-pass',
             timestampWrites: markers?.transform,
           });
-          dispatchSecondPass(secondPass);
+          dispatchSecondPass(secondPass, bindGroups, state.windowCount);
           secondPass.end();
         },
-        dispatch: (pass) => {
-          dispatchFirstPass(pass);
-          dispatchSecondPass(pass);
-        },
+        dispatch,
       };
       return ref;
     },

--- a/packages/fft/src/fourier/fftPackedTiledR2c/params.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/params.ts
@@ -1,30 +1,47 @@
 import { type FourierConfig } from '../config.es.js';
 
-export type PackedTiledR2cParams = {
-  windowSize: number;
-  windowCount: number;
-};
+const paramsByteLength = 16;
 
-export type Params = {
-  value: PackedTiledR2cParams;
+export type ParamsRing = {
   buffer: GPUBuffer;
+  binding: (slot: number) => GPUBufferBinding;
+  reserve: (batchOffset: number) => number;
+  destroy: () => void;
 };
 
-export const createParams = (
+export const createParamsRing = (
   device: GPUDevice,
   config: FourierConfig,
-): Params => {
-  const value = {
-    windowSize: config.windowSize,
-    windowCount: config.windowCount,
-  };
-  const array = new Uint32Array([value.windowSize, value.windowCount]);
+): ParamsRing => {
+  const capacity = Math.max(1, config.windowCount);
+  const alignment = device.limits.minUniformBufferOffsetAlignment;
+  const stride = Math.ceil(paramsByteLength / alignment) * alignment;
   const buffer = device.createBuffer({
     label: 'packed-tiled-r2c-params',
-    size: array.byteLength,
+    size: stride * capacity,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   });
-  device.queue.writeBuffer(buffer, 0, array);
+  const scratch = new Uint32Array(paramsByteLength / 4);
+  scratch[0] = config.windowSize;
+  scratch[1] = config.windowCount;
+  let cursor = 0;
 
-  return { value, buffer };
+  return {
+    buffer,
+    binding: (slot) => ({
+      buffer,
+      offset: slot * stride,
+      size: paramsByteLength,
+    }),
+    reserve: (batchOffset) => {
+      const slot = cursor;
+      cursor = (cursor + 1) % capacity;
+      scratch[2] = batchOffset;
+      device.queue.writeBuffer(buffer, slot * stride, scratch);
+      return slot;
+    },
+    destroy: () => {
+      buffer.destroy();
+    },
+  };
 };

--- a/packages/fft/src/fourier/fftPackedTiledR2c/secondPassMixedShader.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/secondPassMixedShader.ts
@@ -9,9 +9,6 @@ override columnRadix4StageCount: u32 = 0u;
 override columnRadix2StageCount: u32 = 0u;
 override columnRadix3StageCount: u32 = 0u;
 override columnRadix5StageCount: u32 = 0u;
-// Lane stride padding keeps the four lanes of a warp on distinct shared
-// memory banks now that warps span lanes first. Zero when the eight padded
-// arrays would not fit the 32 KB workgroup storage budget.
 override smPad: u32 = 8u;
 
 const threadCount: u32 = 64u;
@@ -20,6 +17,7 @@ const batchSize: u32 = 4u;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> rowAReal0: array<f32, batchSize * (tileSize + smPad)>;
@@ -269,7 +267,7 @@ fn main(
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
   let pairIndex = workgroupId.x * batchSize + localId.x;
-  let windowIndex = workgroupId.y;
+  let windowIndex = params.batchOffset + workgroupId.y;
   if (windowIndex >= params.windowCount) {
     return;
   }

--- a/packages/fft/src/fourier/fftPackedTiledR2c/secondPassShader.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/secondPassShader.ts
@@ -13,14 +13,12 @@ override columnRadix2StageCount: u32 = 0u;
 const threadCount: u32 = 64u;
 const batchSize: u32 = 4u;
 const sqrt1_2: f32 = 0.70710678118654752440;
-// Lane stride padding keeps the four lanes of a warp on distinct shared
-// memory banks now that warps span lanes first. Zero at tileSize 256, where
-// the eight padded arrays would not fit the 32 KB workgroup storage budget.
 override smPad: u32 = 8u;
 
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> rowAReal0: array<f32, batchSize * (tileSize + smPad)>;
@@ -117,8 +115,6 @@ fn writeColB(lane: u32, index: u32, readEven: bool, value: vec2<f32>) {
   }
 }
 
-// Small tiles run the original tight scalar radix-2 loops; the generic mixed
-// helpers measurably regress them (~20-30%).
 fn runColumnFftPairRadix2(t: u32, lane: u32) {
   let columnHalfSize = columnSize / 2u;
   for (var stage: u32 = 0u; stage < columnRadix2StageCount; stage++) {
@@ -414,15 +410,13 @@ fn writeBin(spectrumOffset: u32, k: u32, value: vec2<f32>) {
   spectrum[index + 1u] = value.y;
 }
 
-// Lanes sit on x so a warp spans the batch rows first: spectrum bin writes of
-// adjacent lanes land in the same 32-byte sector.
 @compute @workgroup_size(4, 64)
 fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
   let pairIndex = workgroupId.x * batchSize + localId.x;
-  let windowIndex = workgroupId.y;
+  let windowIndex = params.batchOffset + workgroupId.y;
   if (windowIndex >= params.windowCount) {
     return;
   }

--- a/packages/fft/src/fourier/fftPackedTiledR2c/state.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/state.ts
@@ -1,6 +1,6 @@
 import { createResourceCell, type ResourceCell } from '@musetric/utils';
 import { type FourierArg } from '../types.js';
-import { createParams, type Params } from './params.js';
+import { createParamsRing, type ParamsRing } from './params.js';
 import { createPipelines, type Pipelines } from './pipeline.js';
 import {
   getPackedTiledR2cVariant,
@@ -25,8 +25,8 @@ type Resources = {
 export type State = {
   pipelines: Pipelines;
   tables: TrigTables;
-  bindGroups: BindGroups;
-  params: Params;
+  getBindGroups: (slot: number) => BindGroups;
+  params: ParamsRing;
   dummyInput: GPUBuffer;
   scratch: GPUBuffer;
   windowCount: number;
@@ -68,6 +68,56 @@ const createDummyInputBuffer = (device: GPUDevice): GPUBuffer => {
   });
 };
 
+const createBindGroups = (
+  device: GPUDevice,
+  arg: FourierArg,
+  options: {
+    input: GPUBuffer;
+    params: GPUBufferBinding;
+    pipelines: Pipelines;
+    scratch: GPUBuffer;
+    tables: TrigTables;
+  },
+): BindGroups => ({
+  firstPass: device.createBindGroup({
+    label: 'packed-tiled-r2c-first-pass-bind-group',
+    layout: options.pipelines.firstPass.getBindGroupLayout(0),
+    entries: [
+      { binding: 0, resource: { buffer: options.input } },
+      { binding: 1, resource: { buffer: arg.spectrum } },
+      { binding: 2, resource: { buffer: options.scratch } },
+      { binding: 3, resource: { buffer: options.tables.rowFft } },
+      { binding: 4, resource: { buffer: options.tables.fourStep } },
+      { binding: 5, resource: options.params },
+    ],
+  }),
+  secondPass: device.createBindGroup({
+    label: 'packed-tiled-r2c-second-pass-bind-group',
+    layout: options.pipelines.secondPass.getBindGroupLayout(0),
+    entries: [
+      { binding: 0, resource: { buffer: options.scratch } },
+      { binding: 1, resource: { buffer: arg.spectrum } },
+      { binding: 2, resource: { buffer: options.tables.columnFft } },
+      { binding: 3, resource: { buffer: options.tables.r2c } },
+      { binding: 4, resource: options.params },
+    ],
+  }),
+});
+
+const createSlotCache = <T>(
+  build: (slot: number) => T,
+): ((slot: number) => T) => {
+  const cache = new Map<number, T>();
+  return (slot) => {
+    let cached = cache.get(slot);
+    if (cached === undefined) {
+      cached = build(slot);
+      cache.set(slot, cached);
+    }
+    return cached;
+  };
+};
+
 export const createStateCell = (
   device: GPUDevice,
 ): ResourceCell<FourierArg, State> =>
@@ -89,37 +139,20 @@ export const createStateCell = (
         variant,
         arg.config.windowCount,
       );
-      const params = createParams(device, arg.config);
-      const bindGroups = {
-        firstPass: device.createBindGroup({
-          label: 'packed-tiled-r2c-first-pass-bind-group',
-          layout: pipelines.firstPass.getBindGroupLayout(0),
-          entries: [
-            { binding: 0, resource: { buffer: input } },
-            { binding: 1, resource: { buffer: arg.spectrum } },
-            { binding: 2, resource: { buffer: scratch } },
-            { binding: 3, resource: { buffer: tables.rowFft } },
-            { binding: 4, resource: { buffer: tables.fourStep } },
-            { binding: 5, resource: { buffer: params.buffer } },
-          ],
-        }),
-        secondPass: device.createBindGroup({
-          label: 'packed-tiled-r2c-second-pass-bind-group',
-          layout: pipelines.secondPass.getBindGroupLayout(0),
-          entries: [
-            { binding: 0, resource: { buffer: scratch } },
-            { binding: 1, resource: { buffer: arg.spectrum } },
-            { binding: 2, resource: { buffer: tables.columnFft } },
-            { binding: 3, resource: { buffer: tables.r2c } },
-            { binding: 4, resource: { buffer: params.buffer } },
-          ],
-        }),
-      };
+      const params = createParamsRing(device, arg.config);
 
       return {
         pipelines,
         tables,
-        bindGroups,
+        getBindGroups: createSlotCache((slot) =>
+          createBindGroups(device, arg, {
+            input,
+            params: params.binding(slot),
+            pipelines,
+            scratch,
+            tables,
+          }),
+        ),
         params,
         dummyInput,
         scratch,
@@ -129,7 +162,7 @@ export const createStateCell = (
       };
     },
     dispose: (state) => {
-      state.params.buffer.destroy();
+      state.params.destroy();
       state.dummyInput.destroy();
       state.scratch.destroy();
       disposeTrigTables(state.tables);

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/index.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/index.ts
@@ -1,4 +1,9 @@
-import { type CreateFourier, type Fourier } from '../types.js';
+import { resolveFourierBatchRange } from '../batchRange.js';
+import {
+  type CreateFourier,
+  type Fourier,
+  type FourierBatchRange,
+} from '../types.js';
 import { createStateCell } from './state.js';
 
 export const createIfftPackedStockhamC2r: CreateFourier = (device, markers) => {
@@ -7,32 +12,33 @@ export const createIfftPackedStockhamC2r: CreateFourier = (device, markers) => {
     get: (arg): Fourier => {
       const state = stateCell.get(arg);
 
-      const dispatch = (pass: GPUComputePassEncoder): void => {
-        const { variant, pipeline, bindGroups } = state;
-        if (
-          variant.kind === 'multiPass' &&
-          pipeline.kind === 'multiPass' &&
-          bindGroups.kind === 'multiPass'
-        ) {
-          pipeline.stages.forEach((stagePipeline, index) => {
+      const dispatch = (
+        pass: GPUComputePassEncoder,
+        range?: FourierBatchRange,
+      ): void => {
+        const { batchOffset, batchCount } = resolveFourierBatchRange(
+          range,
+          state.windowCount,
+        );
+        if (batchCount === 0) {
+          return;
+        }
+        const slot = state.params.reserve(batchOffset);
+
+        if (state.kind === 'multiPass') {
+          const stages = state.getStageBindGroups(slot);
+          state.pipeline.stages.forEach((stagePipeline, index) => {
+            const kernel = state.variant.kernels[index];
             pass.setPipeline(stagePipeline);
-            pass.setBindGroup(0, bindGroups.stages[index]);
-            pass.dispatchWorkgroups(
-              state.windowCount,
-              variant.kernels[index].workgroupCount,
-            );
+            pass.setBindGroup(0, stages[index]);
+            pass.dispatchWorkgroups(batchCount, kernel.workgroupCount);
           });
           return;
         }
 
-        if (
-          pipeline.kind === 'singlePass' &&
-          bindGroups.kind === 'singlePass'
-        ) {
-          pass.setPipeline(pipeline.transform);
-          pass.setBindGroup(0, bindGroups.transform);
-          pass.dispatchWorkgroups(state.windowCount);
-        }
+        pass.setPipeline(state.pipeline.transform);
+        pass.setBindGroup(0, state.getBindGroup(slot));
+        pass.dispatchWorkgroups(batchCount);
       };
 
       const ref: Fourier = {

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/multiPassPairStageShader.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/multiPassPairStageShader.ts
@@ -1,6 +1,3 @@
-// Fused pair of inverse Stockham DIT radix stages (see the forward
-// multiPassPairStageShader for the group structure). The first kernel can
-// additionally fuse the C2R prepack read.
 export const multiPassPairStageShader = `
 override packedWindowSize: u32 = 8192u;
 override factor1: u32 = 8u;
@@ -25,6 +22,7 @@ const sin5b: f32 = 0.58778525229247312917;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 override pairSharedSize: u32 = 512u;
@@ -49,7 +47,6 @@ fn mul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
   return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
 }
 
-// Conjugate twiddle (+sin) turns the forward DIT butterfly into the inverse.
 fn getInvTwiddle(index: u32) -> vec2<f32> {
   return vec2<f32>(fftTrigTable[2u * index], fftTrigTable[2u * index + 1u]);
 }
@@ -66,8 +63,6 @@ fn readSpectrumBin(k: u32) -> vec2<f32> {
   return vec2<f32>(readSpectrumFloat(index), readSpectrumFloat(index + 1u));
 }
 
-// C2R combine: fold the half-spectrum bin k and its mirror (N-k) into the
-// packed complex sample feeding the size-(N/2) inverse FFT.
 fn loadPackedSpectrum(k: u32) -> vec2<f32> {
   if (k == 0u) {
     let dc = readSpectrumFloat(0u);
@@ -111,7 +106,6 @@ fn writeScratch(index: u32, value: vec2<f32>) {
   }
 }
 
-// Inverse DFT of size f (2, 4 or 8) from xv into yv (conjugate rotations).
 fn runDft(f: u32) {
   if (f == 8u) {
     let e0 = xv[0] + xv[4];
@@ -190,7 +184,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/multiPassStageShader.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/multiPassStageShader.ts
@@ -19,6 +19,7 @@ const sin5b: f32 = 0.58778525229247312917;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 @group(0) @binding(0) var<storage, read_write> scratch0: array<vec2<f32>>;
@@ -29,9 +30,6 @@ struct Params {
 @group(0) @binding(5) var<storage, read_write> signal: array<f32>;
 @group(0) @binding(6) var<storage, read> r2cTrigTable: array<f32>;
 
-// Per-invocation window offsets, set once in main so the fused prepack read
-// and signal write paths can recover local indices without changing the
-// butterfly codelets' readScratch/writeScratch call sites.
 var<private> windowScratchOffset: u32;
 var<private> windowSpectrumOffset: u32;
 var<private> windowSignalOffset: u32;
@@ -40,7 +38,6 @@ fn mul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
   return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
 }
 
-// Conjugate twiddle (+sin) turns the forward DIT butterfly into the inverse.
 fn getInvTwiddle(index: u32) -> vec2<f32> {
   return vec2<f32>(fftTrigTable[2u * index], fftTrigTable[2u * index + 1u]);
 }
@@ -57,8 +54,6 @@ fn readSpectrumBin(k: u32) -> vec2<f32> {
   return vec2<f32>(readSpectrumFloat(index), readSpectrumFloat(index + 1u));
 }
 
-// C2R combine: fold the half-spectrum bin k and its mirror (N-k) into the
-// packed complex sample feeding the size-(N/2) inverse FFT.
 fn loadPackedSpectrum(k: u32) -> vec2<f32> {
   if (k == 0u) {
     let dc = readSpectrumFloat(0u);
@@ -107,7 +102,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }
@@ -144,7 +139,6 @@ fn main(
       getInvTwiddle(6u * tw));
     let a7 = mul(readScratch(scratchOffset + base + 7u * butterflyCount),
       getInvTwiddle(7u * tw));
-    // inverse radix-8: conjugate W8 rotations vs the forward.
     let e0 = a0 + a4;
     let e1 = a0 - a4;
     let e2 = a2 + a6;
@@ -212,7 +206,6 @@ fn main(
     let diff02 = a0 - a2;
     let sum13 = a1 + a3;
     let diff13 = a1 - a3;
-    // inverse radix-4: +i and -i rotations swap relative to the forward.
     let plusIDiff13 = vec2<f32>(-diff13.y, diff13.x);
     let minusIDiff13 = vec2<f32>(diff13.y, -diff13.x);
     let i0 = block * (stageStride * 4u) + k;
@@ -234,7 +227,6 @@ fn main(
     let t1 = a1 + a2;
     let m = a0 - 0.5 * t1;
     let d = a2 - a1;
-    // inverse radix-3: i-rotation sign flipped vs the forward.
     let ids = vec2<f32>(sin3 * d.y, -sin3 * d.x);
     let o0 = block * (stageStride * 3u) + k;
     writeScratch(scratchOffset + o0, a0 + t1);
@@ -265,7 +257,6 @@ fn main(
     let o2 = o1 + stageStride;
     let o3 = o2 + stageStride;
     let o4 = o3 + stageStride;
-    // inverse radix-5: i-rotation signs flipped vs the forward.
     writeScratch(scratchOffset + o0, a0 + t1 + t2);
     writeScratch(scratchOffset + o1, b1 + vec2<f32>(-b3.y, b3.x));
     writeScratch(scratchOffset + o2, b2 + vec2<f32>(-b4.y, b4.x));

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/params.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/params.ts
@@ -1,21 +1,47 @@
 import { type FourierConfig } from '../config.es.js';
 
-export type Params = {
+const paramsByteLength = 16;
+
+export type ParamsRing = {
   buffer: GPUBuffer;
+  binding: (slot: number) => GPUBufferBinding;
+  reserve: (batchOffset: number) => number;
+  destroy: () => void;
 };
 
-const paramsSize = 2 * Uint32Array.BYTES_PER_ELEMENT;
-
-export const createParams = (
+export const createParamsRing = (
   device: GPUDevice,
   config: FourierConfig,
-): Params => {
-  const array = new Uint32Array([config.windowSize, config.windowCount]);
+): ParamsRing => {
+  const capacity = Math.max(1, config.windowCount);
+  const alignment = device.limits.minUniformBufferOffsetAlignment;
+  const stride = Math.ceil(paramsByteLength / alignment) * alignment;
   const buffer = device.createBuffer({
-    label: 'packed-stockham-c2r-params-buffer',
-    size: paramsSize,
+    label: 'packed-stockham-c2r-params',
+    size: stride * capacity,
     usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
   });
-  device.queue.writeBuffer(buffer, 0, array);
-  return { buffer };
+  const scratch = new Uint32Array(paramsByteLength / 4);
+  scratch[0] = config.windowSize;
+  scratch[1] = config.windowCount;
+  let cursor = 0;
+
+  return {
+    buffer,
+    binding: (slot) => ({
+      buffer,
+      offset: slot * stride,
+      size: paramsByteLength,
+    }),
+    reserve: (batchOffset) => {
+      const slot = cursor;
+      cursor = (cursor + 1) % capacity;
+      scratch[2] = batchOffset;
+      device.queue.writeBuffer(buffer, slot * stride, scratch);
+      return slot;
+    },
+    destroy: () => {
+      buffer.destroy();
+    },
+  };
 };

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/state.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/state.ts
@@ -1,7 +1,12 @@
 import { createResourceCell, type ResourceCell } from '@musetric/utils';
 import { type FourierArg } from '../types.js';
-import { createParams, type Params } from './params.js';
-import { createPipeline, type Pipeline } from './pipeline.js';
+import { createParamsRing, type ParamsRing } from './params.js';
+import {
+  createPipeline,
+  type MultiPassPipeline,
+  type Pipeline,
+  type SinglePassPipeline,
+} from './pipeline.js';
 import {
   getPackedStockhamC2rVariant,
   type PackedStockhamC2rVariant,
@@ -17,28 +22,31 @@ type ScratchBuffers = {
   buffer1: GPUBuffer;
 };
 
-type SinglePassBindGroups = {
-  kind: 'singlePass';
-  transform: GPUBindGroup;
-};
-
-type MultiPassBindGroups = {
-  kind: 'multiPass';
-  stages: GPUBindGroup[];
-};
-
-type BindGroups = SinglePassBindGroups | MultiPassBindGroups;
-
-export type State = {
+type BaseState = {
+  kind: Pipeline['kind'];
   variant: PackedStockhamC2rVariant;
   pipeline: Pipeline;
   tables: TrigTables;
-  bindGroups: BindGroups;
-  params: Params;
+  params: ParamsRing;
   windowCount: number;
   dummySpectrum: GPUBuffer;
-  scratch?: ScratchBuffers;
 };
+
+type SinglePassState = BaseState & {
+  kind: 'singlePass';
+  pipeline: SinglePassPipeline;
+  getBindGroup: (slot: number) => GPUBindGroup;
+};
+
+type MultiPassState = BaseState & {
+  kind: 'multiPass';
+  variant: Extract<PackedStockhamC2rVariant, { kind: 'multiPass' }>;
+  pipeline: MultiPassPipeline;
+  getStageBindGroups: (slot: number) => GPUBindGroup[];
+  scratch: ScratchBuffers;
+};
+
+export type State = SinglePassState | MultiPassState;
 
 const createDummySpectrumBuffer = (device: GPUDevice): GPUBuffer => {
   return device.createBuffer({
@@ -69,6 +77,20 @@ const createScratchBuffers = (
   };
 };
 
+const createSlotCache = <T>(
+  build: (slot: number) => T,
+): ((slot: number) => T) => {
+  const cache = new Map<number, T>();
+  return (slot) => {
+    let cached = cache.get(slot);
+    if (cached === undefined) {
+      cached = build(slot);
+      cache.set(slot, cached);
+    }
+    return cached;
+  };
+};
+
 export const createStateCell = (
   device: GPUDevice,
 ): ResourceCell<FourierArg, State> =>
@@ -84,41 +106,40 @@ export const createStateCell = (
       const inPlace = arg.wave === arg.spectrum;
       const pipeline = createPipeline(device, variant, inPlace);
       const tables = createTrigTables(device, variant);
-      const params = createParams(device, arg.config);
+      const params = createParamsRing(device, arg.config);
       const { windowCount } = arg.config;
       const dummySpectrum = createDummySpectrumBuffer(device);
       const spectrum = inPlace ? dummySpectrum : arg.spectrum;
 
-      if (pipeline.kind === 'multiPass') {
+      if (variant.kind === 'multiPass' && pipeline.kind === 'multiPass') {
         const scratch = createScratchBuffers(
           device,
           variant.packedWindowSize,
           windowCount,
         );
-        const bindGroups: MultiPassBindGroups = {
-          kind: 'multiPass',
-          stages: pipeline.stages.map((stagePipeline) =>
-            device.createBindGroup({
-              label: 'packed-stockham-c2r-multipass-stage-bind-group',
-              layout: stagePipeline.getBindGroupLayout(0),
-              entries: [
-                { binding: 0, resource: { buffer: scratch.buffer0 } },
-                { binding: 1, resource: { buffer: scratch.buffer1 } },
-                { binding: 2, resource: { buffer: tables.fft } },
-                { binding: 3, resource: { buffer: params.buffer } },
-                { binding: 4, resource: { buffer: spectrum } },
-                { binding: 5, resource: { buffer: arg.wave } },
-                { binding: 6, resource: { buffer: tables.r2c } },
-              ],
-            }),
-          ),
-        };
 
         return {
+          kind: 'multiPass',
           variant,
           pipeline,
           tables,
-          bindGroups,
+          getStageBindGroups: createSlotCache((slot) =>
+            pipeline.stages.map((stagePipeline) =>
+              device.createBindGroup({
+                label: 'packed-stockham-c2r-multipass-stage-bind-group',
+                layout: stagePipeline.getBindGroupLayout(0),
+                entries: [
+                  { binding: 0, resource: { buffer: scratch.buffer0 } },
+                  { binding: 1, resource: { buffer: scratch.buffer1 } },
+                  { binding: 2, resource: { buffer: tables.fft } },
+                  { binding: 3, resource: params.binding(slot) },
+                  { binding: 4, resource: { buffer: spectrum } },
+                  { binding: 5, resource: { buffer: arg.wave } },
+                  { binding: 6, resource: { buffer: tables.r2c } },
+                ],
+              }),
+            ),
+          ),
           params,
           windowCount,
           dummySpectrum,
@@ -126,35 +147,37 @@ export const createStateCell = (
         };
       }
 
-      const bindGroups: SinglePassBindGroups = {
-        kind: 'singlePass',
-        transform: device.createBindGroup({
-          label: 'packed-stockham-c2r-transform-bind-group',
-          layout: pipeline.transform.getBindGroupLayout(0),
-          entries: [
-            { binding: 0, resource: { buffer: spectrum } },
-            { binding: 1, resource: { buffer: arg.wave } },
-            { binding: 2, resource: { buffer: tables.fft } },
-            { binding: 3, resource: { buffer: tables.r2c } },
-            { binding: 4, resource: { buffer: params.buffer } },
-          ],
-        }),
-      };
+      if (pipeline.kind !== 'singlePass') {
+        throw new Error('ifftPackedStockhamC2r variant/pipeline kind mismatch');
+      }
 
       return {
+        kind: 'singlePass',
         variant,
         pipeline,
         tables,
-        bindGroups,
+        getBindGroup: createSlotCache((slot) =>
+          device.createBindGroup({
+            label: 'packed-stockham-c2r-transform-bind-group',
+            layout: pipeline.transform.getBindGroupLayout(0),
+            entries: [
+              { binding: 0, resource: { buffer: spectrum } },
+              { binding: 1, resource: { buffer: arg.wave } },
+              { binding: 2, resource: { buffer: tables.fft } },
+              { binding: 3, resource: { buffer: tables.r2c } },
+              { binding: 4, resource: params.binding(slot) },
+            ],
+          }),
+        ),
         params,
         windowCount,
         dummySpectrum,
       };
     },
     dispose: (state) => {
-      state.params.buffer.destroy();
+      state.params.destroy();
       state.dummySpectrum.destroy();
-      if (state.scratch) {
+      if (state.kind === 'multiPass') {
         state.scratch.buffer0.destroy();
         state.scratch.buffer1.destroy();
       }

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/transformInPlaceMixedShader.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/transformInPlaceMixedShader.ts
@@ -19,6 +19,7 @@ const sin5b: f32 = 0.58778525229247312917;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> sm: array<vec2<f32>, packedWindowSize>;
@@ -53,7 +54,6 @@ fn getFactor(stage: u32) -> u32 {
   return 5u;
 }
 
-// Mixed-radix digit reversal for the in-place DIT, digits in getFactor order.
 fn reverseMixed(index: u32) -> u32 {
   var rev = 0u;
   var placeIn = packedWindowSize;
@@ -90,7 +90,6 @@ fn mul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
   return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
 }
 
-// Conjugate twiddle (+sin) for the inverse DIT.
 fn getInvTwiddle(index: u32) -> vec2<f32> {
   return vec2<f32>(fftTrigTable[2u * index], fftTrigTable[2u * index + 1u]);
 }
@@ -145,7 +144,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }
@@ -154,8 +153,6 @@ fn main(
   let spectrumOffset = complexStride() * windowIndex;
   let signalOffset = params.windowSize * windowIndex;
 
-  // C2R prepack: packed(k) and packed(P-k) share the bin pair {k, P-k} and one
-  // twiddle (packed(P-k) = conj(even - i*odd)), halving global/table reads.
   if (t == 0u) {
     store(0u, loadPackedSpectrum(spectrumOffset, 0u));
     if (packedWindowSize % 2u == 0u) {

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/transformShader.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/transformShader.ts
@@ -19,6 +19,7 @@ const sin5b: f32 = 0.58778525229247312917;
 struct Params {
   windowSize: u32,
   windowCount: u32,
+  batchOffset: u32,
 };
 
 var<workgroup> sm0: array<vec2<f32>, packedWindowSize>;
@@ -58,7 +59,6 @@ fn mul(a: vec2<f32>, b: vec2<f32>) -> vec2<f32> {
   return vec2<f32>(a.x * b.x - a.y * b.y, a.x * b.y + a.y * b.x);
 }
 
-// Conjugate twiddle (+sin) turns the forward DIT butterfly into the inverse.
 fn getInvTwiddle(index: u32) -> vec2<f32> {
   return vec2<f32>(fftTrigTable[2u * index], fftTrigTable[2u * index + 1u]);
 }
@@ -85,8 +85,6 @@ fn getResult(index: u32) -> vec2<f32> {
   return sm1[index];
 }
 
-// C2R combine: fold the half-spectrum bin k and its mirror (N-k) into the
-// packed complex sample feeding the size-(N/2) inverse FFT.
 fn complexStride() -> u32 {
   return params.windowSize + 2u;
 }
@@ -129,7 +127,7 @@ fn main(
   @builtin(workgroup_id) workgroupId: vec3<u32>,
   @builtin(local_invocation_id) localId: vec3<u32>,
 ) {
-  let windowIndex = workgroupId.x;
+  let windowIndex = params.batchOffset + workgroupId.x;
   if (windowIndex >= params.windowCount) {
     return;
   }
@@ -138,8 +136,6 @@ fn main(
   let spectrumOffset = complexStride() * windowIndex;
   let signalOffset = params.windowSize * windowIndex;
 
-  // C2R prepack: packed(k) and packed(P-k) share the bin pair {k, P-k} and one
-  // twiddle (packed(P-k) = conj(even - i*odd)), halving global/table reads.
   if (t == 0u) {
     sm0[0u] = loadPackedSpectrum(spectrumOffset, 0u);
     if (packedWindowSize % 2u == 0u) {
@@ -192,7 +188,6 @@ fn main(
           getInvTwiddle(6u * tw));
         let a7 = mul(readStage(base + 7u * butterflyCount, readEven),
           getInvTwiddle(7u * tw));
-        // even-indexed inverse radix-4
         let e0 = a0 + a4;
         let e1 = a0 - a4;
         let e2 = a2 + a6;
@@ -201,7 +196,6 @@ fn main(
         let E1 = e1 + vec2<f32>(-e3.y, e3.x);
         let E2 = e0 - e2;
         let E3 = e1 + vec2<f32>(e3.y, -e3.x);
-        // odd-indexed inverse radix-4
         let f0 = a1 + a5;
         let f1 = a1 - a5;
         let f2 = a3 + a7;
@@ -210,7 +204,6 @@ fn main(
         let O1 = f1 + vec2<f32>(-f3.y, f3.x);
         let O2 = f0 - f2;
         let O3 = f1 + vec2<f32>(f3.y, -f3.x);
-        // combine with conjugate W8^-r
         let p0 = O0;
         let p1 = vec2<f32>(
           sqrt1_2 * (O1.x - O1.y),

--- a/packages/fft/src/fourier/types.ts
+++ b/packages/fft/src/fourier/types.ts
@@ -13,8 +13,8 @@ export type FourierArg = {
 };
 
 export type FourierBatchRange = {
-  slotOffset: number;
-  columnCount: number;
+  batchOffset: number;
+  batchCount: number;
 };
 
 export type Fourier = {


### PR DESCRIPTION
Fourier.dispatch now takes an optional FourierBatchRange ({ batchOffset, batchCount }, renamed from slotOffset/columnCount) and transforms only that contiguous run of windows. Every dispatch reserves a slot in a per-instance uniform ring (windowCount slots, stride aligned to minUniformBufferOffsetAlignment), so several ranged dispatches recorded into one submit each read their own batchOffset instead of last-write-wins on a single uniform; bind groups are cached per slot.

- fftPackedStockhamR2c, fftPackedTiledR2c and ifftPackedStockhamC2r all honour the range; shaders offset windowIndex by params.batchOffset.
- resolveFourierBatchRange validates non-negative integers and rejects wrapping runs (callers split them); the per-submit slot budget is documented on Fourier.dispatch.
- Tests: targeted-only transforms (in-place and out-of-place), disjoint ranges in one submit, ring-cursor wrap across submits, zero-count no-op, validation unit cases; forward and inverse modes.
- Bench: 1/2/3-range dispatch of a quarter of the windows reported against the matching full mode; runsPerSample is capped so one submit stays within the ring budget.