### PR TITLE
feat(spectrogram): incremental dirty-column rendering

### DIFF
--- a/packages/engine/src/spectrogram/runtime.worker.ts
+++ b/packages/engine/src/spectrogram/runtime.worker.ts
@@ -1,10 +1,9 @@
-import { allTrackKeys } from '@musetric/spectrogram';
+import { allTrackKeys, mapTrackKeys } from '@musetric/spectrogram';
 import {
   averageMetrics,
   createSpectrogramProcessor,
   getGpuDevice,
   type SpectrogramProcessorMetrics,
-  type SpectrogramSampleInvalidation,
 } from '@musetric/spectrogram/gpu';
 import { createAnimationFrameLoop } from '@musetric/utils/cross/animationFrameLoop';
 import { createThrottleTime } from '@musetric/utils/cross/throttleTime';
@@ -27,17 +26,7 @@ export type CreateSpectrogramRuntimeOptions = {
 const playheadFrameIndexSlot = 0;
 
 const emptySamples = (): SpectrogramLaneSamples =>
-  allTrackKeys.reduce<SpectrogramLaneSamples>((acc, key) => {
-    acc[key] = undefined;
-    return acc;
-  }, {});
-
-const playheadAdvanceInvalidations: readonly SpectrogramSampleInvalidation[] =
-  allTrackKeys.map((trackKey) => ({
-    trackKey,
-    frameIndex: 0,
-    frameCount: 0,
-  }));
+  mapTrackKeys(() => undefined);
 
 export const createSpectrogramRuntime = async (
   options: CreateSpectrogramRuntimeOptions,
@@ -107,7 +96,6 @@ export const createSpectrogramRuntime = async (
     rendering = true;
     try {
       trackProgress = playheadTrackProgress();
-      processor.invalidateSamples(playheadAdvanceInvalidations);
       await render();
     } finally {
       rendering = false;
@@ -133,6 +121,9 @@ export const createSpectrogramRuntime = async (
           frameCount: message.frameCount,
         },
       ]);
+      if (!playing) {
+        void renderFromPlayhead();
+      }
     },
   });
 
@@ -162,7 +153,13 @@ export const createSpectrogramRuntime = async (
     },
     setTrackProgress: (message) => {
       trackProgress = message.trackProgress;
-      void render();
+      if (frameCount > 0) {
+        const frameIndex = Math.round(message.trackProgress * frameCount);
+        Atomics.store(playhead, playheadFrameIndexSlot, frameIndex);
+      }
+      if (!playing) {
+        void renderFromPlayhead();
+      }
     },
     setFrameCount: (message) => {
       frameCount = message.frameCount;
@@ -171,14 +168,16 @@ export const createSpectrogramRuntime = async (
       playing = message.playing;
       if (playing) {
         renderLoop.start();
-      } else {
-        renderLoop.stop();
-        void render();
+        return;
       }
+      renderLoop.stop();
+      void renderFromPlayhead();
     },
     updateConfig: (message) => {
       processor.updateConfig(message.patch);
-      void render();
+      if (!playing) {
+        void renderFromPlayhead();
+      }
     },
   });
 };

--- a/packages/performance/src/runPipeline.ts
+++ b/packages/performance/src/runPipeline.ts
@@ -126,41 +126,26 @@ export const runPipeline = async (
     onMetrics: metricsArray.push.bind(metricsArray),
   });
 
-  if (params.trackScope !== 'all') {
-    await processor.render(
-      { lead: samples, recording: recordingSamples },
-      progress,
-    );
-    metricsArray.length = 0;
-  }
-
-  const scopeInvalidation =
-    params.trackScope === 'all'
-      ? []
-      : [
-          {
-            trackKey: params.trackScope,
-            frameIndex: 0,
-            frameCount: 0,
-          },
-        ];
+  const renderSamples = () => {
+    const lead = samples.subarray(0);
+    const recording = recordingSamples.subarray(0);
+    if (params.trackScope === 'lead') {
+      return { lead };
+    }
+    if (params.trackScope === 'recording') {
+      return { recording };
+    }
+    return { lead, recording };
+  };
 
   for (let i = 0; i < warmupIters; i++) {
-    processor.invalidateSamples(scopeInvalidation);
-    await processor.render(
-      { lead: samples, recording: recordingSamples },
-      progress,
-    );
+    await processor.render(renderSamples(), progress);
   }
   metricsArray.length = 0;
 
   for (let tryIndex = 0; tryIndex < benchMaxTries; tryIndex++) {
     for (let i = 0; i < benchBatchSize; i++) {
-      processor.invalidateSamples(scopeInvalidation);
-      await processor.render(
-        { lead: samples, recording: recordingSamples },
-        progress,
-      );
+      await processor.render(renderSamples(), progress);
     }
 
     const totals = metricsArray.map((m) => m.total);

--- a/packages/spectrogram/package.json
+++ b/packages/spectrogram/package.json
@@ -24,6 +24,7 @@
     "check:ts": "tsc --build",
     "check:lint": "eslint . --cache --cache-strategy content",
     "fix:lint": "eslint . --fix --cache --cache-strategy content",
+    "test": "vitest run",
     "bench": "node --import tsx ./scripts/bench.ts"
   },
   "peerDependencies": {

--- a/packages/spectrogram/scripts/bench.ts
+++ b/packages/spectrogram/scripts/bench.ts
@@ -3,7 +3,7 @@ import { Writable } from 'node:stream';
 import { fileURLToPath } from 'node:url';
 import { experimental_getRunnerTask, startVitest } from 'vitest/node';
 import { type SpectrogramBenchSummary } from '../src/__test__/bench.es.js';
-import { writeBendReports } from './genBenchReport.js';
+import { writeBenchReports } from './genBenchReport.js';
 
 declare module '@vitest/runner' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
@@ -60,7 +60,7 @@ const runVitest = async (): Promise<SpectrogramBenchSummary[]> => {
 };
 
 const webgpuResults = await runVitest();
-writeBendReports(webgpuResults);
+writeBenchReports(webgpuResults);
 
 const elapsed = ((performance.now() - startTime) / 1000).toFixed(2);
 console.log(`Total script time: ${elapsed}s`);

--- a/packages/spectrogram/scripts/genBenchReport.ts
+++ b/packages/spectrogram/scripts/genBenchReport.ts
@@ -20,13 +20,13 @@ const writeBandReport = (
   const [first] = summaries;
   const filePath = resolve(
     outputDirectory,
-    `bend${bandCount}_${formatBenchTimestamp(first.timestamp)}.md`,
+    `band${bandCount}_${formatBenchTimestamp(first.timestamp)}.md`,
   );
   writeFileSync(filePath, formatBenchMarkdown(summaries), 'utf-8');
   console.log(`Wrote ${filePath}`);
 };
 
-export const writeBendReports = (
+export const writeBenchReports = (
   summaries: SpectrogramBenchSummary[],
 ): void => {
   if (summaries.length < 1) {
@@ -54,7 +54,7 @@ export const writeBendReports = (
 
 if (resolve(process.argv[1] ?? '') === fileURLToPath(import.meta.url)) {
   try {
-    writeBendReports([]);
+    writeBenchReports([]);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error('Failed:', message);

--- a/packages/spectrogram/src/__test__/common.ts
+++ b/packages/spectrogram/src/__test__/common.ts
@@ -1,5 +1,9 @@
 import { createGpuBufferReader } from '@musetric/utils/gpu';
 import { expect } from 'vitest';
+import {
+  computeColumnStep,
+  type ExtSpectrogramConfig,
+} from '../common/extConfig.js';
 import { type SpectrogramConfig } from '../config.cross.js';
 import { defaultSpectrogramConfig } from '../defaultConfig.cross.js';
 
@@ -13,6 +17,17 @@ export const buildConfig = (
     ...overrides,
     canvas,
     viewSize,
+  };
+};
+
+export const extendConfig = (
+  config: SpectrogramConfig,
+): ExtSpectrogramConfig => {
+  const windowCount = config.viewSize.width;
+  return {
+    ...config,
+    windowCount,
+    columnStep: computeColumnStep({ ...config, windowCount }),
   };
 };
 
@@ -77,6 +92,33 @@ export const brightestRow = (
     }
   }
   return bestRow;
+};
+
+export const countDifferences = (
+  left: Uint8ClampedArray,
+  right: Uint8ClampedArray,
+): number => {
+  let count = 0;
+  for (let i = 0; i < left.length; i += 1) {
+    if (left[i] !== right[i]) {
+      count += 1;
+    }
+  }
+  return count;
+};
+
+export const maxAbsDifference = (
+  left: Uint8ClampedArray,
+  right: Uint8ClampedArray,
+): number => {
+  let max = 0;
+  for (let i = 0; i < left.length; i += 1) {
+    const difference = Math.abs(left[i] - right[i]);
+    if (difference > max) {
+      max = difference;
+    }
+  }
+  return max;
 };
 
 export const rowAtFrequency = (

--- a/packages/spectrogram/src/__test__/processor.test.ts
+++ b/packages/spectrogram/src/__test__/processor.test.ts
@@ -1,0 +1,505 @@
+import { createGpuContext } from '@musetric/utils/gpu';
+import { describe, expect, it } from 'vitest';
+import { allTrackKeys, type SpectrogramConfig } from '../config.cross.js';
+import { defaultSpectrogramConfig } from '../defaultConfig.cross.js';
+import {
+  createSpectrogramProcessor,
+  type CreateSpectrogramProcessorOptions,
+  type SpectrogramProcessor,
+  type SpectrogramSamples,
+} from '../processor.js';
+import {
+  brightestRow,
+  buildConfig,
+  countDifferences,
+  createSilence,
+  createTone,
+  maxAbsDifference,
+  maxRed,
+  readCanvas,
+  rowAtFrequency,
+} from './common.js';
+
+const { device } = await createGpuContext();
+
+const windowSize = 2048;
+const toneFrequency = 1000;
+
+const singleBandConfig = (
+  overrides: Partial<SpectrogramConfig> = {},
+): SpectrogramConfig =>
+  buildConfig({
+    windowSize,
+    zeroPaddingFactor: 1,
+    minFrequency: 120,
+    maxFrequency: 4000,
+    spectralBands: [
+      {
+        label: `${windowSize}`,
+        windowSize,
+        minFrequency: 120,
+        fullMinFrequency: 120,
+        fullMaxFrequency: 4000,
+        maxFrequency: 4000,
+      },
+    ],
+    lanes: {
+      lead: {
+        ...defaultSpectrogramConfig.lanes.lead,
+        showSpectrogram: true,
+        showFundamental: false,
+      },
+      recording: {
+        ...defaultSpectrogramConfig.lanes.recording,
+        showSpectrogram: false,
+        showFundamental: false,
+      },
+    },
+    viewSize: { width: 128, height: 128 },
+    ...overrides,
+  });
+
+const withProcessor = async <T>(
+  options: CreateSpectrogramProcessorOptions,
+  fn: (processor: SpectrogramProcessor) => Promise<T>,
+): Promise<T> => {
+  const processor = createSpectrogramProcessor(options);
+  try {
+    return await fn(processor);
+  } finally {
+    processor.dispose();
+  }
+};
+
+const withTwoProcessors = async <T>(
+  incrementalOptions: CreateSpectrogramProcessorOptions,
+  fullOptions: CreateSpectrogramProcessorOptions,
+  fn: (
+    incremental: SpectrogramProcessor,
+    full: SpectrogramProcessor,
+  ) => Promise<T>,
+): Promise<T> =>
+  withProcessor(incrementalOptions, async (incremental) =>
+    withProcessor(fullOptions, async (full) => fn(incremental, full)),
+  );
+
+const renderFromScratch = async (
+  processor: SpectrogramProcessor,
+  config: SpectrogramConfig,
+  samples: SpectrogramSamples,
+  progress: number,
+): Promise<Uint8ClampedArray> => {
+  const copy: SpectrogramSamples = {};
+  for (const key of allTrackKeys) {
+    const track = samples[key];
+    if (track) {
+      copy[key] = Float32Array.from(track);
+    }
+  }
+  await processor.render(copy, progress);
+  return readCanvas(config.canvas);
+};
+
+const expectMatchesReference = (
+  actual: Uint8ClampedArray,
+  reference: Uint8ClampedArray,
+): void => {
+  expect(maxRed(actual)).toBeGreaterThan(40);
+  expect(maxAbsDifference(actual, reference)).toBeLessThan(8);
+};
+
+const writeToneRange = (
+  samples: Float32Array,
+  frameIndex: number,
+  frameCount: number,
+  frequency: number,
+  sampleRate: number,
+): void => {
+  const start = Math.max(0, frameIndex);
+  const end = Math.min(samples.length, frameIndex + frameCount);
+  for (let sampleIndex = start; sampleIndex < end; sampleIndex += 1) {
+    samples[sampleIndex] = Math.sin(
+      (2 * Math.PI * frequency * sampleIndex) / sampleRate,
+    );
+  }
+};
+
+const writeCentreTone = (
+  lead: Float32Array,
+  sampleRate: number,
+): { trackKey: 'lead'; frameIndex: number; frameCount: number } => {
+  const chunkLength = windowSize * 2;
+  const chunkStart = Math.floor(lead.length * 0.5 - chunkLength * 0.5);
+  writeToneRange(lead, chunkStart, chunkLength, toneFrequency, sampleRate);
+  return { trackKey: 'lead', frameIndex: chunkStart, frameCount: chunkLength };
+};
+
+const progressForColumns = (
+  config: SpectrogramConfig,
+  sampleLength: number,
+  columns: number,
+): number => {
+  const step =
+    (config.visibleTime * config.sampleRate) / (config.viewSize.width - 1);
+  return (columns * step) / sampleLength;
+};
+
+const writeRecordingChunks = (
+  recording: Float32Array,
+  firstChunkFrameIndex: number,
+  chunkCount: number,
+  chunkFrameCount: number,
+  sampleRate: number,
+): { trackKey: 'recording'; frameIndex: number; frameCount: number }[] =>
+  Array.from({ length: chunkCount }, (_, index) => {
+    const chunkFrameIndex = firstChunkFrameIndex + index * chunkFrameCount;
+    writeToneRange(
+      recording,
+      chunkFrameIndex,
+      chunkFrameCount,
+      440,
+      sampleRate,
+    );
+    return {
+      trackKey: 'recording' as const,
+      frameIndex: chunkFrameIndex,
+      frameCount: chunkFrameCount,
+    };
+  });
+
+describe('spectrogram processor', () => {
+  it('renders a tone into its expected frequency row', async () => {
+    const config = singleBandConfig();
+    await withProcessor({ device, config }, async (processor) => {
+      const lead = createTone(
+        config.sampleRate * 5,
+        toneFrequency,
+        config.sampleRate,
+      );
+      const ok = await processor.render({ lead }, 0.5);
+      expect(ok).toBe(true);
+
+      const pixels = await readCanvas(config.canvas);
+      const { width, height } = config.viewSize;
+
+      expect(maxRed(pixels)).toBeGreaterThan(40);
+
+      const expectedRow = rowAtFrequency(toneFrequency, config);
+      const actualRow = brightestRow(pixels, width, height);
+      expect(Math.abs(actualRow - expectedRow)).toBeLessThan(height * 0.15);
+    });
+  });
+
+  it('keeps silence dark', async () => {
+    const config = singleBandConfig();
+    await withProcessor({ device, config }, async (processor) => {
+      const lead = createSilence(config.sampleRate * 5);
+      await processor.render({ lead }, 0.5);
+      const pixels = await readCanvas(config.canvas);
+      expect(maxRed(pixels)).toBeLessThan(16);
+    });
+  });
+
+  it('is deterministic across identical renders', async () => {
+    const config = singleBandConfig();
+    await withProcessor({ device, config }, async (processor) => {
+      const lead = createTone(
+        config.sampleRate * 5,
+        toneFrequency,
+        config.sampleRate,
+      );
+      await processor.render({ lead }, 0.5);
+      const first = await readCanvas(config.canvas);
+      await processor.render({ lead }, 0.5);
+      const second = await readCanvas(config.canvas);
+      expect(countDifferences(first, second)).toBe(0);
+    });
+  });
+
+  it('requires an invalidated sample chunk after in-place sample mutation', async () => {
+    const config = singleBandConfig();
+    await withProcessor({ device, config }, async (processor) => {
+      const lead = createSilence(config.sampleRate * 5);
+      await processor.render({ lead }, 0.5);
+      const silent = await readCanvas(config.canvas);
+      expect(maxRed(silent)).toBeLessThan(16);
+
+      const invalidation = writeCentreTone(lead, config.sampleRate);
+      await processor.render({ lead }, 0.5);
+      const stale = await readCanvas(config.canvas);
+      expect(countDifferences(silent, stale)).toBe(0);
+
+      processor.invalidateSamples([invalidation]);
+      await processor.render({ lead }, 0.5);
+      const updated = await readCanvas(config.canvas);
+      expect(maxRed(updated)).toBeGreaterThan(40);
+    });
+  });
+
+  it('keeps resident samples across draw-only config changes', async () => {
+    const config = singleBandConfig();
+    await withProcessor({ device, config }, async (processor) => {
+      const lead = createSilence(config.sampleRate * 5);
+      await processor.render({ lead }, 0.5);
+      const silent = await readCanvas(config.canvas);
+      expect(maxRed(silent)).toBeLessThan(16);
+
+      const invalidation = writeCentreTone(lead, config.sampleRate);
+      processor.updateConfig({
+        colors: {
+          ...config.colors,
+          foreground: '#ff0000',
+        },
+      });
+      await processor.render({ lead }, 0.5);
+      const stale = await readCanvas(config.canvas);
+      expect(maxRed(stale)).toBeLessThan(16);
+
+      processor.invalidateSamples([invalidation]);
+      await processor.render({ lead }, 0.5);
+      const updated = await readCanvas(config.canvas);
+      expect(maxRed(updated)).toBeGreaterThan(40);
+    });
+  });
+
+  it('matches a full render when slide and recording dirty disjoint columns', async () => {
+    const incrementalConfig = singleBandConfig();
+    const fullConfig = singleBandConfig();
+    await withTwoProcessors(
+      { device, config: incrementalConfig },
+      { device, config: fullConfig },
+      async (incremental, full) => {
+        const length = incrementalConfig.sampleRate * 5;
+        const lead = createSilence(length);
+        const start = 0.5;
+        const slide = progressForColumns(incrementalConfig, length, 4);
+
+        await incremental.render({ lead }, start);
+        const invalidation = writeCentreTone(
+          lead,
+          incrementalConfig.sampleRate,
+        );
+        incremental.invalidateSamples([invalidation]);
+        await incremental.render({ lead }, start + slide);
+        const incrementalPixels = await readCanvas(incrementalConfig.canvas);
+
+        const fullPixels = await renderFromScratch(
+          full,
+          fullConfig,
+          { lead },
+          start + slide,
+        );
+
+        expect(maxRed(fullPixels)).toBeGreaterThan(40);
+        expectMatchesReference(incrementalPixels, fullPixels);
+      },
+    );
+  });
+
+  it('matches a full render for playback plus adjacent recording chunks', async () => {
+    const lanes = {
+      lead: {
+        ...defaultSpectrogramConfig.lanes.lead,
+        showSpectrogram: true,
+        showFundamental: true,
+      },
+      recording: {
+        ...defaultSpectrogramConfig.lanes.recording,
+        showSpectrogram: true,
+        showFundamental: true,
+      },
+    };
+    const incrementalConfig = singleBandConfig({ lanes });
+    const fullConfig = singleBandConfig({ lanes });
+    await withTwoProcessors(
+      { device, config: incrementalConfig },
+      { device, config: fullConfig },
+      async (incremental, full) => {
+        const length = incrementalConfig.sampleRate * 6;
+        const lead = createTone(
+          length,
+          toneFrequency,
+          incrementalConfig.sampleRate,
+          0.7,
+        );
+        const recording = createSilence(length);
+        const start = 0.5;
+        const slide = progressForColumns(incrementalConfig, length, 5);
+
+        await incremental.render({ lead, recording }, start);
+
+        const chunkFrameCount = 256;
+        const chunkCount = 3;
+        const frameIndex = Math.round((start + slide) * length);
+        const firstChunkFrameIndex = frameIndex - chunkFrameCount * chunkCount;
+        const invalidatedSamples = writeRecordingChunks(
+          recording,
+          firstChunkFrameIndex,
+          chunkCount,
+          chunkFrameCount,
+          incrementalConfig.sampleRate,
+        );
+
+        incremental.invalidateSamples(invalidatedSamples);
+        await incremental.render({ lead, recording }, start + slide);
+        const incrementalPixels = await readCanvas(incrementalConfig.canvas);
+
+        const fullPixels = await renderFromScratch(
+          full,
+          fullConfig,
+          { lead, recording },
+          start + slide,
+        );
+
+        expectMatchesReference(incrementalPixels, fullPixels);
+      },
+    );
+  });
+
+  it('matches a full render with the fundamental line enabled', async () => {
+    const fundamentalLanes = {
+      lead: {
+        ...defaultSpectrogramConfig.lanes.lead,
+        showSpectrogram: true,
+        showFundamental: true,
+      },
+      recording: {
+        ...defaultSpectrogramConfig.lanes.recording,
+        showSpectrogram: false,
+        showFundamental: false,
+      },
+    };
+    const incrementalConfig = singleBandConfig({ lanes: fundamentalLanes });
+    const fullConfig = singleBandConfig({ lanes: fundamentalLanes });
+    await withTwoProcessors(
+      { device, config: incrementalConfig },
+      { device, config: fullConfig },
+      async (incremental, full) => {
+        const length = incrementalConfig.sampleRate * 5;
+        const lead = createTone(
+          length,
+          toneFrequency,
+          incrementalConfig.sampleRate,
+        );
+
+        await incremental.render({ lead }, 0.5);
+
+        const chunkLength = windowSize * 6;
+        const chunkStart = Math.floor(length * 0.5 - chunkLength * 0.5);
+        writeToneRange(
+          lead,
+          chunkStart,
+          chunkLength,
+          toneFrequency * 1.5,
+          incrementalConfig.sampleRate,
+        );
+        const invalidation = {
+          trackKey: 'lead' as const,
+          frameIndex: chunkStart,
+          frameCount: chunkLength,
+        };
+        incremental.invalidateSamples([invalidation]);
+        await incremental.render({ lead }, 0.5);
+        const incrementalPixels = await readCanvas(incrementalConfig.canvas);
+
+        const fullPixels = await renderFromScratch(
+          full,
+          fullConfig,
+          { lead },
+          0.5,
+        );
+
+        expectMatchesReference(incrementalPixels, fullPixels);
+      },
+    );
+  });
+
+  it('matches a full render after a lane-only gain change', async () => {
+    const gainedLanes = {
+      lead: {
+        ...defaultSpectrogramConfig.lanes.lead,
+        showSpectrogram: true,
+        showFundamental: false,
+        gainDb: defaultSpectrogramConfig.lanes.lead.gainDb + 6,
+      },
+      recording: {
+        ...defaultSpectrogramConfig.lanes.recording,
+        showSpectrogram: false,
+        showFundamental: false,
+      },
+    };
+    const incrementalConfig = singleBandConfig();
+    const fullConfig = singleBandConfig({ lanes: gainedLanes });
+    await withTwoProcessors(
+      { device, config: incrementalConfig },
+      { device, config: fullConfig },
+      async (incremental, full) => {
+        const lead = createTone(
+          incrementalConfig.sampleRate * 5,
+          toneFrequency,
+          incrementalConfig.sampleRate,
+        );
+        await incremental.render({ lead }, 0.5);
+        incremental.updateConfig({ lanes: gainedLanes });
+        await incremental.render({ lead }, 0.5);
+        const incrementalPixels = await readCanvas(incrementalConfig.canvas);
+
+        const fullPixels = await renderFromScratch(
+          full,
+          fullConfig,
+          { lead },
+          0.5,
+        );
+
+        expect(maxRed(fullPixels)).toBeGreaterThan(40);
+        expectMatchesReference(incrementalPixels, fullPixels);
+      },
+    );
+  });
+
+  it('renders identically with and without profiling', async () => {
+    const profilingContext = await createGpuContext(true).catch(
+      () => undefined,
+    );
+    if (!profilingContext) {
+      return;
+    }
+    const profilingDevice = profilingContext.device;
+
+    const drivePlayback = async (
+      processor: SpectrogramProcessor,
+      config: SpectrogramConfig,
+    ): Promise<Uint8ClampedArray> => {
+      const length = config.sampleRate * 5;
+      const slide = progressForColumns(config, length, 4);
+      const lead = createSilence(length);
+      await processor.render({ lead }, 0.5);
+      const invalidation = writeCentreTone(lead, config.sampleRate);
+      processor.invalidateSamples([invalidation]);
+      await processor.render({ lead }, 0.5 + slide);
+      return readCanvas(config.canvas);
+    };
+
+    try {
+      const plainConfig = singleBandConfig();
+      const meteredConfig = singleBandConfig();
+      const plainPixels = await withProcessor(
+        { device: profilingDevice, config: plainConfig },
+        async (plain) => drivePlayback(plain, plainConfig),
+      );
+      const meteredPixels = await withProcessor(
+        {
+          device: profilingDevice,
+          config: meteredConfig,
+          onMetrics: () => undefined,
+        },
+        async (metered) => drivePlayback(metered, meteredConfig),
+      );
+
+      expect(maxRed(plainPixels)).toBeGreaterThan(40);
+      expect(maxAbsDifference(plainPixels, meteredPixels)).toBeLessThan(8);
+    } finally {
+      profilingDevice.destroy();
+    }
+  });
+});

--- a/packages/spectrogram/src/common/__test__/columnRanges.test.ts
+++ b/packages/spectrogram/src/common/__test__/columnRanges.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type ColumnGrid,
+  expandColumnRanges,
+  markInvalidatedColumns,
+  markShiftColumns,
+  toColumnRanges,
+} from '../columnRanges.js';
+import {
+  type SpectrogramSampleRange,
+  windowStartForColumn,
+} from '../extConfig.js';
+
+const grid = (windowCount: number, columnStep: number): ColumnGrid => ({
+  windowCount,
+  columnStep,
+});
+
+const falseColumns = (length: number): boolean[] =>
+  new Array<boolean>(length).fill(false);
+
+const trueIndices = (columns: readonly boolean[]): number[] =>
+  columns.flatMap((value, index) => (value ? [index] : []));
+
+describe('markShiftColumns', () => {
+  it('marks nothing when the playhead does not move', () => {
+    const columns = falseColumns(8);
+    markShiftColumns(columns, 100, 100);
+    expect(trueIndices(columns)).toEqual([]);
+  });
+
+  it('marks the leading edge when advancing', () => {
+    const columns = falseColumns(8);
+    markShiftColumns(columns, 103, 100);
+    expect(trueIndices(columns)).toEqual([5, 6, 7]);
+  });
+
+  it('marks the trailing edge when rewinding', () => {
+    const columns = falseColumns(8);
+    markShiftColumns(columns, 98, 100);
+    expect(trueIndices(columns)).toEqual([0, 1]);
+  });
+
+  it('marks every column once the move clears the screen', () => {
+    const columns = falseColumns(4);
+    markShiftColumns(columns, 100, 0);
+    expect(trueIndices(columns)).toEqual([0, 1, 2, 3]);
+  });
+});
+
+describe('toColumnRanges', () => {
+  it('returns nothing for a clean screen', () => {
+    expect(toColumnRanges(grid(8, 10), 0, falseColumns(8))).toEqual([]);
+  });
+
+  it('coalesces a contiguous run and resolves its ring slot', () => {
+    const columns = falseColumns(8);
+    columns[2] = true;
+    columns[3] = true;
+    columns[4] = true;
+    expect(toColumnRanges(grid(8, 10), 5, columns)).toEqual([
+      { screenBase: 2, slotOffset: (5 + 2) % 8, columnCount: 3 },
+    ]);
+  });
+
+  it('keeps disjoint runs separate', () => {
+    const columns = falseColumns(10);
+    columns[1] = true;
+    columns[6] = true;
+    columns[7] = true;
+    expect(toColumnRanges(grid(10, 10), 0, columns)).toEqual([
+      { screenBase: 1, slotOffset: 1, columnCount: 1 },
+      { screenBase: 6, slotOffset: 6, columnCount: 2 },
+    ]);
+  });
+});
+
+describe('expandColumnRanges', () => {
+  it('grows each range by the radius and clamps to the screen', () => {
+    const ranges = [{ screenBase: 5, slotOffset: 5, columnCount: 2 }];
+    expect(expandColumnRanges(grid(20, 10), 0, ranges, 3)).toEqual([
+      { screenBase: 2, slotOffset: 2, columnCount: 8 },
+    ]);
+  });
+
+  it('merges ranges that overlap once expanded', () => {
+    const ranges = [
+      { screenBase: 2, slotOffset: 2, columnCount: 1 },
+      { screenBase: 6, slotOffset: 6, columnCount: 1 },
+    ];
+    expect(expandColumnRanges(grid(20, 10), 0, ranges, 2)).toEqual([
+      { screenBase: 0, slotOffset: 0, columnCount: 9 },
+    ]);
+  });
+});
+
+describe('markInvalidatedColumns', () => {
+  const reference = (
+    columnGrid: ColumnGrid,
+    baseColumn: number,
+    analysisWindowSize: number,
+    invalidations: readonly SpectrogramSampleRange[],
+  ): boolean[] => {
+    const columns = falseColumns(columnGrid.windowCount);
+    for (let screen = 0; screen < columnGrid.windowCount; screen += 1) {
+      const windowStart = windowStartForColumn(
+        columnGrid,
+        analysisWindowSize,
+        baseColumn + screen,
+      );
+      const windowEnd = windowStart + analysisWindowSize;
+      for (const invalidation of invalidations) {
+        if (invalidation.frameCount <= 0) {
+          continue;
+        }
+        const start = invalidation.frameIndex;
+        const end = invalidation.frameIndex + invalidation.frameCount;
+        if (windowStart < end && windowEnd > start) {
+          columns[screen] = true;
+          break;
+        }
+      }
+    }
+    return columns;
+  };
+
+  it('does nothing without a window or a range', () => {
+    const columns = falseColumns(8);
+    markInvalidatedColumns(columns, grid(8, 10), 0, 0, [
+      { frameIndex: 0, frameCount: 100 },
+    ]);
+    expect(trueIndices(columns)).toEqual([]);
+    markInvalidatedColumns(columns, grid(8, 10), 0, 64, []);
+    expect(trueIndices(columns)).toEqual([]);
+  });
+
+  it('matches the brute-force scan across many shapes', () => {
+    const windowCount = 64;
+    const cases: {
+      columnStep: number;
+      baseColumn: number;
+      windowSize: number;
+      invalidations: SpectrogramSampleRange[];
+    }[] = [];
+    for (let seed = 0; seed < 200; seed += 1) {
+      const columnStep = 4 + (seed % 17);
+      const baseColumn = (seed * 31) % 500;
+      const windowSize = 16 << (seed % 4);
+      const frameIndex = baseColumn * columnStep + ((seed * 13) % 4000) - 1000;
+      const frameCount = 1 + ((seed * 7) % 900);
+      cases.push({
+        columnStep,
+        baseColumn,
+        windowSize,
+        invalidations: [{ frameIndex, frameCount }],
+      });
+    }
+    for (const item of cases) {
+      const columnGrid = grid(windowCount, item.columnStep);
+      const expected = reference(
+        columnGrid,
+        item.baseColumn,
+        item.windowSize,
+        item.invalidations,
+      );
+      const actual = falseColumns(windowCount);
+      markInvalidatedColumns(
+        actual,
+        columnGrid,
+        item.baseColumn,
+        item.windowSize,
+        item.invalidations,
+      );
+      expect(trueIndices(actual)).toEqual(trueIndices(expected));
+    }
+  });
+
+  it('handles several disjoint invalidations at once', () => {
+    const columnGrid = grid(64, 8);
+    const invalidations: SpectrogramSampleRange[] = [
+      { frameIndex: 80, frameCount: 16 },
+      { frameIndex: 400, frameCount: 16 },
+    ];
+    const actual = falseColumns(64);
+    markInvalidatedColumns(actual, columnGrid, 0, 32, invalidations);
+    const expected = reference(columnGrid, 0, 32, invalidations);
+    expect(trueIndices(actual)).toEqual(trueIndices(expected));
+    const indices = trueIndices(actual);
+    expect(indices.length).toBeGreaterThan(0);
+    expect(toColumnRanges(columnGrid, 0, actual)).toHaveLength(2);
+  });
+});

--- a/packages/spectrogram/src/common/__test__/sampleInvalidations.test.ts
+++ b/packages/spectrogram/src/common/__test__/sampleInvalidations.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import {
+  mergeSampleInvalidation,
+  type SpectrogramSampleInvalidation,
+} from '../sampleInvalidations.js';
+
+const lead = (
+  frameIndex: number,
+  frameCount: number,
+): SpectrogramSampleInvalidation => ({
+  trackKey: 'lead',
+  frameIndex,
+  frameCount,
+});
+
+const recording = (
+  frameIndex: number,
+  frameCount: number,
+): SpectrogramSampleInvalidation => ({
+  trackKey: 'recording',
+  frameIndex,
+  frameCount,
+});
+
+describe('mergeSampleInvalidation', () => {
+  it('appends a disjoint range', () => {
+    const pending = [lead(0, 10)];
+    expect(mergeSampleInvalidation(pending, lead(20, 5))).toEqual([
+      lead(0, 10),
+      lead(20, 5),
+    ]);
+  });
+
+  it('drops empty and negative ranges', () => {
+    const pending = [lead(0, 10)];
+    expect(mergeSampleInvalidation(pending, lead(20, 0))).toEqual(pending);
+    expect(mergeSampleInvalidation(pending, lead(20, -5))).toEqual(pending);
+  });
+
+  it('merges an overlapping range of the same track', () => {
+    const pending = [lead(0, 10)];
+    expect(mergeSampleInvalidation(pending, lead(5, 10))).toEqual([
+      lead(0, 15),
+    ]);
+  });
+
+  it('merges a touching range of the same track', () => {
+    const pending = [lead(0, 10)];
+    expect(mergeSampleInvalidation(pending, lead(10, 5))).toEqual([
+      lead(0, 15),
+    ]);
+  });
+
+  it('keeps ranges of different tracks separate', () => {
+    const pending = [lead(0, 10)];
+    expect(mergeSampleInvalidation(pending, recording(5, 10))).toEqual([
+      lead(0, 10),
+      recording(5, 10),
+    ]);
+  });
+
+  it('bridges several pending ranges into one', () => {
+    const pending = [lead(0, 10), recording(0, 5), lead(20, 10)];
+    expect(mergeSampleInvalidation(pending, lead(8, 14))).toEqual([
+      recording(0, 5),
+      lead(0, 30),
+    ]);
+  });
+
+  it('leaves the input array untouched', () => {
+    const pending = [lead(0, 10)];
+    mergeSampleInvalidation(pending, lead(5, 10));
+    expect(pending).toEqual([lead(0, 10)]);
+  });
+});

--- a/packages/spectrogram/src/common/columnRanges.ts
+++ b/packages/spectrogram/src/common/columnRanges.ts
@@ -1,0 +1,162 @@
+import {
+  floorMod,
+  type SpectrogramColumnRange,
+  type SpectrogramSampleRange,
+  windowStartForColumn,
+} from './extConfig.js';
+
+export type ColumnGrid = {
+  windowCount: number;
+  columnStep: number;
+};
+
+const markColumns = (columns: boolean[], from: number, count: number): void => {
+  const start = Math.max(0, from);
+  const end = Math.min(columns.length, from + count);
+  for (let index = start; index < end; index += 1) {
+    columns[index] = true;
+  }
+};
+
+export const markShiftColumns = (
+  columns: boolean[],
+  baseColumn: number,
+  previousBaseColumn: number,
+): void => {
+  const delta = baseColumn - previousBaseColumn;
+  if (delta === 0) {
+    return;
+  }
+  if (Math.abs(delta) >= columns.length) {
+    markColumns(columns, 0, columns.length);
+    return;
+  }
+  if (delta > 0) {
+    markColumns(columns, columns.length - delta, delta);
+    return;
+  }
+  markColumns(columns, 0, -delta);
+};
+
+export const markInvalidatedColumns = (
+  columns: boolean[],
+  grid: ColumnGrid,
+  baseColumn: number,
+  analysisWindowSize: number,
+  invalidations: readonly SpectrogramSampleRange[],
+): void => {
+  if (analysisWindowSize <= 0) {
+    return;
+  }
+  const { columnStep } = grid;
+  for (const invalidation of invalidations) {
+    if (invalidation.frameCount <= 0) {
+      continue;
+    }
+    const invalidationStart = invalidation.frameIndex;
+    const invalidationEnd = invalidation.frameIndex + invalidation.frameCount;
+    const loColumn =
+      Math.floor((invalidationStart - analysisWindowSize / 2) / columnStep) - 1;
+    const hiColumn =
+      Math.ceil((invalidationEnd + analysisWindowSize / 2) / columnStep) + 1;
+    const from = Math.max(0, loColumn - baseColumn);
+    const to = Math.min(columns.length, hiColumn - baseColumn + 1);
+    for (let screenColumn = from; screenColumn < to; screenColumn += 1) {
+      const windowStart = windowStartForColumn(
+        grid,
+        analysisWindowSize,
+        baseColumn + screenColumn,
+      );
+      const windowEnd = windowStart + analysisWindowSize;
+      if (windowStart < invalidationEnd && windowEnd > invalidationStart) {
+        columns[screenColumn] = true;
+      }
+    }
+  }
+};
+
+export const toColumnRanges = (
+  grid: ColumnGrid,
+  baseColumn: number,
+  columns: readonly boolean[],
+): SpectrogramColumnRange[] => {
+  const ranges: SpectrogramColumnRange[] = [];
+  let screenColumn = 0;
+  while (screenColumn < columns.length) {
+    while (screenColumn < columns.length && !columns[screenColumn]) {
+      screenColumn += 1;
+    }
+    const screenBase = screenColumn;
+    while (screenColumn < columns.length && columns[screenColumn]) {
+      screenColumn += 1;
+    }
+    const columnCount = screenColumn - screenBase;
+    if (columnCount > 0) {
+      ranges.push({
+        screenBase,
+        slotOffset: floorMod(baseColumn + screenBase, grid.windowCount),
+        columnCount,
+      });
+    }
+  }
+  return ranges;
+};
+
+const expandColumnRange = (
+  grid: ColumnGrid,
+  baseColumn: number,
+  range: SpectrogramColumnRange,
+  radius: number,
+): SpectrogramColumnRange => {
+  const screenBase = Math.max(0, range.screenBase - radius);
+  const screenEnd = Math.min(
+    grid.windowCount,
+    range.screenBase + range.columnCount + radius,
+  );
+  return {
+    screenBase,
+    slotOffset: floorMod(baseColumn + screenBase, grid.windowCount),
+    columnCount: screenEnd - screenBase,
+  };
+};
+
+const mergeColumnRanges = (
+  grid: ColumnGrid,
+  baseColumn: number,
+  ranges: readonly SpectrogramColumnRange[],
+): SpectrogramColumnRange[] => {
+  const merged: SpectrogramColumnRange[] = [];
+  for (const range of ranges) {
+    if (merged.length > 0) {
+      const previous = merged[merged.length - 1];
+      if (range.screenBase <= previous.screenBase + previous.columnCount) {
+        const screenEnd = Math.max(
+          previous.screenBase + previous.columnCount,
+          range.screenBase + range.columnCount,
+        );
+        previous.columnCount = screenEnd - previous.screenBase;
+        continue;
+      }
+    }
+    merged.push({ ...range });
+  }
+  for (const range of merged) {
+    range.slotOffset = floorMod(
+      baseColumn + range.screenBase,
+      grid.windowCount,
+    );
+  }
+  return merged;
+};
+
+export const expandColumnRanges = (
+  grid: ColumnGrid,
+  baseColumn: number,
+  ranges: readonly SpectrogramColumnRange[],
+  radius: number,
+): SpectrogramColumnRange[] =>
+  mergeColumnRanges(
+    grid,
+    baseColumn,
+    ranges.map((range) => expandColumnRange(grid, baseColumn, range, radius)),
+  );

--- a/packages/spectrogram/src/common/dynamicUniform.ts
+++ b/packages/spectrogram/src/common/dynamicUniform.ts
@@ -1,0 +1,47 @@
+export type DynamicUniformParams = {
+  buffer: GPUBuffer;
+  byteLength: number;
+  write: (fill: (view: DataView) => void) => number;
+  destroy: () => void;
+};
+
+const alignTo = (value: number, alignment: number): number =>
+  Math.ceil(value / alignment) * alignment;
+
+export const createDynamicUniformParams = (
+  device: GPUDevice,
+  options: {
+    label: string;
+    byteLength: number;
+    capacity: number;
+  },
+): DynamicUniformParams => {
+  const capacity = Math.max(1, Math.floor(options.capacity));
+  const stride = alignTo(
+    options.byteLength,
+    device.limits.minUniformBufferOffsetAlignment,
+  );
+  const buffer = device.createBuffer({
+    label: options.label,
+    size: stride * capacity,
+    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+  });
+  const scratch = new ArrayBuffer(options.byteLength);
+  const view = new DataView(scratch);
+  let cursor = 0;
+
+  return {
+    buffer,
+    byteLength: options.byteLength,
+    write: (fill) => {
+      const byteOffset = cursor * stride;
+      cursor = (cursor + 1) % capacity;
+      fill(view);
+      device.queue.writeBuffer(buffer, byteOffset, scratch);
+      return byteOffset;
+    },
+    destroy: () => {
+      buffer.destroy();
+    },
+  };
+};

--- a/packages/spectrogram/src/common/extConfig.ts
+++ b/packages/spectrogram/src/common/extConfig.ts
@@ -2,9 +2,56 @@ import { type SpectrogramConfig } from '../config.cross.js';
 
 export type ExtSpectrogramConfig = SpectrogramConfig & {
   windowCount: number;
+
+  columnStep: number;
+};
+
+export type SpectrogramColumnRange = {
+  screenBase: number;
+  slotOffset: number;
+  columnCount: number;
 };
 
 export type SpectrogramSampleRange = {
   frameIndex: number;
   frameCount: number;
 };
+
+export const computeColumnStep = (
+  config: Pick<SpectrogramConfig, 'visibleTime' | 'sampleRate'> & {
+    windowCount: number;
+  },
+): number => {
+  const divisor = Math.max(1, config.windowCount - 1);
+  return (config.visibleTime * config.sampleRate) / divisor;
+};
+
+export const floorMod = (value: number, modulus: number): number =>
+  ((value % modulus) + modulus) % modulus;
+
+export const computeBaseColumn = (
+  config: ExtSpectrogramConfig,
+  trackProgress: number,
+  sampleLength: number,
+): number => {
+  const beforePlayhead =
+    config.visibleTime * config.playheadRatio * config.sampleRate;
+  const anchor =
+    trackProgress * sampleLength - beforePlayhead - config.windowSize / 2;
+  return Math.round(anchor / config.columnStep);
+};
+
+export const windowStartForColumn = (
+  config: Pick<ExtSpectrogramConfig, 'columnStep'>,
+  bandWindowSize: number,
+  column: number,
+): number => Math.round(column * config.columnStep - bandWindowSize / 2);
+
+export const fullColumnRange = (
+  config: ExtSpectrogramConfig,
+  baseColumn: number,
+): SpectrogramColumnRange => ({
+  screenBase: 0,
+  slotOffset: floorMod(baseColumn, config.windowCount),
+  columnCount: config.windowCount,
+});

--- a/packages/spectrogram/src/common/sampleInvalidations.ts
+++ b/packages/spectrogram/src/common/sampleInvalidations.ts
@@ -1,0 +1,37 @@
+import { type TrackKey } from '../config.cross.js';
+import { type SpectrogramSampleRange } from './extConfig.js';
+
+export type SpectrogramSampleInvalidation = SpectrogramSampleRange & {
+  trackKey: TrackKey;
+};
+
+export const mergeSampleInvalidation = (
+  pending: readonly SpectrogramSampleInvalidation[],
+  invalidation: SpectrogramSampleInvalidation,
+): SpectrogramSampleInvalidation[] => {
+  if (invalidation.frameCount <= 0) {
+    return [...pending];
+  }
+  let nextStart = invalidation.frameIndex;
+  let nextEnd = invalidation.frameIndex + invalidation.frameCount;
+  const merged: SpectrogramSampleInvalidation[] = [];
+  for (const current of pending) {
+    const currentEnd = current.frameIndex + current.frameCount;
+    const disjoint =
+      current.trackKey !== invalidation.trackKey ||
+      nextStart > currentEnd ||
+      nextEnd < current.frameIndex;
+    if (disjoint) {
+      merged.push(current);
+      continue;
+    }
+    nextStart = Math.min(current.frameIndex, nextStart);
+    nextEnd = Math.max(currentEnd, nextEnd);
+  }
+  merged.push({
+    trackKey: invalidation.trackKey,
+    frameIndex: nextStart,
+    frameCount: nextEnd - nextStart,
+  });
+  return merged;
+};

--- a/packages/spectrogram/src/config.cross.ts
+++ b/packages/spectrogram/src/config.cross.ts
@@ -6,6 +6,17 @@ import { extractConfig } from './common/config.es.js';
 export const allTrackKeys = ['lead', 'recording'] as const;
 export type TrackKey = (typeof allTrackKeys)[number];
 
+export const mapTrackKeys = <Value>(
+  fn: (key: TrackKey, index: number) => Value,
+): Record<TrackKey, Value> => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  const result = {} as Record<TrackKey, Value>;
+  allTrackKeys.forEach((key, index) => {
+    result[key] = fn(key, index);
+  });
+  return result;
+};
+
 export type SpectrogramZeroPaddingFactor = 1 | 2 | 4;
 
 export type SpectrogramLaneConfig = {

--- a/packages/spectrogram/src/configurator.ts
+++ b/packages/spectrogram/src/configurator.ts
@@ -1,10 +1,14 @@
 import { applyPatchConfig } from '@musetric/utils';
 import { spectrogramConfigFieldEqual } from './common/configFieldEqual.js';
-import { type ExtSpectrogramConfig } from './common/extConfig.js';
+import {
+  computeColumnStep,
+  type ExtSpectrogramConfig,
+} from './common/extConfig.js';
 import { type SpectrogramMarkers } from './common/processorTimer.js';
 import {
   allTrackKeys,
   buildSpectrogramConfig,
+  mapTrackKeys,
   type SpectrogramConfig,
   type TrackKey,
 } from './config.cross.js';
@@ -31,7 +35,7 @@ export type SpectrogramTrack = {
 };
 
 export type SpectrogramRuntime = {
-  config: SpectrogramConfig;
+  config: ExtSpectrogramConfig;
   state: SpectrogramState;
   tracks: Record<TrackKey, SpectrogramTrack>;
   draw: SpectrogramDraw;
@@ -61,19 +65,10 @@ export const createSpectrogramConfigurator = (
     markers.getGpuMarker('draw'),
   );
 
-  const trackCells = allTrackKeys.reduce(
-    (acc, key) => {
-      acc[key] = {
-        lane: createSpectrogramLaneCell(device, {
-          label: key,
-        }),
-        remap: createSpectrogramRemapCell(device),
-      };
-      return acc;
-    },
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    {} as Record<TrackKey, TrackCells>,
-  );
+  const trackCells = mapTrackKeys<TrackCells>((key) => ({
+    lane: createSpectrogramLaneCell(device, { label: key }),
+    remap: createSpectrogramRemapCell(device),
+  }));
 
   const buildConfig = (): ExtSpectrogramConfig | undefined => {
     const baseConfig = buildSpectrogramConfig(config, draftConfig);
@@ -81,9 +76,11 @@ export const createSpectrogramConfigurator = (
       return undefined;
     }
     draftConfig = undefined;
+    const windowCount = baseConfig.viewSize.width;
     return {
       ...baseConfig,
-      windowCount: baseConfig.viewSize.width,
+      windowCount,
+      columnStep: computeColumnStep({ ...baseConfig, windowCount }),
     };
   };
 
@@ -102,31 +99,21 @@ export const createSpectrogramConfigurator = (
       const state = stateCell.get(nextConfig);
       const { texture } = state;
 
-      const tracks = allTrackKeys.reduce(
-        (acc, key, index) => {
-          const lane = trackCells[key].lane.get(nextConfig);
-          const remap = nextConfig.lanes[key].showSpectrogram
-            ? trackCells[key].remap.get({
-                spectra: lane.bandSpectra,
-                texture: texture.layerViews[index],
-                config: nextConfig,
-                gainDb: nextConfig.lanes[key].gainDb,
-              })
-            : undefined;
-          acc[key] = { lane, remap };
-          return acc;
-        },
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        {} as Record<TrackKey, SpectrogramTrack>,
-      );
+      const tracks = mapTrackKeys<SpectrogramTrack>((key, index) => {
+        const lane = trackCells[key].lane.get(nextConfig);
+        const remap = nextConfig.lanes[key].showSpectrogram
+          ? trackCells[key].remap.get({
+              spectra: lane.bandSpectra,
+              texture: texture.layerViews[index],
+              config: nextConfig,
+              gainDb: nextConfig.lanes[key].gainDb,
+            })
+          : undefined;
+        return { lane, remap };
+      });
 
-      const fundamentalFrequencies = allTrackKeys.reduce(
-        (acc, key) => {
-          acc[key] = tracks[key].lane.fundamentalFrequencyBuffer;
-          return acc;
-        },
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        {} as Record<TrackKey, GPUBuffer>,
+      const fundamentalFrequencies = mapTrackKeys<GPUBuffer>(
+        (key) => tracks[key].lane.fundamentalFrequencyBuffer,
       );
 
       const draw = drawCell.get({

--- a/packages/spectrogram/src/decibelify/energyShader.ts
+++ b/packages/spectrogram/src/decibelify/energyShader.ts
@@ -7,7 +7,7 @@ struct DecibelifyParams {
   gainOverReferenceMagnitude: f32,
   gateFloorDb: f32,
   gateRangeDb: f32,
-  padding: f32,
+  slotOffset: u32,
 };
 
 @group(0) @binding(0) var<storage, read> magnitude: array<f32>;
@@ -21,9 +21,10 @@ var<workgroup> localSums: array<f32, 64>;
 fn main(@builtin(workgroup_id) workgroupId: vec3<u32>, @builtin(local_invocation_id) lid: vec3<u32>) {
   let halfSize = params.halfSize;
   let windowCount = params.windowCount;
-  let windowIndex = workgroupId.x;
+  let localWindowIndex = workgroupId.x;
+  let windowIndex = (params.slotOffset + localWindowIndex) % windowCount;
   let workerId = lid.x;
-  if (windowIndex >= windowCount) {
+  if (localWindowIndex >= windowCount) {
     return;
   }
 

--- a/packages/spectrogram/src/decibelify/index.ts
+++ b/packages/spectrogram/src/decibelify/index.ts
@@ -1,4 +1,5 @@
 import { type ResourceCell } from '@musetric/utils';
+import { type SpectrogramColumnRange } from '../common/extConfig.js';
 import { createPipelines } from './pipeline.js';
 import { createStateCell, type StateArg } from './state.js';
 
@@ -7,9 +8,18 @@ const workgroupSize = 64;
 export type SpectrogramDecibelify = {
   columnEnergy: GPUBuffer;
   run: (encoder: GPUCommandEncoder) => void;
-  dispatchEnergy: (pass: GPUComputePassEncoder) => void;
-  dispatchRun: (pass: GPUComputePassEncoder) => void;
-  dispatch: (pass: GPUComputePassEncoder) => void;
+  dispatchEnergy: (
+    pass: GPUComputePassEncoder,
+    range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+  ) => void;
+  dispatchRun: (
+    pass: GPUComputePassEncoder,
+    range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+  ) => void;
+  dispatch: (
+    pass: GPUComputePassEncoder,
+    range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+  ) => void;
 };
 
 export const createSpectrogramDecibelifyCell = (
@@ -23,26 +33,42 @@ export const createSpectrogramDecibelifyCell = (
     get: (arg) => {
       const state = stateCell.get(arg);
 
-      const dispatchEnergy = (pass: GPUComputePassEncoder) => {
-        const { windowCount } = state.params.value;
+      const dispatchEnergy = (
+        pass: GPUComputePassEncoder,
+        range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+      ) => {
+        const { columnCount, byteOffset } = state.params.writeRange(range);
+        if (columnCount <= 0) {
+          return;
+        }
 
         pass.setPipeline(state.pipelines.energy);
-        pass.setBindGroup(0, state.bindGroup);
-        pass.dispatchWorkgroups(windowCount);
+        pass.setBindGroup(0, state.bindGroup, [byteOffset]);
+        pass.dispatchWorkgroups(columnCount);
       };
 
-      const dispatchRun = (pass: GPUComputePassEncoder) => {
-        const { halfSize, windowCount } = state.params.value;
+      const dispatchRun = (
+        pass: GPUComputePassEncoder,
+        range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+      ) => {
+        const { halfSize } = state.params.value;
         const xCount = Math.ceil(halfSize / workgroupSize);
+        const { columnCount, byteOffset } = state.params.writeRange(range);
+        if (columnCount <= 0) {
+          return;
+        }
 
         pass.setPipeline(state.pipelines.run);
-        pass.setBindGroup(0, state.bindGroup);
-        pass.dispatchWorkgroups(xCount, windowCount);
+        pass.setBindGroup(0, state.bindGroup, [byteOffset]);
+        pass.dispatchWorkgroups(xCount, columnCount);
       };
 
-      const dispatch = (pass: GPUComputePassEncoder) => {
-        dispatchEnergy(pass);
-        dispatchRun(pass);
+      const dispatch = (
+        pass: GPUComputePassEncoder,
+        range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+      ) => {
+        dispatchEnergy(pass, range);
+        dispatchRun(pass, range);
       };
 
       return {

--- a/packages/spectrogram/src/decibelify/params.ts
+++ b/packages/spectrogram/src/decibelify/params.ts
@@ -1,5 +1,9 @@
 import { createResourceCell } from '@musetric/utils';
-import { type ExtSpectrogramConfig } from '../common/extConfig.js';
+import { createDynamicUniformParams } from '../common/dynamicUniform.js';
+import {
+  type ExtSpectrogramConfig,
+  type SpectrogramColumnRange,
+} from '../common/extConfig.js';
 
 export type DecibelifyParams = {
   halfSize: number;
@@ -10,6 +14,9 @@ export type DecibelifyParams = {
   gateFloorDb: number;
   gateRangeDb: number;
 };
+
+export const slotOffsetByteOffset = 28;
+const paramsByteLength = 32;
 
 export type DecibelifyParamsArg = {
   config: ExtSpectrogramConfig;
@@ -36,31 +43,50 @@ const toParams = (arg: DecibelifyParamsArg): DecibelifyParams => {
 export type StateParams = {
   value: DecibelifyParams;
   buffer: GPUBuffer;
+  byteLength: number;
+  writeRange: (
+    range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+  ) => {
+    columnCount: number;
+    byteOffset: number;
+  };
 };
 
 export const createParamsCell = (device: GPUDevice) =>
   createResourceCell({
     create: (arg: DecibelifyParamsArg): StateParams => {
       const value = toParams(arg);
-      const array = new DataView(new ArrayBuffer(32));
-      array.setUint32(0, value.halfSize, true);
-      array.setUint32(4, value.windowCount, true);
-      array.setFloat32(8, value.decibelFactor, true);
-      array.setFloat32(12, value.gain, true);
-      array.setFloat32(16, value.gainOverReferenceMagnitude, true);
-      array.setFloat32(20, value.gateFloorDb, true);
-      array.setFloat32(24, value.gateRangeDb, true);
-
-      const buffer = device.createBuffer({
+      const params = createDynamicUniformParams(device, {
         label: 'decibelify-params-buffer',
-        size: array.buffer.byteLength,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        byteLength: paramsByteLength,
+        capacity: value.windowCount * 2,
       });
-      device.queue.writeBuffer(buffer, 0, array.buffer);
 
       return {
         value,
-        buffer,
+        buffer: params.buffer,
+        byteLength: params.byteLength,
+        writeRange: (range) => {
+          const columnCount = range ? range.columnCount : value.windowCount;
+          const byteOffset = params.write((view) => {
+            view.setUint32(0, value.halfSize, true);
+            view.setUint32(4, value.windowCount, true);
+            view.setFloat32(8, value.decibelFactor, true);
+            view.setFloat32(12, value.gain, true);
+            view.setFloat32(16, value.gainOverReferenceMagnitude, true);
+            view.setFloat32(20, value.gateFloorDb, true);
+            view.setFloat32(24, value.gateRangeDb, true);
+            view.setUint32(
+              slotOffsetByteOffset,
+              range ? range.slotOffset : 0,
+              true,
+            );
+          });
+          return {
+            columnCount,
+            byteOffset,
+          };
+        },
       };
     },
     dispose: (params) => {

--- a/packages/spectrogram/src/decibelify/pipeline.ts
+++ b/packages/spectrogram/src/decibelify/pipeline.ts
@@ -19,7 +19,7 @@ export const createPipelines = (device: GPUDevice): Pipelines => {
       {
         binding: 1,
         visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform' },
+        buffer: { type: 'uniform', hasDynamicOffset: true },
       },
       {
         binding: 2,

--- a/packages/spectrogram/src/decibelify/runShader.ts
+++ b/packages/spectrogram/src/decibelify/runShader.ts
@@ -7,7 +7,7 @@ struct DecibelifyParams {
   gainOverReferenceMagnitude: f32,
   gateFloorDb: f32,
   gateRangeDb: f32,
-  padding: f32,
+  slotOffset: u32,
 };
 
 @group(0) @binding(0) var<storage, read> magnitude: array<f32>;
@@ -23,8 +23,9 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let gainOverReferenceMagnitude = params.gainOverReferenceMagnitude;
 
   let sampleIndex = gid.x;
-  let windowIndex = gid.y;
-  if (sampleIndex >= halfSize || windowIndex >= windowCount) {
+  let localWindowIndex = gid.y;
+  let windowIndex = (params.slotOffset + localWindowIndex) % windowCount;
+  if (sampleIndex >= halfSize || localWindowIndex >= windowCount) {
     return;
   }
   let windowOffset = halfSize * windowIndex + sampleIndex;

--- a/packages/spectrogram/src/decibelify/state.ts
+++ b/packages/spectrogram/src/decibelify/state.ts
@@ -40,7 +40,7 @@ export const createStateCell = (
     create: (arg: {
       signal: GPUBuffer;
       magnitude: GPUBuffer;
-      params: GPUBuffer;
+      params: StateParams;
       columnEnergy: GPUBuffer;
     }): GPUBindGroup =>
       device.createBindGroup({
@@ -48,7 +48,13 @@ export const createStateCell = (
         layout: pipelines.layout,
         entries: [
           { binding: 0, resource: { buffer: arg.magnitude } },
-          { binding: 1, resource: { buffer: arg.params } },
+          {
+            binding: 1,
+            resource: {
+              buffer: arg.params.buffer,
+              size: arg.params.byteLength,
+            },
+          },
           { binding: 2, resource: { buffer: arg.columnEnergy } },
           { binding: 3, resource: { buffer: arg.signal } },
         ],
@@ -72,7 +78,7 @@ export const createStateCell = (
       const bindGroup = bindGroupCell.get({
         signal,
         magnitude,
-        params: params.buffer,
+        params,
         columnEnergy,
       });
 

--- a/packages/spectrogram/src/draw/colors.ts
+++ b/packages/spectrogram/src/draw/colors.ts
@@ -14,6 +14,8 @@ const toVec4 = (hex: string): [number, number, number, number] => {
 export type StateColors = {
   buffer: GPUBuffer;
 };
+
+export const drawRingSlotsByteOffset = 160;
 const areLaneConfigsEqual = (
   first: SpectrogramLaneConfig,
   second: SpectrogramLaneConfig,
@@ -63,7 +65,7 @@ const areConfigsEqual = (
 export const createColorsCell = (device: GPUDevice) =>
   createResourceCell({
     create: (config: SpectrogramConfig): StateColors => {
-      const arrayBuffer = new ArrayBuffer(160);
+      const arrayBuffer = new ArrayBuffer(176);
       const f32 = new Float32Array(arrayBuffer);
       const u32 = new Uint32Array(arrayBuffer);
       const { colors, lanes, comparison } = config;

--- a/packages/spectrogram/src/draw/fragmentShader.ts
+++ b/packages/spectrogram/src/draw/fragmentShader.ts
@@ -10,6 +10,7 @@ struct DrawParams {
   comparisonThresholds : vec4f,
   visibility : vec4u,
   relation : vec4u,
+  ringSlots : vec4u,
 };
 
 @group(0) @binding(0) var<uniform> drawParams : DrawParams;
@@ -149,25 +150,48 @@ fn lineMaskAtPixel(
   return mask;
 }
 
+fn slotForScreenX(baseSlot: u32, screenX: u32, width: u32) -> u32 {
+  return (baseSlot + screenX) % width;
+}
+
+fn sampleSpectrogram(slot: u32, y: u32, layer: u32, width: u32, height: u32) -> f32 {
+  let sampleUv = vec2f(
+    (f32(slot) + 0.5) / f32(width),
+    (f32(y) + 0.5) / f32(height),
+  );
+  return textureSampleLevel(
+    spectrogramTextures,
+    valueSampler,
+    sampleUv,
+    layer,
+    0.0,
+  ).r;
+}
+
 @fragment
 fn main(@location(0) uv: vec2f, @builtin(position) position: vec4f) -> @location(0) vec4f {
   let dimensions = textureDimensions(spectrogramTextures);
   let width = dimensions.x;
   let height = f32(dimensions.y);
+  let textureHeight = dimensions.y;
   let x = min(u32(position.x), width - 1u);
-  let sampleUv = vec2f(uv.x, 1.0 - uv.y);
+  let y = min(u32(position.y), textureHeight - 1u);
+  let layer0Slot = slotForScreenX(drawParams.ringSlots.x, x, width);
+  let layer1Slot = slotForScreenX(drawParams.ringSlots.y, x, width);
+  let referenceSlot = slotForScreenX(drawParams.ringSlots.z, x, width);
+  let targetSlot = slotForScreenX(drawParams.ringSlots.w, x, width);
 
   var intensity = 0.0;
   if (drawParams.visibility.x != 0u) {
     intensity = max(
       intensity,
-      textureSample(spectrogramTextures, valueSampler, sampleUv, 0).r,
+      sampleSpectrogram(layer0Slot, y, 0u, width, textureHeight),
     );
   }
   if (drawParams.visibility.y != 0u) {
     intensity = max(
       intensity,
-      textureSample(spectrogramTextures, valueSampler, sampleUv, 1).r,
+      sampleSpectrogram(layer1Slot, y, 1u, width, textureHeight),
     );
   }
   let baseColor = mix(
@@ -182,14 +206,18 @@ fn main(@location(0) uv: vec2f, @builtin(position) position: vec4f) -> @location
   var referenceMask = 0.0;
   let referenceVisible = drawParams.visibility.z != 0u;
   if (referenceVisible) {
-    let referenceCenter = referenceFundamentalFrequencies[x];
+    let referenceCenter = referenceFundamentalFrequencies[referenceSlot];
     var referencePrev = 0.0;
     if (x > 0u) {
-      referencePrev = referenceFundamentalFrequencies[x - 1u];
+      referencePrev = referenceFundamentalFrequencies[
+        slotForScreenX(drawParams.ringSlots.z, x - 1u, width)
+      ];
     }
     var referenceNext = 0.0;
     if (x + 1u < width) {
-      referenceNext = referenceFundamentalFrequencies[x + 1u];
+      referenceNext = referenceFundamentalFrequencies[
+        slotForScreenX(drawParams.ringSlots.z, x + 1u, width)
+      ];
     }
     referenceMask = lineMaskAtPixel(
       position.xy,
@@ -207,14 +235,18 @@ fn main(@location(0) uv: vec2f, @builtin(position) position: vec4f) -> @location
   var targetFreq = 0.0;
   let targetVisible = drawParams.visibility.w != 0u;
   if (targetVisible) {
-    targetFreq = targetFundamentalFrequencies[x];
+    targetFreq = targetFundamentalFrequencies[targetSlot];
     var targetPrev = 0.0;
     if (x > 0u) {
-      targetPrev = targetFundamentalFrequencies[x - 1u];
+      targetPrev = targetFundamentalFrequencies[
+        slotForScreenX(drawParams.ringSlots.w, x - 1u, width)
+      ];
     }
     var targetNext = 0.0;
     if (x + 1u < width) {
-      targetNext = targetFundamentalFrequencies[x + 1u];
+      targetNext = targetFundamentalFrequencies[
+        slotForScreenX(drawParams.ringSlots.w, x + 1u, width)
+      ];
     }
     targetMask = lineMaskAtPixel(
       position.xy,
@@ -234,7 +266,7 @@ fn main(@location(0) uv: vec2f, @builtin(position) position: vec4f) -> @location
   if (targetMask > 0.0) {
     var targetColor = drawParams.recordingMissColor.xyz;
     if (referenceVisible) {
-      let referenceFreq = referenceFundamentalFrequencies[x];
+      let referenceFreq = referenceFundamentalFrequencies[referenceSlot];
       if (referenceFreq > 0.0) {
         targetColor = targetLineColor(referenceFreq, targetFreq);
       }

--- a/packages/spectrogram/src/draw/index.ts
+++ b/packages/spectrogram/src/draw/index.ts
@@ -1,12 +1,19 @@
 import { type ResourceCell } from '@musetric/utils';
 import { setOffscreenCanvasSize } from '@musetric/utils/cross/offscreenCanvas';
-import { type SpectrogramConfig, type TrackKey } from '../config.cross.js';
+import {
+  allTrackKeys,
+  type SpectrogramConfig,
+  type TrackKey,
+} from '../config.cross.js';
 import { createBindGroupCell } from './bindGroup.js';
 import { createCanvasCell } from './canvas.js';
-import { createColorsCell } from './colors.js';
+import { createColorsCell, drawRingSlotsByteOffset } from './colors.js';
 
 export type SpectrogramDraw = {
-  run: (encoder: GPUCommandEncoder) => void;
+  run: (
+    encoder: GPUCommandEncoder,
+    baseSlots: Record<TrackKey, number>,
+  ) => void;
 };
 
 export type SpectrogramDrawArg = {
@@ -27,6 +34,7 @@ export const createSpectrogramDrawCell = (
     minFilter: 'nearest',
   });
   const bindGroupCell = createBindGroupCell(device, sampler);
+  const ringSlotsScratch = new Uint32Array(4);
 
   return {
     get: (arg) => {
@@ -44,7 +52,16 @@ export const createSpectrogramDrawCell = (
       });
 
       return {
-        run: (encoder) => {
+        run: (encoder, baseSlots) => {
+          ringSlotsScratch[0] = baseSlots[allTrackKeys[0]];
+          ringSlotsScratch[1] = baseSlots[allTrackKeys[1]];
+          ringSlotsScratch[2] = baseSlots[reference];
+          ringSlotsScratch[3] = baseSlots[target];
+          device.queue.writeBuffer(
+            colors.buffer,
+            drawRingSlotsByteOffset,
+            ringSlotsScratch,
+          );
           const targetView = canvas.context.getCurrentTexture().createView({
             label: 'draw-view',
           });

--- a/packages/spectrogram/src/fundamentalFrequency/filterShader.ts
+++ b/packages/spectrogram/src/fundamentalFrequency/filterShader.ts
@@ -10,20 +10,26 @@ struct FundamentalFrequencyParams {
   minimumFundamentalIntensity: f32,
   minimumScore: f32,
   harmonicCount: u32,
-  pad0: u32,
-  pad1: u32,
+  slotOffset: u32,
+  columnCount: u32,
+  screenBase: u32,
+  baseSlot: u32,
 };
 
 @group(0) @binding(0) var<storage, read> rawOutput: array<f32>;
 @group(0) @binding(1) var<storage, read_write> filteredOutput: array<f32>;
 @group(0) @binding(2) var<uniform> params: FundamentalFrequencyParams;
 
-fn frequencyAt(index: i32) -> f32 {
-  if (index < 0 || index >= i32(params.windowCount)) {
+fn slotAtScreenIndex(index: u32) -> u32 {
+  return (params.baseSlot + index) % params.windowCount;
+}
+
+fn frequencyAtScreen(index: i32) -> f32 {
+  if (index < 0i || index >= i32(params.windowCount)) {
     return 0.0;
   }
 
-  return rawOutput[u32(index)];
+  return rawOutput[slotAtScreenIndex(u32(index))];
 }
 
 fn centsDistance(frequency: f32, targetFrequency: f32) -> f32 {
@@ -41,7 +47,7 @@ fn countCompatibleNeighbors(windowIndex: i32, frequency: f32) -> u32 {
       continue;
     }
 
-    let neighborFrequency = frequencyAt(windowIndex + offset);
+    let neighborFrequency = frequencyAtScreen(windowIndex + offset);
     if (centsDistance(frequency, neighborFrequency) <= 160.0) {
       count += 1u;
     }
@@ -52,7 +58,7 @@ fn countCompatibleNeighbors(windowIndex: i32, frequency: f32) -> u32 {
 
 fn nearestPreviousFrequency(windowIndex: i32) -> f32 {
   for (var offset = 1i; offset <= 6i; offset += 1i) {
-    let frequency = frequencyAt(windowIndex - offset);
+    let frequency = frequencyAtScreen(windowIndex - offset);
     if (frequency > 0.0) {
       return frequency;
     }
@@ -63,7 +69,7 @@ fn nearestPreviousFrequency(windowIndex: i32) -> f32 {
 
 fn nearestNextFrequency(windowIndex: i32) -> f32 {
   for (var offset = 1i; offset <= 6i; offset += 1i) {
-    let frequency = frequencyAt(windowIndex + offset);
+    let frequency = frequencyAtScreen(windowIndex + offset);
     if (frequency > 0.0) {
       return frequency;
     }
@@ -91,10 +97,12 @@ fn isUnsupportedJump(windowIndex: i32, frequency: f32) -> bool {
 
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
-  let windowIndex = gid.x;
-  if (windowIndex >= params.windowCount) {
+  let localWindowIndex = gid.x;
+  if (localWindowIndex >= params.columnCount) {
     return;
   }
+  let screenIndex = params.screenBase + localWindowIndex;
+  let windowIndex = (params.slotOffset + localWindowIndex) % params.windowCount;
 
   let frequency = rawOutput[windowIndex];
   if (frequency <= 0.0) {
@@ -102,7 +110,7 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
     return;
   }
 
-  let index = i32(windowIndex);
+  let index = i32(screenIndex);
   if (countCompatibleNeighbors(index, frequency) <= 4u) {
     filteredOutput[windowIndex] = 0.0;
     return;

--- a/packages/spectrogram/src/fundamentalFrequency/index.ts
+++ b/packages/spectrogram/src/fundamentalFrequency/index.ts
@@ -1,4 +1,5 @@
 import { type ResourceCell } from '@musetric/utils';
+import { type SpectrogramColumnRange } from '../common/extConfig.js';
 import { createPipelines } from './pipeline.js';
 import { createStateCell, type StateArg } from './state.js';
 
@@ -7,7 +8,16 @@ const workgroupSize = 64;
 export type SpectrogramFundamentalFrequency = {
   buffer: GPUBuffer;
   run: (encoder: GPUCommandEncoder) => void;
-  dispatch: (pass: GPUComputePassEncoder) => void;
+
+  dispatchScore: (
+    pass: GPUComputePassEncoder,
+    range?: SpectrogramColumnRange,
+  ) => void;
+
+  dispatchFilter: (
+    pass: GPUComputePassEncoder,
+    range?: SpectrogramColumnRange,
+  ) => void;
 };
 
 export const createSpectrogramFundamentalFrequencyCell = (
@@ -21,25 +31,35 @@ export const createSpectrogramFundamentalFrequencyCell = (
     get: (arg) => {
       const state = stateCell.get(arg);
 
-      const dispatch = (pass: GPUComputePassEncoder) => {
-        const { windowCount, candidateCount } = state.params.value;
-        const scoreThreads = Math.max(1, windowCount * candidateCount);
-        const scoreGroups = Math.ceil(scoreThreads / workgroupSize);
+      const dispatchScore = (
+        pass: GPUComputePassEncoder,
+        range?: SpectrogramColumnRange,
+      ) => {
+        const { columnCount, byteOffset } = state.params.writeRange(range);
+        if (columnCount <= 0) {
+          return;
+        }
+
+        pass.setPipeline(state.pipelines.scoreAndPick);
+        pass.setBindGroup(0, state.bindGroups.scoreAndPick, [byteOffset]);
+        pass.dispatchWorkgroups(columnCount);
+      };
+
+      const dispatchFilter = (
+        pass: GPUComputePassEncoder,
+        range?: SpectrogramColumnRange,
+      ) => {
+        const { columnCount, byteOffset } = state.params.writeRange(range);
+        if (columnCount <= 0) {
+          return;
+        }
         const windowGroups = Math.max(
           1,
-          Math.ceil(windowCount / workgroupSize),
+          Math.ceil(columnCount / workgroupSize),
         );
 
-        pass.setPipeline(state.pipelines.scoreCandidates);
-        pass.setBindGroup(0, state.bindGroups.scoreCandidates);
-        pass.dispatchWorkgroups(scoreGroups);
-
-        pass.setPipeline(state.pipelines.pickBest);
-        pass.setBindGroup(0, state.bindGroups.pickBest);
-        pass.dispatchWorkgroups(windowGroups);
-
         pass.setPipeline(state.pipelines.filter);
-        pass.setBindGroup(0, state.bindGroups.filter);
+        pass.setBindGroup(0, state.bindGroups.filter, [byteOffset]);
         pass.dispatchWorkgroups(windowGroups);
       };
 
@@ -50,10 +70,12 @@ export const createSpectrogramFundamentalFrequencyCell = (
             label: 'fundamental-frequency-pass',
             timestampWrites: marker,
           });
-          dispatch(pass);
+          dispatchScore(pass);
+          dispatchFilter(pass);
           pass.end();
         },
-        dispatch,
+        dispatchScore,
+        dispatchFilter,
       };
     },
     dispose: () => {

--- a/packages/spectrogram/src/fundamentalFrequency/params.ts
+++ b/packages/spectrogram/src/fundamentalFrequency/params.ts
@@ -1,5 +1,10 @@
 import { createResourceCell } from '@musetric/utils';
-import { type ExtSpectrogramConfig } from '../common/extConfig.js';
+import { createDynamicUniformParams } from '../common/dynamicUniform.js';
+import {
+  type ExtSpectrogramConfig,
+  floorMod,
+  type SpectrogramColumnRange,
+} from '../common/extConfig.js';
 
 export type FundamentalFrequencyParams = {
   halfSize: number;
@@ -13,6 +18,12 @@ export type FundamentalFrequencyParams = {
   minimumScore: number;
   harmonicCount: number;
 };
+
+export const slotOffsetByteOffset = 40;
+const columnCountByteOffset = 44;
+const screenBaseByteOffset = 48;
+const baseSlotByteOffset = 52;
+const paramsByteLength = 64;
 
 const minimumVocalFrequency = 55;
 const maximumVocalFrequency = 1100;
@@ -55,34 +66,60 @@ const toParams = (config: ExtSpectrogramConfig): FundamentalFrequencyParams => {
 export type StateParams = {
   value: FundamentalFrequencyParams;
   buffer: GPUBuffer;
+  byteLength: number;
+  writeRange: (range?: SpectrogramColumnRange) => {
+    columnCount: number;
+    candidateCount: number;
+    byteOffset: number;
+  };
 };
 
 export const createParamsCell = (device: GPUDevice) =>
   createResourceCell({
     create: (config: ExtSpectrogramConfig): StateParams => {
       const value = toParams(config);
-      const array = new DataView(new ArrayBuffer(48));
-      array.setUint32(0, value.halfSize, true);
-      array.setUint32(4, value.windowCount, true);
-      array.setUint32(8, value.windowSize, true);
-      array.setUint32(12, value.candidateCount, true);
-      array.setFloat32(16, value.sampleRate, true);
-      array.setFloat32(20, value.minimumFrequency, true);
-      array.setFloat32(24, value.candidateStepCents, true);
-      array.setFloat32(28, value.minimumFundamentalIntensity, true);
-      array.setFloat32(32, value.minimumScore, true);
-      array.setUint32(36, value.harmonicCount, true);
-
-      const buffer = device.createBuffer({
+      const params = createDynamicUniformParams(device, {
         label: 'fundamental-frequency-params-buffer',
-        size: array.byteLength,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        byteLength: paramsByteLength,
+        capacity: value.windowCount,
       });
-      device.queue.writeBuffer(buffer, 0, array.buffer);
 
       return {
         value,
-        buffer,
+        buffer: params.buffer,
+        byteLength: params.byteLength,
+        writeRange: (range) => {
+          const columnCount = range ? range.columnCount : value.windowCount;
+          const slotOffset = range ? range.slotOffset : 0;
+          const screenBase = range ? range.screenBase : 0;
+          const byteOffset = params.write((view) => {
+            view.setUint32(0, value.halfSize, true);
+            view.setUint32(4, value.windowCount, true);
+            view.setUint32(8, value.windowSize, true);
+            view.setUint32(12, value.candidateCount, true);
+            view.setFloat32(16, value.sampleRate, true);
+            view.setFloat32(20, value.minimumFrequency, true);
+            view.setFloat32(24, value.candidateStepCents, true);
+            view.setFloat32(28, value.minimumFundamentalIntensity, true);
+            view.setFloat32(32, value.minimumScore, true);
+            view.setUint32(36, value.harmonicCount, true);
+            view.setUint32(slotOffsetByteOffset, slotOffset, true);
+            view.setUint32(columnCountByteOffset, columnCount, true);
+            view.setUint32(screenBaseByteOffset, screenBase, true);
+            view.setUint32(
+              baseSlotByteOffset,
+              floorMod(slotOffset - screenBase, value.windowCount),
+              true,
+            );
+            view.setUint32(56, 0, true);
+            view.setUint32(60, 0, true);
+          });
+          return {
+            columnCount,
+            candidateCount: value.candidateCount,
+            byteOffset,
+          };
+        },
       };
     },
     dispose: (params) => {

--- a/packages/spectrogram/src/fundamentalFrequency/pipeline.ts
+++ b/packages/spectrogram/src/fundamentalFrequency/pipeline.ts
@@ -2,14 +2,61 @@ import { filterShader } from './filterShader.js';
 import { shader } from './shader.js';
 
 export type FundamentalFrequencyPipelines = {
-  scoreCandidates: GPUComputePipeline;
-  pickBest: GPUComputePipeline;
+  scoreAndPick: GPUComputePipeline;
   filter: GPUComputePipeline;
 };
 
 export const createPipelines = (
   device: GPUDevice,
 ): FundamentalFrequencyPipelines => {
+  const scoreAndPickLayout = device.createBindGroupLayout({
+    label: 'fundamental-frequency-score-and-pick-bind-group-layout',
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'read-only-storage' },
+      },
+      {
+        binding: 2,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'storage' },
+      },
+      {
+        binding: 3,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'uniform', hasDynamicOffset: true },
+      },
+    ],
+  });
+  const filterLayout = device.createBindGroupLayout({
+    label: 'fundamental-frequency-filter-bind-group-layout',
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'read-only-storage' },
+      },
+      {
+        binding: 1,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'storage' },
+      },
+      {
+        binding: 2,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'uniform', hasDynamicOffset: true },
+      },
+    ],
+  });
+  const scoreAndPickPipelineLayout = device.createPipelineLayout({
+    label: 'fundamental-frequency-score-and-pick-pipeline-layout',
+    bindGroupLayouts: [scoreAndPickLayout],
+  });
+  const filterPipelineLayout = device.createPipelineLayout({
+    label: 'fundamental-frequency-filter-pipeline-layout',
+    bindGroupLayouts: [filterLayout],
+  });
   const module = device.createShaderModule({
     label: 'fundamental-frequency-shader',
     code: shader,
@@ -20,25 +67,17 @@ export const createPipelines = (
   });
 
   return {
-    scoreCandidates: device.createComputePipeline({
-      label: 'fundamental-frequency-score-candidates-pipeline',
-      layout: 'auto',
+    scoreAndPick: device.createComputePipeline({
+      label: 'fundamental-frequency-score-and-pick-pipeline',
+      layout: scoreAndPickPipelineLayout,
       compute: {
         module,
-        entryPoint: 'scoreCandidates',
-      },
-    }),
-    pickBest: device.createComputePipeline({
-      label: 'fundamental-frequency-pick-best-pipeline',
-      layout: 'auto',
-      compute: {
-        module,
-        entryPoint: 'pickBest',
+        entryPoint: 'scoreAndPick',
       },
     }),
     filter: device.createComputePipeline({
       label: 'fundamental-frequency-filter-pipeline',
-      layout: 'auto',
+      layout: filterPipelineLayout,
       compute: {
         module: filterModule,
         entryPoint: 'main',

--- a/packages/spectrogram/src/fundamentalFrequency/shader.ts
+++ b/packages/spectrogram/src/fundamentalFrequency/shader.ts
@@ -10,8 +10,10 @@ struct FundamentalFrequencyParams {
   minimumFundamentalIntensity: f32,
   minimumScore: f32,
   harmonicCount: u32,
-  pad0: u32,
-  pad1: u32,
+  slotOffset: u32,
+  columnCount: u32,
+  screenBase: u32,
+  baseSlot: u32,
 };
 
 struct CandidateStats {
@@ -25,7 +27,6 @@ struct CandidateStats {
 };
 
 @group(0) @binding(0) var<storage, read> signal: array<f32>;
-@group(0) @binding(1) var<storage, read_write> scores: array<f32>;
 @group(0) @binding(2) var<storage, read_write> rawOutput: array<f32>;
 @group(0) @binding(3) var<uniform> params: FundamentalFrequencyParams;
 
@@ -44,6 +45,9 @@ const harmonicWeights = array<f32, 11>(
 );
 
 const prominenceProbeRatio = 1.041243772;
+
+var<workgroup> workgroupScores: array<f32, 256>;
+var<workgroup> workgroupCandidates: array<u32, 256>;
 
 fn frequencyAtCandidate(candidate: u32) -> f32 {
   return params.minimumFrequency *
@@ -274,41 +278,81 @@ fn refinementScore(windowIndex: u32, frequency: f32) -> f32 {
   return max(stats.score, 0.0);
 }
 
-@compute @workgroup_size(64)
-fn scoreCandidates(@builtin(global_invocation_id) gid: vec3<u32>) {
-  let totalThreads = params.windowCount * params.candidateCount;
-  let index = gid.x;
-  if (index >= totalThreads) {
-    return;
-  }
-
-  let windowIndex = index / params.candidateCount;
-  let candidate = index % params.candidateCount;
-  let frequency = frequencyAtCandidate(candidate);
-  scores[windowIndex * params.candidateCount + candidate] =
-    harmonicScore(windowIndex, frequency);
+fn shouldReplaceBest(
+  score: f32,
+  candidate: u32,
+  bestScore: f32,
+  bestCandidate: u32,
+) -> bool {
+  return score > bestScore || (score == bestScore && candidate < bestCandidate);
 }
 
-@compute @workgroup_size(64)
-fn pickBest(@builtin(global_invocation_id) gid: vec3<u32>) {
-  let windowIndex = gid.x;
-  if (windowIndex >= params.windowCount) {
+@compute @workgroup_size(256)
+fn scoreAndPick(
+  @builtin(workgroup_id) workgroupId: vec3<u32>,
+  @builtin(local_invocation_id) localId: vec3<u32>,
+) {
+  let localWindowIndex = workgroupId.x;
+  let threadIndex = localId.x;
+  if (localWindowIndex >= params.columnCount) {
     return;
   }
-
+  let windowIndex = (params.slotOffset + localWindowIndex) % params.windowCount;
   let candidateCount = params.candidateCount;
-  let base = windowIndex * candidateCount;
 
   var bestScore = 0.0;
   var bestCandidate = 0u;
-  for (var c = 0u; c < candidateCount; c += 1u) {
-    let candidateScore = scores[base + c];
-    if (candidateScore > bestScore) {
+  for (
+    var candidate = threadIndex;
+    candidate < candidateCount;
+    candidate += 256u
+  ) {
+    let candidateScore = harmonicScore(
+      windowIndex,
+      frequencyAtCandidate(candidate),
+    );
+    if (
+      shouldReplaceBest(
+        candidateScore,
+        candidate,
+        bestScore,
+        bestCandidate,
+      )
+    ) {
       bestScore = candidateScore;
-      bestCandidate = c;
+      bestCandidate = candidate;
     }
   }
 
+  workgroupScores[threadIndex] = bestScore;
+  workgroupCandidates[threadIndex] = bestCandidate;
+  workgroupBarrier();
+
+  for (var stride = 128u; stride > 0u; stride = stride / 2u) {
+    if (threadIndex < stride) {
+      let otherScore = workgroupScores[threadIndex + stride];
+      let otherCandidate = workgroupCandidates[threadIndex + stride];
+      if (
+        shouldReplaceBest(
+          otherScore,
+          otherCandidate,
+          workgroupScores[threadIndex],
+          workgroupCandidates[threadIndex],
+        )
+      ) {
+        workgroupScores[threadIndex] = otherScore;
+        workgroupCandidates[threadIndex] = otherCandidate;
+      }
+    }
+    workgroupBarrier();
+  }
+
+  if (threadIndex != 0u) {
+    return;
+  }
+
+  bestScore = workgroupScores[0];
+  bestCandidate = workgroupCandidates[0];
   if (bestScore <= 0.0) {
     rawOutput[windowIndex] = 0.0;
     return;

--- a/packages/spectrogram/src/fundamentalFrequency/state.ts
+++ b/packages/spectrogram/src/fundamentalFrequency/state.ts
@@ -11,40 +11,15 @@ export type StateArg = {
 export type FundamentalFrequencyState = {
   pipelines: FundamentalFrequencyPipelines;
   params: StateParams;
-  scores: GPUBuffer;
   output: {
     raw: GPUBuffer;
     filtered: GPUBuffer;
   };
   bindGroups: {
-    scoreCandidates: GPUBindGroup;
-    pickBest: GPUBindGroup;
+    scoreAndPick: GPUBindGroup;
     filter: GPUBindGroup;
   };
 };
-
-type ScoresBufferArg = {
-  windowCount: number;
-  candidateCount: number;
-};
-
-const createScoresBufferCell = (device: GPUDevice) =>
-  createResourceCell({
-    create: (arg: ScoresBufferArg): GPUBuffer =>
-      device.createBuffer({
-        label: 'fundamental-frequency-scores-buffer',
-        size:
-          Math.max(1, arg.windowCount * arg.candidateCount) *
-          Float32Array.BYTES_PER_ELEMENT,
-        usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_DST,
-      }),
-    dispose: (buffer) => {
-      buffer.destroy();
-    },
-    equals: (current, next) =>
-      current.windowCount === next.windowCount &&
-      current.candidateCount === next.candidateCount,
-  });
 
 const createFrequencyBufferCell = (device: GPUDevice, label: string) =>
   createResourceCell({
@@ -65,7 +40,6 @@ export const createStateCell = (
   pipelines: FundamentalFrequencyPipelines,
 ): ResourceCell<StateArg, FundamentalFrequencyState> => {
   const paramsCell = createParamsCell(device);
-  const scoresCell = createScoresBufferCell(device);
   const rawOutputCell = createFrequencyBufferCell(
     device,
     'fundamental-frequency-raw-output-buffer',
@@ -74,48 +48,30 @@ export const createStateCell = (
     device,
     'fundamental-frequency-filtered-output-buffer',
   );
-  const scoreCandidatesBindGroupCell = createResourceCell({
+  const scoreAndPickBindGroupCell = createResourceCell({
     create: (arg: {
       signal: GPUBuffer;
-      scores: GPUBuffer;
-      params: GPUBuffer;
-    }): GPUBindGroup =>
-      device.createBindGroup({
-        label: 'fundamental-frequency-score-candidates-bind-group',
-        layout: pipelines.scoreCandidates.getBindGroupLayout(0),
-        entries: [
-          { binding: 0, resource: { buffer: arg.signal } },
-          { binding: 1, resource: { buffer: arg.scores } },
-          { binding: 3, resource: { buffer: arg.params } },
-        ],
-      }),
-    dispose: () => undefined,
-    equals: (current, next) =>
-      current.signal === next.signal &&
-      current.scores === next.scores &&
-      current.params === next.params,
-  });
-  const pickBestBindGroupCell = createResourceCell({
-    create: (arg: {
-      signal: GPUBuffer;
-      scores: GPUBuffer;
       rawOutput: GPUBuffer;
-      params: GPUBuffer;
+      params: StateParams;
     }): GPUBindGroup =>
       device.createBindGroup({
-        label: 'fundamental-frequency-pick-best-bind-group',
-        layout: pipelines.pickBest.getBindGroupLayout(0),
+        label: 'fundamental-frequency-score-and-pick-bind-group',
+        layout: pipelines.scoreAndPick.getBindGroupLayout(0),
         entries: [
           { binding: 0, resource: { buffer: arg.signal } },
-          { binding: 1, resource: { buffer: arg.scores } },
           { binding: 2, resource: { buffer: arg.rawOutput } },
-          { binding: 3, resource: { buffer: arg.params } },
+          {
+            binding: 3,
+            resource: {
+              buffer: arg.params.buffer,
+              size: arg.params.byteLength,
+            },
+          },
         ],
       }),
     dispose: () => undefined,
     equals: (current, next) =>
       current.signal === next.signal &&
-      current.scores === next.scores &&
       current.rawOutput === next.rawOutput &&
       current.params === next.params,
   });
@@ -123,7 +79,7 @@ export const createStateCell = (
     create: (arg: {
       rawOutput: GPUBuffer;
       filteredOutput: GPUBuffer;
-      params: GPUBuffer;
+      params: StateParams;
     }): GPUBindGroup =>
       device.createBindGroup({
         label: 'fundamental-frequency-filter-bind-group',
@@ -131,7 +87,13 @@ export const createStateCell = (
         entries: [
           { binding: 0, resource: { buffer: arg.rawOutput } },
           { binding: 1, resource: { buffer: arg.filteredOutput } },
-          { binding: 2, resource: { buffer: arg.params } },
+          {
+            binding: 2,
+            resource: {
+              buffer: arg.params.buffer,
+              size: arg.params.byteLength,
+            },
+          },
         ],
       }),
     dispose: () => undefined,
@@ -144,51 +106,37 @@ export const createStateCell = (
   return {
     get: (arg) => {
       const params = paramsCell.get(arg.config);
-      const scores = scoresCell.get({
-        windowCount: params.value.windowCount,
-        candidateCount: params.value.candidateCount,
-      });
       const rawOutput = rawOutputCell.get(params.value.windowCount);
       const filteredOutput = filteredOutputCell.get(params.value.windowCount);
-      const scoreCandidatesBindGroup = scoreCandidatesBindGroupCell.get({
+      const scoreAndPickBindGroup = scoreAndPickBindGroupCell.get({
         signal: arg.signal,
-        scores,
-        params: params.buffer,
-      });
-      const pickBestBindGroup = pickBestBindGroupCell.get({
-        signal: arg.signal,
-        scores,
         rawOutput,
-        params: params.buffer,
+        params,
       });
       const filterBindGroup = filterBindGroupCell.get({
         rawOutput,
         filteredOutput,
-        params: params.buffer,
+        params,
       });
 
       return {
         pipelines,
         params,
-        scores,
         output: {
           raw: rawOutput,
           filtered: filteredOutput,
         },
         bindGroups: {
-          scoreCandidates: scoreCandidatesBindGroup,
-          pickBest: pickBestBindGroup,
+          scoreAndPick: scoreAndPickBindGroup,
           filter: filterBindGroup,
         },
       };
     },
     dispose: () => {
       filterBindGroupCell.dispose();
-      pickBestBindGroupCell.dispose();
-      scoreCandidatesBindGroupCell.dispose();
+      scoreAndPickBindGroupCell.dispose();
       filteredOutputCell.dispose();
       rawOutputCell.dispose();
-      scoresCell.dispose();
       paramsCell.dispose();
     },
   };

--- a/packages/spectrogram/src/gpu.ts
+++ b/packages/spectrogram/src/gpu.ts
@@ -2,6 +2,7 @@ export * from './common/configFieldEqual.js';
 export * from './common/extConfig.js';
 export * from './common/gpuDevice.js';
 export * from './common/processorTimer.js';
+export * from './common/sampleInvalidations.js';
 export * from './common/timer/index.js';
 export * from './configurator.js';
 export * from './decibelify/index.js';

--- a/packages/spectrogram/src/lane/__test__/columnRangeDispatch.test.ts
+++ b/packages/spectrogram/src/lane/__test__/columnRangeDispatch.test.ts
@@ -1,0 +1,66 @@
+import { type Fourier, type FourierBatchRange } from '@musetric/fft/gpu';
+import { describe, expect, it } from 'vitest';
+import { type SpectrogramColumnRange } from '../../common/extConfig.js';
+import { dispatchFourierColumnRange } from '../index.js';
+
+type RecordedDispatch = FourierBatchRange | 'full';
+
+const record = (): { fourier: Fourier; calls: RecordedDispatch[] } => {
+  const calls: RecordedDispatch[] = [];
+  const fourier: Fourier = {
+    run: () => undefined,
+    dispatch: (_pass, range) => {
+      calls.push(range ? { ...range } : 'full');
+    },
+  };
+  return { fourier, calls };
+};
+
+// eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+const pass = {} as GPUComputePassEncoder;
+
+const windowCount = 8;
+
+const range = (
+  slotOffset: number,
+  columnCount: number,
+): SpectrogramColumnRange => ({
+  screenBase: 0,
+  slotOffset,
+  columnCount,
+});
+
+describe('dispatchFourierColumnRange', () => {
+  it('skips empty ranges', () => {
+    const { fourier, calls } = record();
+    dispatchFourierColumnRange(fourier, pass, range(3, 0), windowCount);
+    expect(calls).toEqual([]);
+  });
+
+  it('runs the full transform when the range covers the ring', () => {
+    const { fourier, calls } = record();
+    dispatchFourierColumnRange(fourier, pass, range(5, 8), windowCount);
+    expect(calls).toEqual(['full']);
+  });
+
+  it('forwards a non-wrapping range as one batch', () => {
+    const { fourier, calls } = record();
+    dispatchFourierColumnRange(fourier, pass, range(2, 4), windowCount);
+    expect(calls).toEqual([{ batchOffset: 2, batchCount: 4 }]);
+  });
+
+  it('splits a range crossing the ring seam into two batches', () => {
+    const { fourier, calls } = record();
+    dispatchFourierColumnRange(fourier, pass, range(6, 4), windowCount);
+    expect(calls).toEqual([
+      { batchOffset: 6, batchCount: 2 },
+      { batchOffset: 0, batchCount: 2 },
+    ]);
+  });
+
+  it('keeps a range ending exactly at the seam unsplit', () => {
+    const { fourier, calls } = record();
+    dispatchFourierColumnRange(fourier, pass, range(4, 4), windowCount);
+    expect(calls).toEqual([{ batchOffset: 4, batchCount: 4 }]);
+  });
+});

--- a/packages/spectrogram/src/lane/index.ts
+++ b/packages/spectrogram/src/lane/index.ts
@@ -1,6 +1,10 @@
-import { createFourierCell } from '@musetric/fft/gpu';
+import { createFourierCell, type Fourier } from '@musetric/fft/gpu';
 import { createResourceCell, type ResourceCell } from '@musetric/utils';
-import { type ExtSpectrogramConfig } from '../common/extConfig.js';
+import {
+  type ExtSpectrogramConfig,
+  type SpectrogramColumnRange,
+  type SpectrogramSampleRange,
+} from '../common/extConfig.js';
 import {
   type SpectrogramSpectralBand,
   type TrackKey,
@@ -30,6 +34,7 @@ export type SpectrogramLaneWork = {
 type SpectrogramLaneDispatch = (
   pass: GPUComputePassEncoder,
   work: SpectrogramLaneWork,
+  range: SpectrogramColumnRange,
 ) => void;
 
 export type SpectrogramLane = {
@@ -38,16 +43,23 @@ export type SpectrogramLane = {
   fundamentalFrequencyBuffer: GPUBuffer;
   writeSamples: (
     samples: Float32Array,
-    trackProgress: number,
+    baseColumn: number,
     work: SpectrogramLaneWork,
-    contentChanged: boolean,
+    forceFullUpload: boolean,
+    invalidations: readonly SpectrogramSampleRange[],
   ) => void;
-  clearSignal: (encoder: GPUCommandEncoder, work: SpectrogramLaneWork) => void;
   dispatchSliceSamples: SpectrogramLaneDispatch;
   dispatchFourierTransform: SpectrogramLaneDispatch;
   dispatchMagnitudify: SpectrogramLaneDispatch;
   dispatchDecibelify: SpectrogramLaneDispatch;
-  dispatchFundamentalFrequency: (pass: GPUComputePassEncoder) => void;
+  dispatchFundamentalScore: (
+    pass: GPUComputePassEncoder,
+    range: SpectrogramColumnRange,
+  ) => void;
+  dispatchFundamentalFilter: (
+    pass: GPUComputePassEncoder,
+    range: SpectrogramColumnRange,
+  ) => void;
   clear: (encoder: GPUCommandEncoder) => void;
 };
 
@@ -57,20 +69,36 @@ export type SpectrogramLaneCell = ResourceCell<
 >;
 
 type BandSpectrumPipeline = {
+  signal: GPUBuffer;
   rawMagnitudeBuffer: GPUBuffer;
   columnEnergyBuffer: GPUBuffer;
   windowSize: number;
   writeSamples: (
     samples: Float32Array,
-    trackProgress: number,
-    contentChanged: boolean,
+    baseColumn: number,
+    forceFullUpload: boolean,
+    invalidations: readonly SpectrogramSampleRange[],
   ) => void;
-  clearSignal: (encoder: GPUCommandEncoder) => void;
-  dispatchSliceSamples: (pass: GPUComputePassEncoder) => void;
-  dispatchFourier: (pass: GPUComputePassEncoder) => void;
-  dispatchMagnitudify: (pass: GPUComputePassEncoder) => void;
-  dispatchDecibelEnergy: (pass: GPUComputePassEncoder) => void;
-  dispatchDecibelRun: (pass: GPUComputePassEncoder) => void;
+  dispatchSliceSamples: (
+    pass: GPUComputePassEncoder,
+    range: SpectrogramColumnRange,
+  ) => void;
+  dispatchFourier: (
+    pass: GPUComputePassEncoder,
+    range: SpectrogramColumnRange,
+  ) => void;
+  dispatchMagnitudify: (
+    pass: GPUComputePassEncoder,
+    range: SpectrogramColumnRange,
+  ) => void;
+  dispatchDecibelEnergy: (
+    pass: GPUComputePassEncoder,
+    range: SpectrogramColumnRange,
+  ) => void;
+  dispatchDecibelRun: (
+    pass: GPUComputePassEncoder,
+    range: SpectrogramColumnRange,
+  ) => void;
   clear: (encoder: GPUCommandEncoder) => void;
 };
 
@@ -87,11 +115,6 @@ const createSpectralBandConfig = (
   ...config,
   windowSize: band.windowSize,
 });
-
-const getSpectralBandSampleOffset = (
-  config: ExtSpectrogramConfig,
-  band: SpectrogramSpectralBand,
-): number => (band.windowSize - config.windowSize) / 2;
 
 const areSpectralBandsEqual = (
   current: SpectrogramSpectralBand,
@@ -111,72 +134,124 @@ const areSpectralBandListsEqual = (
   current.length === next.length &&
   current.every((band, index) => areSpectralBandsEqual(band, next[index]));
 
+type BandPipelineCells = {
+  signalCell: ReturnType<typeof createSignalBufferCell>;
+  sliceSamplesCell: ReturnType<typeof createSpectrogramSliceSamplesCell>;
+  fourierCell: ReturnType<typeof createFourierCell>;
+  magnitudifyCell: ReturnType<typeof createSpectrogramMagnitudifyCell>;
+  decibelifyCell: ReturnType<typeof createSpectrogramDecibelifyCell>;
+};
+
+const createBandPipelineCells = (device: GPUDevice): BandPipelineCells => ({
+  signalCell: createSignalBufferCell(device),
+  sliceSamplesCell: createSpectrogramSliceSamplesCell(device),
+  fourierCell: createFourierCell(device),
+  magnitudifyCell: createSpectrogramMagnitudifyCell(device),
+  decibelifyCell: createSpectrogramDecibelifyCell(device),
+});
+
+const disposeBandPipelineCells = (cells: BandPipelineCells): void => {
+  cells.decibelifyCell.dispose();
+  cells.magnitudifyCell.dispose();
+  cells.fourierCell.dispose();
+  cells.sliceSamplesCell.dispose();
+  cells.signalCell.dispose();
+};
+
+export const dispatchFourierColumnRange = (
+  fourier: Fourier,
+  pass: GPUComputePassEncoder,
+  range: SpectrogramColumnRange,
+  windowCount: number,
+): void => {
+  if (range.columnCount <= 0) {
+    return;
+  }
+  if (range.columnCount >= windowCount) {
+    fourier.dispatch(pass);
+    return;
+  }
+  const firstBatchCount = Math.min(
+    range.columnCount,
+    windowCount - range.slotOffset,
+  );
+  if (firstBatchCount > 0) {
+    fourier.dispatch(pass, {
+      batchOffset: range.slotOffset,
+      batchCount: firstBatchCount,
+    });
+  }
+  const secondBatchCount = range.columnCount - firstBatchCount;
+  if (secondBatchCount > 0) {
+    fourier.dispatch(pass, {
+      batchOffset: 0,
+      batchCount: secondBatchCount,
+    });
+  }
+};
+
+const buildBandSpectrumPipeline = (
+  cells: BandPipelineCells,
+  config: ExtSpectrogramConfig,
+  label: TrackKey,
+): BandSpectrumPipeline => {
+  const paddedWindowSize = config.windowSize * config.zeroPaddingFactor;
+  const laneConfig = config.lanes[label];
+  const signal = cells.signalCell.get({
+    windowSize: paddedWindowSize,
+    windowCount: config.windowCount,
+  });
+  const sliceSamples = cells.sliceSamplesCell.get({ out: signal, config });
+  const fourier = cells.fourierCell.get({ signal, config });
+  const magnitudify = cells.magnitudifyCell.get({ signal, config });
+  const decibelify = cells.decibelifyCell.get({
+    signal,
+    magnitude: magnitudify.magnitude,
+    config,
+    gainDb: laneConfig.gainDb,
+  });
+
+  return {
+    signal,
+    rawMagnitudeBuffer: magnitudify.magnitude,
+    columnEnergyBuffer: decibelify.columnEnergy,
+    windowSize: paddedWindowSize,
+    writeSamples: (samples, baseColumn, forceFullUpload, invalidations) => {
+      sliceSamples.write(
+        samples,
+        baseColumn,
+        laneConfig.truncateAfterPlayhead,
+        forceFullUpload,
+        invalidations,
+      );
+    },
+    dispatchSliceSamples: sliceSamples.dispatch,
+    dispatchFourier: (pass, range) => {
+      dispatchFourierColumnRange(fourier, pass, range, config.windowCount);
+    },
+    dispatchMagnitudify: magnitudify.dispatch,
+    dispatchDecibelEnergy: decibelify.dispatchEnergy,
+    dispatchDecibelRun: decibelify.dispatchRun,
+    clear: (encoder) => {
+      encoder.clearBuffer(signal);
+      encoder.clearBuffer(magnitudify.magnitude);
+      encoder.clearBuffer(decibelify.columnEnergy);
+    },
+  };
+};
+
 const createBandSpectrumCell = (
   device: GPUDevice,
 ): ResourceCell<BandSpectrumCellArg, BandSpectrumPipeline> => {
-  const signalCell = createSignalBufferCell(device);
-  const sliceSamplesCell = createSpectrogramSliceSamplesCell(device);
-  const fourierCell = createFourierCell(device);
-  const magnitudifyCell = createSpectrogramMagnitudifyCell(device);
-  const decibelifyCell = createSpectrogramDecibelifyCell(device);
+  const cells = createBandPipelineCells(device);
 
   const cell = createResourceCell<BandSpectrumCellArg, BandSpectrumPipeline>({
-    create: (arg) => {
-      const { config, band, label } = arg;
-      const bandConfig = createSpectralBandConfig(config, band);
-      const signal = signalCell.get({
-        windowSize: bandConfig.windowSize * bandConfig.zeroPaddingFactor,
-        windowCount: bandConfig.windowCount,
-      });
-      const sliceSamples = sliceSamplesCell.get({
-        out: signal,
-        config: bandConfig,
-        sampleOffset: getSpectralBandSampleOffset(config, band),
-      });
-      const fourier = fourierCell.get({
-        signal,
-        config: bandConfig,
-      });
-      const magnitudify = magnitudifyCell.get({
-        signal,
-        config: bandConfig,
-      });
-      const decibelify = decibelifyCell.get({
-        signal,
-        magnitude: magnitudify.magnitude,
-        config: bandConfig,
-        gainDb: bandConfig.lanes[label].gainDb,
-      });
-
-      return {
-        rawMagnitudeBuffer: magnitudify.magnitude,
-        columnEnergyBuffer: decibelify.columnEnergy,
-        windowSize: bandConfig.windowSize * bandConfig.zeroPaddingFactor,
-        writeSamples: (samples, trackProgress, contentChanged) => {
-          sliceSamples.write(
-            samples,
-            trackProgress,
-            bandConfig.lanes[label].truncateAfterPlayhead,
-            contentChanged,
-          );
-        },
-        dispatchSliceSamples: sliceSamples.dispatch,
-        clearSignal: (encoder) => {
-          if (bandConfig.zeroPaddingFactor > 1) {
-            encoder.clearBuffer(signal);
-          }
-        },
-        dispatchFourier: fourier.dispatch,
-        dispatchMagnitudify: magnitudify.dispatch,
-        dispatchDecibelEnergy: decibelify.dispatchEnergy,
-        dispatchDecibelRun: decibelify.dispatchRun,
-        clear: (encoder) => {
-          encoder.clearBuffer(signal);
-          encoder.clearBuffer(magnitudify.magnitude);
-          encoder.clearBuffer(decibelify.columnEnergy);
-        },
-      };
-    },
+    create: (arg) =>
+      buildBandSpectrumPipeline(
+        cells,
+        createSpectralBandConfig(arg.config, arg.band),
+        arg.label,
+      ),
     dispose: () => undefined,
     equals: (current, next) =>
       current.config.fourierMode === next.config.fourierMode &&
@@ -201,11 +276,7 @@ const createBandSpectrumCell = (
     get: cell.get,
     dispose: () => {
       cell.dispose();
-      decibelifyCell.dispose();
-      magnitudifyCell.dispose();
-      fourierCell.dispose();
-      sliceSamplesCell.dispose();
-      signalCell.dispose();
+      disposeBandPipelineCells(cells);
     },
   };
 };
@@ -214,11 +285,7 @@ export const createSpectrogramLaneCell = (
   device: GPUDevice,
   options: SpectrogramLaneOptions,
 ): SpectrogramLaneCell => {
-  const signalCell = createSignalBufferCell(device);
-  const sliceSamplesCell = createSpectrogramSliceSamplesCell(device);
-  const fourierCell = createFourierCell(device);
-  const magnitudifyCell = createSpectrogramMagnitudifyCell(device);
-  const decibelifyCell = createSpectrogramDecibelifyCell(device);
+  const cells = createBandPipelineCells(device);
   const fundamentalFrequencyCell =
     createSpectrogramFundamentalFrequencyCell(device);
   const bandSpectrumCells: ReturnType<typeof createBandSpectrumCell>[] = [];
@@ -236,107 +303,50 @@ export const createSpectrogramLaneCell = (
   const laneCell = createResourceCell<ExtSpectrogramConfig, SpectrogramLane>({
     create: (config): SpectrogramLane => {
       const laneConfig = config.lanes[options.label];
-      const signal = signalCell.get({
-        windowSize: config.windowSize * config.zeroPaddingFactor,
-        windowCount: config.windowCount,
-      });
-      const sliceSamples = sliceSamplesCell.get({
-        out: signal,
+      const baseBandPipeline = buildBandSpectrumPipeline(
+        cells,
         config,
-        sampleOffset: 0,
-      });
-      const fourier = fourierCell.get({ signal, config });
-      const magnitudify = magnitudifyCell.get({ signal, config });
-      const decibelify = decibelifyCell.get({
-        signal,
-        magnitude: magnitudify.magnitude,
-        config,
-        gainDb: laneConfig.gainDb,
-      });
+        options.label,
+      );
       const fundamentalFrequency = fundamentalFrequencyCell.get({
-        signal,
+        signal: baseBandPipeline.signal,
         config,
       });
-      const baseBandPipeline: BandSpectrumPipeline = {
-        rawMagnitudeBuffer: magnitudify.magnitude,
-        columnEnergyBuffer: decibelify.columnEnergy,
-        windowSize: config.windowSize * config.zeroPaddingFactor,
-        writeSamples: (samples, trackProgress, contentChanged) => {
-          sliceSamples.write(
-            samples,
-            trackProgress,
-            laneConfig.truncateAfterPlayhead,
-            contentChanged,
-          );
-        },
-        dispatchSliceSamples: sliceSamples.dispatch,
-        clearSignal: (encoder) => {
-          if (config.zeroPaddingFactor > 1) {
-            encoder.clearBuffer(signal);
-          }
-        },
-        dispatchFourier: fourier.dispatch,
-        dispatchMagnitudify: magnitudify.dispatch,
-        dispatchDecibelEnergy: decibelify.dispatchEnergy,
-        dispatchDecibelRun: decibelify.dispatchRun,
-        clear: (encoder) => {
-          encoder.clearBuffer(signal);
-          encoder.clearBuffer(magnitudify.magnitude);
-          encoder.clearBuffer(decibelify.columnEnergy);
-        },
-      };
+
       const externalSpectralBands = laneConfig.showSpectrogram
         ? config.spectralBands.filter(
             (band) => band.windowSize !== config.windowSize,
           )
         : [];
-      const bandPipelines = getBandSpectrumCells(externalSpectralBands).map(
-        (cell, index) => {
-          const band = externalSpectralBands[index];
-          return cell.get({
+      const externalPipelines = getBandSpectrumCells(externalSpectralBands).map(
+        (cell, index) =>
+          cell.get({
             config,
-            band,
+            band: externalSpectralBands[index],
             label: options.label,
-          });
-        },
+          }),
       );
-      let externalBandPipelineIndex = 0;
-      const spectrogramBandPipelines: BandSpectrumPipeline[] = [];
-      if (laneConfig.showSpectrogram) {
-        for (const band of config.spectralBands) {
-          const pipeline =
-            band.windowSize === config.windowSize
-              ? baseBandPipeline
-              : bandPipelines[externalBandPipelineIndex];
-          if (band.windowSize !== config.windowSize) {
-            externalBandPipelineIndex += 1;
-          }
-          if (!spectrogramBandPipelines.includes(pipeline)) {
-            spectrogramBandPipelines.push(pipeline);
-          }
-        }
-      }
-      externalBandPipelineIndex = 0;
-      const bandSpectra = laneConfig.showSpectrogram
+      let externalIndex = 0;
+      const bandPipelines = laneConfig.showSpectrogram
         ? config.spectralBands.map((band) => {
-            if (band.windowSize === config.windowSize) {
-              return {
-                rawMagnitudeBuffer: magnitudify.magnitude,
-                columnEnergyBuffer: decibelify.columnEnergy,
-                windowSize: config.windowSize * config.zeroPaddingFactor,
-                band,
-              };
-            }
-            const pipeline = bandPipelines[externalBandPipelineIndex];
-            externalBandPipelineIndex += 1;
-            return {
-              rawMagnitudeBuffer: pipeline.rawMagnitudeBuffer,
-              columnEnergyBuffer: pipeline.columnEnergyBuffer,
-              windowSize: pipeline.windowSize,
-              band,
-            };
+            const pipeline =
+              band.windowSize === config.windowSize
+                ? baseBandPipeline
+                : externalPipelines[externalIndex++];
+            return { band, pipeline };
           })
         : [];
+      const spectrogramBandPipelines = [
+        ...new Set(bandPipelines.map((entry) => entry.pipeline)),
+      ];
+      const bandSpectra: SpectrogramBandSpectrum[] = bandPipelines.map(
+        (entry) => ({
+          rawMagnitudeBuffer: entry.pipeline.rawMagnitudeBuffer,
+          columnEnergyBuffer: entry.pipeline.columnEnergyBuffer,
+          windowSize: entry.pipeline.windowSize,
+          band: entry.band,
+        }),
+      );
 
       const forEachWorkPipeline = (
         work: SpectrogramLaneWork,
@@ -357,48 +367,53 @@ export const createSpectrogramLaneCell = (
       };
 
       return {
-        signal,
+        signal: baseBandPipeline.signal,
         bandSpectra,
         fundamentalFrequencyBuffer: fundamentalFrequency.buffer,
-        writeSamples: (samples, trackProgress, work, contentChanged) => {
+        writeSamples: (
+          samples,
+          baseColumn,
+          work,
+          forceFullUpload,
+          invalidations,
+        ) => {
           forEachWorkPipeline(work, (pipeline) => {
-            pipeline.writeSamples(samples, trackProgress, contentChanged);
+            pipeline.writeSamples(
+              samples,
+              baseColumn,
+              forceFullUpload,
+              invalidations,
+            );
           });
         },
-        clearSignal: (encoder, work) => {
+        dispatchSliceSamples: (pass, work, range) => {
           forEachWorkPipeline(work, (pipeline) => {
-            pipeline.clearSignal(encoder);
+            pipeline.dispatchSliceSamples(pass, range);
           });
         },
-        dispatchSliceSamples: (pass, work) => {
+        dispatchFourierTransform: (pass, work, range) => {
           forEachWorkPipeline(work, (pipeline) => {
-            pipeline.dispatchSliceSamples(pass);
+            pipeline.dispatchFourier(pass, range);
           });
         },
-        dispatchFourierTransform: (pass, work) => {
+        dispatchMagnitudify: (pass, work, range) => {
           forEachWorkPipeline(work, (pipeline) => {
-            pipeline.dispatchFourier(pass);
+            pipeline.dispatchMagnitudify(pass, range);
           });
         },
-        dispatchMagnitudify: (pass, work) => {
+        dispatchDecibelify: (pass, work, range) => {
           forEachWorkPipeline(work, (pipeline) => {
-            pipeline.dispatchMagnitudify(pass);
-          });
-        },
-        dispatchDecibelify: (pass, work) => {
-          forEachWorkPipeline(work, (pipeline) => {
-            pipeline.dispatchDecibelEnergy(pass);
+            pipeline.dispatchDecibelEnergy(pass, range);
           });
           if (work.fundamental) {
-            baseBandPipeline.dispatchDecibelRun(pass);
+            baseBandPipeline.dispatchDecibelRun(pass, range);
           }
         },
-        dispatchFundamentalFrequency: fundamentalFrequency.dispatch,
+        dispatchFundamentalScore: fundamentalFrequency.dispatchScore,
+        dispatchFundamentalFilter: fundamentalFrequency.dispatchFilter,
         clear: (encoder) => {
-          encoder.clearBuffer(signal);
-          encoder.clearBuffer(magnitudify.magnitude);
-          encoder.clearBuffer(decibelify.columnEnergy);
-          for (const pipeline of bandPipelines) {
+          baseBandPipeline.clear(encoder);
+          for (const pipeline of externalPipelines) {
             pipeline.clear(encoder);
           }
           encoder.clearBuffer(fundamentalFrequency.buffer);
@@ -434,11 +449,7 @@ export const createSpectrogramLaneCell = (
         cell.dispose();
       }
       fundamentalFrequencyCell.dispose();
-      decibelifyCell.dispose();
-      magnitudifyCell.dispose();
-      fourierCell.dispose();
-      sliceSamplesCell.dispose();
-      signalCell.dispose();
+      disposeBandPipelineCells(cells);
     },
   };
 };

--- a/packages/spectrogram/src/magnitudify/index.ts
+++ b/packages/spectrogram/src/magnitudify/index.ts
@@ -1,4 +1,5 @@
 import { type ResourceCell } from '@musetric/utils';
+import { type SpectrogramColumnRange } from '../common/extConfig.js';
 import { createPipelines } from './pipeline.js';
 import { createStateCell, type StateArg } from './state.js';
 
@@ -7,7 +8,10 @@ const workgroupSize = 64;
 export type SpectrogramMagnitudify = {
   magnitude: GPUBuffer;
   run: (encoder: GPUCommandEncoder) => void;
-  dispatch: (pass: GPUComputePassEncoder) => void;
+  dispatch: (
+    pass: GPUComputePassEncoder,
+    range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+  ) => void;
 };
 
 export const createSpectrogramMagnitudifyCell = (
@@ -21,14 +25,21 @@ export const createSpectrogramMagnitudifyCell = (
     get: (arg) => {
       const state = stateCell.get(arg);
 
-      const dispatch = (pass: GPUComputePassEncoder) => {
-        const { windowSize, windowCount } = state.params.value;
+      const dispatch = (
+        pass: GPUComputePassEncoder,
+        range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+      ) => {
+        const { windowSize } = state.params.value;
         const halfSize = Math.ceil(windowSize / 2);
         const xCount = Math.ceil(halfSize / workgroupSize);
+        const { columnCount, byteOffset } = state.params.writeRange(range);
+        if (columnCount <= 0) {
+          return;
+        }
 
         pass.setPipeline(state.pipelines.run);
-        pass.setBindGroup(0, state.bindGroup);
-        pass.dispatchWorkgroups(xCount, windowCount);
+        pass.setBindGroup(0, state.bindGroup, [byteOffset]);
+        pass.dispatchWorkgroups(xCount, columnCount);
       };
 
       return {

--- a/packages/spectrogram/src/magnitudify/params.ts
+++ b/packages/spectrogram/src/magnitudify/params.ts
@@ -1,10 +1,17 @@
 import { createResourceCell } from '@musetric/utils';
-import { type ExtSpectrogramConfig } from '../common/extConfig.js';
+import { createDynamicUniformParams } from '../common/dynamicUniform.js';
+import {
+  type ExtSpectrogramConfig,
+  type SpectrogramColumnRange,
+} from '../common/extConfig.js';
 
 export type MagnitudifyParams = {
   windowSize: number;
   windowCount: number;
 };
+
+export const slotOffsetByteOffset = 8;
+const paramsByteLength = 16;
 
 const toParams = (config: ExtSpectrogramConfig): MagnitudifyParams => ({
   windowSize: config.windowSize * config.zeroPaddingFactor,
@@ -14,26 +21,46 @@ const toParams = (config: ExtSpectrogramConfig): MagnitudifyParams => ({
 export type StateParams = {
   value: MagnitudifyParams;
   buffer: GPUBuffer;
+  byteLength: number;
+  writeRange: (
+    range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+  ) => {
+    columnCount: number;
+    byteOffset: number;
+  };
 };
 
 export const createParamsCell = (device: GPUDevice) =>
   createResourceCell({
     create: (config: ExtSpectrogramConfig): StateParams => {
       const value = toParams(config);
-      const array = new Uint32Array(2);
-      array[0] = value.windowSize;
-      array[1] = value.windowCount;
-
-      const buffer = device.createBuffer({
+      const params = createDynamicUniformParams(device, {
         label: 'magnitudify-params-buffer',
-        size: array.byteLength,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        byteLength: paramsByteLength,
+        capacity: value.windowCount,
       });
-      device.queue.writeBuffer(buffer, 0, array);
 
       return {
         value,
-        buffer,
+        buffer: params.buffer,
+        byteLength: params.byteLength,
+        writeRange: (range) => {
+          const columnCount = range ? range.columnCount : value.windowCount;
+          const byteOffset = params.write((view) => {
+            view.setUint32(0, value.windowSize, true);
+            view.setUint32(4, value.windowCount, true);
+            view.setUint32(
+              slotOffsetByteOffset,
+              range ? range.slotOffset : 0,
+              true,
+            );
+            view.setUint32(12, 0, true);
+          });
+          return {
+            columnCount,
+            byteOffset,
+          };
+        },
       };
     },
     dispose: (params) => {

--- a/packages/spectrogram/src/magnitudify/pipeline.ts
+++ b/packages/spectrogram/src/magnitudify/pipeline.ts
@@ -22,7 +22,7 @@ export const createPipelines = (device: GPUDevice): Pipelines => {
       {
         binding: 2,
         visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform' },
+        buffer: { type: 'uniform', hasDynamicOffset: true },
       },
     ],
   });

--- a/packages/spectrogram/src/magnitudify/runShader.ts
+++ b/packages/spectrogram/src/magnitudify/runShader.ts
@@ -2,6 +2,8 @@ export const runShader = `
 struct MagnitudifyParams {
   windowSize: u32,
   windowCount: u32,
+  slotOffset: u32,
+  padding: u32,
 };
 
 @group(0) @binding(0) var<storage, read_write> signal: array<f32>;
@@ -14,9 +16,10 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let windowCount = params.windowCount;
 
   let sampleIndex = gid.x;
-  let windowIndex = gid.y;
+  let localWindowIndex = gid.y;
+  let windowIndex = (params.slotOffset + localWindowIndex) % windowCount;
   let halfSize = windowSize / 2u;
-  if (sampleIndex >= halfSize || windowIndex >= windowCount) {
+  if (sampleIndex >= halfSize || localWindowIndex >= windowCount) {
     return;
   }
   let complexStride = windowSize + 2u;

--- a/packages/spectrogram/src/magnitudify/state.ts
+++ b/packages/spectrogram/src/magnitudify/state.ts
@@ -41,7 +41,7 @@ export const createStateCell = (
     create: (arg: {
       signal: GPUBuffer;
       magnitude: GPUBuffer;
-      params: GPUBuffer;
+      params: StateParams;
     }): GPUBindGroup =>
       device.createBindGroup({
         label: 'magnitudify-bind-group',
@@ -49,7 +49,13 @@ export const createStateCell = (
         entries: [
           { binding: 0, resource: { buffer: arg.signal } },
           { binding: 1, resource: { buffer: arg.magnitude } },
-          { binding: 2, resource: { buffer: arg.params } },
+          {
+            binding: 2,
+            resource: {
+              buffer: arg.params.buffer,
+              size: arg.params.byteLength,
+            },
+          },
         ],
       }),
     dispose: () => undefined,
@@ -67,7 +73,7 @@ export const createStateCell = (
       const bindGroup = bindGroupCell.get({
         signal,
         magnitude,
-        params: params.buffer,
+        params,
       });
 
       return {

--- a/packages/spectrogram/src/processor.ts
+++ b/packages/spectrogram/src/processor.ts
@@ -1,12 +1,30 @@
 import { createCallLatest } from '@musetric/utils';
 import {
+  expandColumnRanges,
+  markInvalidatedColumns,
+  markShiftColumns,
+  toColumnRanges,
+} from './common/columnRanges.js';
+import {
+  computeBaseColumn,
+  floorMod,
+  fullColumnRange,
+  type SpectrogramColumnRange,
+  type SpectrogramSampleRange,
+} from './common/extConfig.js';
+import {
   createSpectrogramProcessorTimer,
   type SpectrogramProcessorMetrics,
   type SpectrumStage,
   spectrumStages,
 } from './common/processorTimer.js';
 import {
+  mergeSampleInvalidation,
+  type SpectrogramSampleInvalidation,
+} from './common/sampleInvalidations.js';
+import {
   allTrackKeys,
+  mapTrackKeys,
   type SpectrogramConfig,
   type TrackKey,
 } from './config.cross.js';
@@ -14,21 +32,21 @@ import {
   createSpectrogramConfigurator,
   type SpectrogramRuntime,
 } from './configurator.js';
-import { type SpectrogramLaneWork } from './lane/index.js';
+import {
+  type SpectrogramLane,
+  type SpectrogramLaneWork,
+} from './lane/index.js';
 
 export type SpectrogramSamples = Partial<Record<TrackKey, Float32Array>>;
 
-export type SpectrogramSampleInvalidation = {
-  trackKey: TrackKey;
-  frameIndex: number;
-  frameCount: number;
-};
+const emptyInvalidations: readonly SpectrogramSampleInvalidation[] = [];
 
 export type SpectrogramProcessor = {
   render: (
     samples: SpectrogramSamples,
     trackProgress: number,
   ) => Promise<boolean>;
+
   invalidateSamples: (
     invalidations: readonly SpectrogramSampleInvalidation[],
   ) => void;
@@ -39,152 +57,363 @@ export type SpectrogramProcessor = {
 export type CreateSpectrogramProcessorOptions = {
   device: GPUDevice;
   config?: Partial<SpectrogramConfig>;
+
   onMetrics?: (metrics: SpectrogramProcessorMetrics) => void;
 };
-
-const createTrackFlags = (): Record<TrackKey, boolean> =>
-  allTrackKeys.reduce(
-    (acc, key) => {
-      acc[key] = false;
-      return acc;
-    },
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    {} as Record<TrackKey, boolean>,
-  );
 
 const createTrackWork = (
   runtime: SpectrogramRuntime,
 ): Record<TrackKey, SpectrogramLaneWork> =>
-  allTrackKeys.reduce(
-    (acc, key) => {
-      const lane = runtime.config.lanes[key];
-      acc[key] = {
-        spectrogram: lane.showSpectrogram,
-        fundamental: lane.showFundamental,
-      };
-      return acc;
-    },
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    {} as Record<TrackKey, SpectrogramLaneWork>,
-  );
+  mapTrackKeys((key) => {
+    const lane = runtime.config.lanes[key];
+    return {
+      spectrogram: lane.showSpectrogram,
+      fundamental: lane.showFundamental,
+    };
+  });
+
+const hasVisibleWork = (work: SpectrogramLaneWork): boolean =>
+  work.spectrogram || work.fundamental;
+
+type TrackResident = {
+  valid: boolean;
+  samples: Float32Array | undefined;
+  sampleLength: number;
+  baseColumn: number;
+};
+
+type TrackRenderPlan = {
+  present: boolean;
+  clearMissing: boolean;
+  baseColumn: number;
+  baseSlot: number;
+  ranges: readonly SpectrogramColumnRange[];
+  forceFullUpload: boolean;
+  invalidations: readonly SpectrogramSampleRange[];
+};
+
+type RenderResult = {
+  ok: boolean;
+};
+
+type ConfigInvalidationScope = 'all' | ReadonlySet<TrackKey>;
+
+const createTrackResidents = (): Record<TrackKey, TrackResident> =>
+  mapTrackKeys(() => ({
+    valid: false,
+    samples: undefined,
+    sampleLength: 0,
+    baseColumn: 0,
+  }));
+
+const getTrackInvalidations = (
+  invalidatedSamples: readonly SpectrogramSampleInvalidation[],
+  trackKey: TrackKey,
+): SpectrogramSampleRange[] =>
+  invalidatedSamples
+    .filter((invalidation) => invalidation.trackKey === trackKey)
+    .map((invalidation) => ({
+      frameIndex: invalidation.frameIndex,
+      frameCount: invalidation.frameCount,
+    }));
+
+const getMaxAnalysisWindowSize = (
+  runtime: SpectrogramRuntime,
+  work: SpectrogramLaneWork,
+): number => {
+  const spectrogramWindowSize = work.spectrogram
+    ? Math.max(
+        runtime.config.windowSize,
+        ...runtime.config.spectralBands.map((band) => band.windowSize),
+      )
+    : 0;
+  const fundamentalWindowSize = work.fundamental
+    ? runtime.config.windowSize
+    : 0;
+  return Math.max(spectrogramWindowSize, fundamentalWindowSize);
+};
+
+const emptyConfigInvalidationScope: ConfigInvalidationScope = new Set();
+
+const isTrackConfigInvalidated = (
+  scope: ConfigInvalidationScope,
+  key: TrackKey,
+): boolean => scope === 'all' || scope.has(key);
+
+const isLaneComputeConfigEqual = (
+  current: SpectrogramConfig['lanes'][TrackKey],
+  next: SpectrogramConfig['lanes'][TrackKey],
+): boolean =>
+  current.showSpectrogram === next.showSpectrogram &&
+  current.showFundamental === next.showFundamental &&
+  current.truncateAfterPlayhead === next.truncateAfterPlayhead &&
+  current.gainDb === next.gainDb;
+
+const computeInvalidatingConfigKeys: readonly (keyof SpectrogramConfig)[] = [
+  'fourierMode',
+  'windowSize',
+  'sampleRate',
+  'visibleTime',
+  'playheadRatio',
+  'zeroPaddingFactor',
+  'spectralBands',
+  'windowName',
+  'minDecibel',
+  'visual',
+  'minFrequency',
+  'maxFrequency',
+  'viewSize',
+];
+
+const createConfigInvalidationScope = (
+  current: SpectrogramRuntime['config'] | undefined,
+  next: SpectrogramRuntime['config'],
+): ConfigInvalidationScope => {
+  if (!current) {
+    return 'all';
+  }
+
+  for (const key of computeInvalidatingConfigKeys) {
+    if (current[key] !== next[key]) {
+      return 'all';
+    }
+  }
+
+  const changedTracks = new Set<TrackKey>();
+  for (const key of allTrackKeys) {
+    if (!isLaneComputeConfigEqual(current.lanes[key], next.lanes[key])) {
+      changedTracks.add(key);
+    }
+  }
+  return changedTracks;
+};
+
+const fundamentalFilterRadius = 6;
+
+const createRenderPlans = (options: {
+  columns: boolean[];
+  configInvalidationScope: ConfigInvalidationScope;
+  invalidatedSamples: readonly SpectrogramSampleInvalidation[];
+  residents: Record<TrackKey, TrackResident>;
+  runtime: SpectrogramRuntime;
+  samples: SpectrogramSamples;
+  trackProgress: number;
+  work: Record<TrackKey, SpectrogramLaneWork>;
+}): Record<TrackKey, TrackRenderPlan> => {
+  const {
+    columns,
+    configInvalidationScope,
+    invalidatedSamples,
+    residents,
+    runtime,
+    samples,
+    trackProgress,
+    work,
+  } = options;
+  return mapTrackKeys<TrackRenderPlan>((key) => {
+    const trackSamples = samples[key];
+    const resident = residents[key];
+    const present = trackSamples !== undefined;
+    const baseColumn = present
+      ? computeBaseColumn(runtime.config, trackProgress, trackSamples.length)
+      : resident.baseColumn;
+    const baseSlot = floorMod(baseColumn, runtime.config.windowCount);
+    const invalidations = getTrackInvalidations(invalidatedSamples, key);
+    const trackWork = work[key];
+    const forceFullUpload =
+      isTrackConfigInvalidated(configInvalidationScope, key) ||
+      !resident.valid ||
+      resident.samples !== trackSamples ||
+      resident.sampleLength !== (trackSamples?.length ?? 0);
+
+    let ranges: readonly SpectrogramColumnRange[] = [];
+    if (present && hasVisibleWork(trackWork)) {
+      if (forceFullUpload) {
+        ranges = [fullColumnRange(runtime.config, baseColumn)];
+      } else {
+        columns.fill(false);
+        markShiftColumns(columns, baseColumn, resident.baseColumn);
+        markInvalidatedColumns(
+          columns,
+          runtime.config,
+          baseColumn,
+          getMaxAnalysisWindowSize(runtime, trackWork),
+          invalidations,
+        );
+        ranges = toColumnRanges(runtime.config, baseColumn, columns);
+      }
+    }
+
+    return {
+      present,
+      clearMissing: !present && resident.valid,
+      baseColumn,
+      baseSlot,
+      ranges,
+      forceFullUpload,
+      invalidations,
+    };
+  });
+};
+
+type DispatchContext = {
+  plans: Record<TrackKey, TrackRenderPlan>;
+  runtime: SpectrogramRuntime;
+  work: Record<TrackKey, SpectrogramLaneWork>;
+};
+
+const hasSpectrumWork = (ctx: DispatchContext, key: TrackKey): boolean =>
+  ctx.plans[key].ranges.length > 0 && hasVisibleWork(ctx.work[key]);
+
+const hasFundamentalWork = (ctx: DispatchContext, key: TrackKey): boolean =>
+  ctx.plans[key].ranges.length > 0 &&
+  ctx.runtime.config.lanes[key].showFundamental;
+
+const hasRemapWork = (ctx: DispatchContext, key: TrackKey): boolean =>
+  ctx.runtime.config.lanes[key].showSpectrogram &&
+  (ctx.plans[key].ranges.length > 0 || ctx.plans[key].clearMissing);
+
+const stageDispatchKeys = {
+  sliceSamples: 'dispatchSliceSamples',
+  fourierTransform: 'dispatchFourierTransform',
+  magnitudify: 'dispatchMagnitudify',
+  decibelify: 'dispatchDecibelify',
+} as const satisfies Record<SpectrumStage, keyof SpectrogramLane>;
 
 const dispatchSpectrumStage = (
-  encoder: GPUCommandEncoder,
-  options: {
-    dirty: Record<TrackKey, boolean>;
-    marker?: GPUComputePassTimestampWrites;
-    presence: Record<TrackKey, boolean>;
-    runtime: SpectrogramRuntime;
-    stage: SpectrumStage;
-    work: Record<TrackKey, SpectrogramLaneWork>;
-  },
+  pass: GPUComputePassEncoder,
+  ctx: DispatchContext,
+  stage: SpectrumStage,
 ) => {
-  const { dirty, marker, presence, runtime, stage, work } = options;
-  const hasWork = allTrackKeys.some((key) => {
-    if (!presence[key] || !dirty[key]) {
-      return false;
-    }
-    const trackWork = work[key];
-    return trackWork.spectrogram || trackWork.fundamental;
-  });
-  if (!hasWork && !marker) {
-    return;
-  }
-  const pass = encoder.beginComputePass({
-    label: `${stage}-pass`,
-    timestampWrites: marker,
-  });
   for (const key of allTrackKeys) {
-    if (!presence[key] || !dirty[key]) {
+    if (!hasSpectrumWork(ctx, key)) {
       continue;
     }
-    const trackWork = work[key];
-    if (!trackWork.spectrogram && !trackWork.fundamental) {
-      continue;
-    }
-    const { lane } = runtime.tracks[key];
-    if (stage === 'sliceSamples') {
-      lane.dispatchSliceSamples(pass, trackWork);
-    }
-    if (stage === 'fourierTransform') {
-      lane.dispatchFourierTransform(pass, trackWork);
-    }
-    if (stage === 'magnitudify') {
-      lane.dispatchMagnitudify(pass, trackWork);
-    }
-    if (stage === 'decibelify') {
-      lane.dispatchDecibelify(pass, trackWork);
+    const { lane } = ctx.runtime.tracks[key];
+    const trackWork = ctx.work[key];
+    const dispatchStage = lane[stageDispatchKeys[stage]];
+    for (const range of ctx.plans[key].ranges) {
+      dispatchStage(pass, trackWork, range);
     }
   }
+};
+
+const dispatchFundamental = (
+  pass: GPUComputePassEncoder,
+  ctx: DispatchContext,
+) => {
+  const { plans, runtime } = ctx;
+  for (const key of allTrackKeys) {
+    if (!hasFundamentalWork(ctx, key)) {
+      continue;
+    }
+    for (const range of plans[key].ranges) {
+      runtime.tracks[key].lane.dispatchFundamentalScore(pass, range);
+    }
+  }
+  for (const key of allTrackKeys) {
+    if (!hasFundamentalWork(ctx, key)) {
+      continue;
+    }
+    const ranges = expandColumnRanges(
+      runtime.config,
+      plans[key].baseColumn,
+      plans[key].ranges,
+      fundamentalFilterRadius,
+    );
+    for (const range of ranges) {
+      runtime.tracks[key].lane.dispatchFundamentalFilter(pass, range);
+    }
+  }
+};
+
+const dispatchRemap = (pass: GPUComputePassEncoder, ctx: DispatchContext) => {
+  const { plans, runtime } = ctx;
+  for (const key of allTrackKeys) {
+    if (!hasRemapWork(ctx, key)) {
+      continue;
+    }
+    const plan = plans[key];
+    const ranges = plan.clearMissing
+      ? [fullColumnRange(runtime.config, 0)]
+      : plan.ranges;
+    for (const range of ranges) {
+      runtime.tracks[key].remap?.dispatch(pass, range);
+    }
+  }
+};
+
+type ComputeMarkers = {
+  spectrum: Readonly<
+    Record<SpectrumStage, GPUComputePassTimestampWrites | undefined>
+  >;
+  fundamental: GPUComputePassTimestampWrites | undefined;
+  remap: GPUComputePassTimestampWrites | undefined;
+};
+
+const runPass = (
+  encoder: GPUCommandEncoder,
+  label: string,
+  timestampWrites: GPUComputePassTimestampWrites | undefined,
+  body: (pass: GPUComputePassEncoder) => void,
+) => {
+  const pass = encoder.beginComputePass({ label, timestampWrites });
+  body(pass);
   pass.end();
 };
 
-const dispatchFundamentalFrequency = (
+const dispatchCompute = (
   encoder: GPUCommandEncoder,
   options: {
-    dirty: Record<TrackKey, boolean>;
-    marker?: GPUComputePassTimestampWrites;
-    presence: Record<TrackKey, boolean>;
-    runtime: SpectrogramRuntime;
+    ctx: DispatchContext;
+    markers: ComputeMarkers;
   },
 ) => {
-  const { dirty, marker, presence, runtime } = options;
-  const hasWork = allTrackKeys.some(
-    (key) =>
-      presence[key] && dirty[key] && runtime.config.lanes[key].showFundamental,
+  const { ctx, markers } = options;
+  const spectrumHasWork = allTrackKeys.some((key) => hasSpectrumWork(ctx, key));
+  const fundamentalHasWork = allTrackKeys.some((key) =>
+    hasFundamentalWork(ctx, key),
   );
-  if (!hasWork && !marker) {
-    return;
-  }
-  const pass = encoder.beginComputePass({
-    label: 'fundamentalFrequency-pass',
-    timestampWrites: marker,
-  });
-  for (const key of allTrackKeys) {
-    if (
-      presence[key] &&
-      dirty[key] &&
-      runtime.config.lanes[key].showFundamental
-    ) {
-      runtime.tracks[key].lane.dispatchFundamentalFrequency(pass);
-    }
-  }
-  pass.end();
-};
+  const remapHasWork = allTrackKeys.some((key) => hasRemapWork(ctx, key));
+  const profiling =
+    spectrumStages.some((stage) => markers.spectrum[stage]) ||
+    markers.fundamental !== undefined ||
+    markers.remap !== undefined;
 
-const dispatchRemap = (
-  encoder: GPUCommandEncoder,
-  options: {
-    clearMissing: Record<TrackKey, boolean>;
-    dirty: Record<TrackKey, boolean>;
-    marker?: GPUComputePassTimestampWrites;
-    presence: Record<TrackKey, boolean>;
-    runtime: SpectrogramRuntime;
-  },
-) => {
-  const { clearMissing, dirty, marker, presence, runtime } = options;
-  const hasWork = allTrackKeys.some(
-    (key) =>
-      runtime.config.lanes[key].showSpectrogram &&
-      ((presence[key] && dirty[key]) || clearMissing[key]),
-  );
-  if (!hasWork && !marker) {
+  if (profiling) {
+    for (const stage of spectrumStages) {
+      if (spectrumHasWork || markers.spectrum[stage]) {
+        runPass(encoder, `${stage}-pass`, markers.spectrum[stage], (pass) =>
+          dispatchSpectrumStage(pass, ctx, stage),
+        );
+      }
+    }
+    if (fundamentalHasWork || markers.fundamental !== undefined) {
+      runPass(
+        encoder,
+        'fundamentalFrequency-pass',
+        markers.fundamental,
+        (pass) => dispatchFundamental(pass, ctx),
+      );
+    }
+    if (remapHasWork || markers.remap !== undefined) {
+      runPass(encoder, 'remap-pass', markers.remap, (pass) =>
+        dispatchRemap(pass, ctx),
+      );
+    }
     return;
   }
-  const pass = encoder.beginComputePass({
-    label: 'remap-pass',
-    timestampWrites: marker,
-  });
-  for (const key of allTrackKeys) {
-    if (!runtime.config.lanes[key].showSpectrogram) {
-      continue;
-    }
-    if (!((presence[key] && dirty[key]) || clearMissing[key])) {
-      continue;
-    }
-    runtime.tracks[key].remap?.dispatch(pass);
+
+  if (!spectrumHasWork && !fundamentalHasWork && !remapHasWork) {
+    return;
   }
-  pass.end();
+  runPass(encoder, 'pipeline-pass', undefined, (pass) => {
+    for (const stage of spectrumStages) {
+      dispatchSpectrumStage(pass, ctx, stage);
+    }
+    dispatchFundamental(pass, ctx);
+    dispatchRemap(pass, ctx);
+  });
 };
 
 export const createSpectrogramProcessor = (
@@ -194,6 +423,16 @@ export const createSpectrogramProcessor = (
 
   const timer = createSpectrogramProcessorTimer(device, onMetrics);
   const { markers } = timer;
+  const computeMarkers: ComputeMarkers = {
+    spectrum: {
+      sliceSamples: markers.getGpuMarker('sliceSamples'),
+      fourierTransform: markers.getGpuMarker('fourierTransform'),
+      magnitudify: markers.getGpuMarker('magnitudify'),
+      decibelify: markers.getGpuMarker('decibelify'),
+    },
+    fundamental: markers.getGpuMarker('fundamentalFrequency'),
+    remap: markers.getGpuMarker('remap'),
+  };
 
   const configurator = createSpectrogramConfigurator(device, markers);
   configurator.updateConfig(config);
@@ -202,24 +441,24 @@ export const createSpectrogramProcessor = (
     (
       runtime: SpectrogramRuntime,
       samples: SpectrogramSamples,
-      trackProgress: number,
-      dirty: Record<TrackKey, boolean>,
-      contentChanged: Record<TrackKey, boolean>,
+      plans: Record<TrackKey, TrackRenderPlan>,
       work: Record<TrackKey, SpectrogramLaneWork>,
     ) => {
       for (const key of allTrackKeys) {
         const trackSamples = samples[key];
         const trackWork = work[key];
+        const plan = plans[key];
         if (
           trackSamples &&
-          dirty[key] &&
-          (trackWork.spectrogram || trackWork.fundamental)
+          plan.ranges.length > 0 &&
+          hasVisibleWork(trackWork)
         ) {
           runtime.tracks[key].lane.writeSamples(
             trackSamples,
-            trackProgress,
+            plan.baseColumn,
             trackWork,
-            contentChanged[key],
+            plan.forceFullUpload,
+            plan.invalidations,
           );
         }
       }
@@ -228,53 +467,23 @@ export const createSpectrogramProcessor = (
   const createCommand = markers.createCommand(
     (
       runtime: SpectrogramRuntime,
-      dirty: Record<TrackKey, boolean>,
-      presence: Record<TrackKey, boolean>,
-      clearMissing: Record<TrackKey, boolean>,
+      plans: Record<TrackKey, TrackRenderPlan>,
       work: Record<TrackKey, SpectrogramLaneWork>,
     ) => {
       const encoder = device.createCommandEncoder({
         label: 'processor-render-encoder',
       });
       for (const key of allTrackKeys) {
-        if (clearMissing[key]) {
+        if (plans[key].clearMissing) {
           runtime.tracks[key].lane.clear(encoder);
         }
       }
-      for (const key of allTrackKeys) {
-        if (!presence[key] || !dirty[key]) {
-          continue;
-        }
-        const trackWork = work[key];
-        if (!trackWork.spectrogram && !trackWork.fundamental) {
-          continue;
-        }
-        runtime.tracks[key].lane.clearSignal(encoder, trackWork);
-      }
-      for (const stage of spectrumStages) {
-        dispatchSpectrumStage(encoder, {
-          dirty,
-          marker: markers.getGpuMarker(stage),
-          presence,
-          runtime,
-          stage,
-          work,
-        });
-      }
-      dispatchFundamentalFrequency(encoder, {
-        dirty,
-        marker: markers.getGpuMarker('fundamentalFrequency'),
-        presence,
-        runtime,
+      dispatchCompute(encoder, {
+        ctx: { plans, runtime, work },
+        markers: computeMarkers,
       });
-      dispatchRemap(encoder, {
-        clearMissing,
-        dirty,
-        marker: markers.getGpuMarker('remap'),
-        presence,
-        runtime,
-      });
-      runtime.draw.run(encoder);
+      const baseSlots = mapTrackKeys((key) => plans[key].baseSlot);
+      runtime.draw.run(encoder, baseSlots);
       timer.resolve(encoder);
       return encoder.finish();
     },
@@ -287,97 +496,131 @@ export const createSpectrogramProcessor = (
     },
   );
 
-  const lastRendered: Record<TrackKey, boolean> = createTrackFlags();
-  const pendingDirty = new Set<TrackKey>();
-  const pendingContentChanged = new Set<TrackKey>();
-  const lastSamples: Record<TrackKey, Float32Array | undefined> =
-    allTrackKeys.reduce(
-      (acc, key) => {
-        acc[key] = undefined;
-        return acc;
-      },
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-      {} as Record<TrackKey, Float32Array | undefined>,
-    );
+  const residents = createTrackResidents();
+  let reusableColumns: boolean[] = [];
+  let lastConfig: SpectrogramRuntime['config'] | undefined = undefined;
+  let lastBaseSlots: Record<TrackKey, number> | undefined = undefined;
 
-  const render = markers.total(
-    async (samples: SpectrogramSamples, trackProgress: number) => {
+  const isRenderNoop = (plans: Record<TrackKey, TrackRenderPlan>): boolean => {
+    const previousBaseSlots = lastBaseSlots;
+    if (!previousBaseSlots) {
+      return false;
+    }
+    return allTrackKeys.every((key) => {
+      const plan = plans[key];
+      return (
+        plan.ranges.length === 0 &&
+        !plan.clearMissing &&
+        plan.baseSlot === previousBaseSlots[key]
+      );
+    });
+  };
+  let pendingInvalidations: SpectrogramSampleInvalidation[] = [];
+
+  const consumeInvalidations = (
+    samples: SpectrogramSamples,
+  ): readonly SpectrogramSampleInvalidation[] => {
+    if (pendingInvalidations.length < 1) {
+      return emptyInvalidations;
+    }
+    const consumed = pendingInvalidations;
+    pendingInvalidations = [];
+    return consumed.filter(
+      (invalidation) =>
+        invalidation.frameCount > 0 &&
+        samples[invalidation.trackKey] !== undefined,
+    );
+  };
+
+  const commitPlans = (
+    runtime: SpectrogramRuntime,
+    samples: SpectrogramSamples,
+    plans: Record<TrackKey, TrackRenderPlan>,
+    work: Record<TrackKey, SpectrogramLaneWork>,
+  ) => {
+    for (const key of allTrackKeys) {
+      const plan = plans[key];
+      if (plan.clearMissing) {
+        residents[key] = {
+          valid: false,
+          samples: undefined,
+          sampleLength: 0,
+          baseColumn: 0,
+        };
+        continue;
+      }
+      if (plan.present) {
+        residents[key] = {
+          valid: hasVisibleWork(work[key]),
+          samples: samples[key],
+          sampleLength: samples[key]?.length ?? 0,
+          baseColumn: plan.baseColumn,
+        };
+      }
+    }
+    lastConfig = runtime.config;
+  };
+
+  const runRender = markers.total(
+    async (
+      samples: SpectrogramSamples,
+      trackProgress: number,
+    ): Promise<RenderResult> => {
       const runtime = configurator.configure();
       if (!runtime) {
-        return false;
+        return { ok: false };
       }
       timer.configure();
+      const configChanged = runtime.config !== lastConfig;
+      const configInvalidationScope = configChanged
+        ? createConfigInvalidationScope(lastConfig, runtime.config)
+        : emptyConfigInvalidationScope;
       const work = createTrackWork(runtime);
-      for (const key of allTrackKeys) {
-        const current = samples[key];
-        if (current !== undefined && lastSamples[key] !== current) {
-          pendingContentChanged.add(key);
-          pendingDirty.add(key);
-        }
+      if (reusableColumns.length !== runtime.config.windowCount) {
+        reusableColumns = new Array(runtime.config.windowCount).fill(false);
       }
-      const dirty = createTrackFlags();
-      const contentChanged = createTrackFlags();
-      const noExplicitDirty = pendingDirty.size === 0;
-      for (const key of allTrackKeys) {
-        if (noExplicitDirty || pendingDirty.has(key)) {
-          dirty[key] = samples[key] !== undefined;
-        }
-        if (pendingContentChanged.has(key)) {
-          contentChanged[key] = samples[key] !== undefined;
-        }
-      }
-      const presence: Record<TrackKey, boolean> = createTrackFlags();
-      const clearMissing: Record<TrackKey, boolean> = createTrackFlags();
-      for (const key of allTrackKeys) {
-        const has = samples[key] !== undefined;
-        presence[key] = has;
-        clearMissing[key] = dirty[key] && !has && lastRendered[key];
-      }
-      writeBuffers(
+      const invalidatedSamples = consumeInvalidations(samples);
+      const plans = createRenderPlans({
+        columns: reusableColumns,
+        configInvalidationScope,
+        invalidatedSamples,
+        residents,
         runtime,
         samples,
         trackProgress,
-        dirty,
-        contentChanged,
         work,
-      );
-      const command = createCommand(
-        runtime,
-        dirty,
-        presence,
-        clearMissing,
-        work,
-      );
-      await submitCommand(command);
-      for (const key of allTrackKeys) {
-        if (dirty[key] || clearMissing[key]) {
-          lastRendered[key] = presence[key];
-          lastSamples[key] = samples[key];
-        }
+      });
+      if (!onMetrics && !configChanged && isRenderNoop(plans)) {
+        return { ok: true };
       }
-      pendingDirty.clear();
-      pendingContentChanged.clear();
+      writeBuffers(runtime, samples, plans, work);
+      const command = createCommand(runtime, plans, work);
+      await submitCommand(command);
+      commitPlans(runtime, samples, plans, work);
+      lastBaseSlots = mapTrackKeys((key) => plans[key].baseSlot);
+      return { ok: true };
+    },
+  );
+
+  const renderLatest = createCallLatest(
+    async (samples: SpectrogramSamples, trackProgress: number) => {
+      const result = await runRender(samples, trackProgress);
+      if (!result.ok) {
+        return false;
+      }
+      await timer.finish();
       return true;
     },
   );
 
   return {
-    render: createCallLatest(
-      async (samples: SpectrogramSamples, trackProgress: number) => {
-        const ok = await render(samples, trackProgress);
-        if (!ok) {
-          return false;
-        }
-        await timer.finish();
-        return true;
-      },
-    ),
+    render: renderLatest,
     invalidateSamples: (invalidations) => {
       for (const invalidation of invalidations) {
-        pendingDirty.add(invalidation.trackKey);
-        if (invalidation.frameCount > 0) {
-          pendingContentChanged.add(invalidation.trackKey);
-        }
+        pendingInvalidations = mergeSampleInvalidation(
+          pendingInvalidations,
+          invalidation,
+        );
       }
     },
     updateConfig: configurator.updateConfig,

--- a/packages/spectrogram/src/remap/index.ts
+++ b/packages/spectrogram/src/remap/index.ts
@@ -1,4 +1,5 @@
 import { createResourceCell, type ResourceCell } from '@musetric/utils';
+import { type SpectrogramColumnRange } from '../common/extConfig.js';
 import { createPipeline } from './pipeline.js';
 import { createStateCell, type StateArg } from './state.js';
 
@@ -6,7 +7,10 @@ const workgroupSize = 16;
 const storageBuffersPerSpectrum = 2;
 
 export type SpectrogramRemap = {
-  dispatch: (pass: GPUComputePassEncoder) => void;
+  dispatch: (
+    pass: GPUComputePassEncoder,
+    range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+  ) => void;
 };
 
 export const createSpectrogramRemapCell = (
@@ -35,14 +39,18 @@ export const createSpectrogramRemapCell = (
       }
       const pipelines = pipelineCell.get(arg.spectra.length);
       const state = stateCell.get({ ...arg, pipelines });
-      const { width, height } = state.params.value;
-      const xGroups = Math.ceil(width / workgroupSize);
+      const { height } = state.params.value;
       const yGroups = Math.ceil(height / workgroupSize);
 
       return {
-        dispatch: (pass) => {
+        dispatch: (pass, range) => {
+          const { columnCount, byteOffset } = state.params.writeRange(range);
+          if (columnCount <= 0) {
+            return;
+          }
+          const xGroups = Math.ceil(columnCount / workgroupSize);
           pass.setPipeline(state.pipelines.compute);
-          pass.setBindGroup(0, state.bindGroup);
+          pass.setBindGroup(0, state.bindGroup, [byteOffset]);
           pass.dispatchWorkgroups(xGroups, yGroups);
         },
       };

--- a/packages/spectrogram/src/remap/params.ts
+++ b/packages/spectrogram/src/remap/params.ts
@@ -1,4 +1,6 @@
 import { createResourceCell } from '@musetric/utils';
+import { createDynamicUniformParams } from '../common/dynamicUniform.js';
+import { type SpectrogramColumnRange } from '../common/extConfig.js';
 import { type SpectrogramConfig } from '../config.cross.js';
 import { type SpectrogramBandSpectrum } from '../lane/index.js';
 
@@ -26,6 +28,8 @@ export type RemapParams = {
   frequencyTiltMinGain: number;
   frequencyTiltMaxGain: number;
   displayGamma: number;
+  slotOffset: number;
+  columnCount: number;
   bands: RemapBandParams[];
 };
 
@@ -37,6 +41,8 @@ export type RemapParamsArg = {
 
 const headerByteLength = 64;
 const bandByteLength = 32;
+export const slotOffsetByteOffset = 52;
+export const columnCountByteOffset = 56;
 
 const toParams = (arg: RemapParamsArg): RemapParams => {
   const { sampleRate, minFrequency, maxFrequency, viewSize, minDecibel } =
@@ -59,6 +65,8 @@ const toParams = (arg: RemapParamsArg): RemapParams => {
     frequencyTiltMinGain: visual.frequencyTiltMinGain,
     frequencyTiltMaxGain: visual.frequencyTiltMaxGain,
     displayGamma: visual.displayGamma,
+    slotOffset: 0,
+    columnCount: width,
     bands: arg.spectra.map((spectrum) => ({
       windowSize: spectrum.windowSize,
       halfSize: spectrum.windowSize / 2,
@@ -74,6 +82,13 @@ const toParams = (arg: RemapParamsArg): RemapParams => {
 export type StateParams = {
   value: RemapParams;
   buffer: GPUBuffer;
+  byteLength: number;
+  writeRange: (
+    range?: Pick<SpectrogramColumnRange, 'slotOffset' | 'columnCount'>,
+  ) => {
+    columnCount: number;
+    byteOffset: number;
+  };
 };
 
 const areSpectraEqual = (
@@ -98,44 +113,61 @@ export const createParamsCell = (device: GPUDevice) =>
   createResourceCell({
     create: (arg: RemapParamsArg): StateParams => {
       const value = toParams(arg);
-      const array = new DataView(
-        new ArrayBuffer(headerByteLength + value.bands.length * bandByteLength),
-      );
-      array.setUint32(0, value.width, true);
-      array.setUint32(4, value.height, true);
-      array.setFloat32(8, value.sampleRate, true);
-      array.setFloat32(12, value.logMinFrequency, true);
-      array.setFloat32(16, value.logFrequencyRange, true);
-      array.setFloat32(20, value.decibelFactor, true);
-      array.setFloat32(24, value.gain, true);
-      array.setFloat32(28, value.gateFloorDb, true);
-      array.setFloat32(32, value.gateRangeDb, true);
-      array.setFloat32(36, value.frequencyTiltSlope, true);
-      array.setFloat32(40, value.frequencyTiltMinGain, true);
-      array.setFloat32(44, value.frequencyTiltMaxGain, true);
-      array.setFloat32(48, value.displayGamma, true);
-      // 52..63 padding (16-byte alignment for uniform buffer)
-      value.bands.forEach((band, index) => {
-        const offset = headerByteLength + index * bandByteLength;
-        array.setFloat32(offset, band.windowSize, true);
-        array.setFloat32(offset + 4, band.halfSize, true);
-        array.setFloat32(offset + 8, band.minFrequency, true);
-        array.setFloat32(offset + 12, band.fullMinFrequency, true);
-        array.setFloat32(offset + 16, band.fullMaxFrequency, true);
-        array.setFloat32(offset + 20, band.maxFrequency, true);
-        array.setFloat32(offset + 24, band.inverseReferenceMagnitude, true);
-      });
-
-      const buffer = device.createBuffer({
+      const byteLength = headerByteLength + value.bands.length * bandByteLength;
+      const params = createDynamicUniformParams(device, {
         label: 'remap-params-buffer',
-        size: array.byteLength,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        byteLength,
+        capacity: value.width,
       });
-      device.queue.writeBuffer(buffer, 0, array.buffer);
 
       return {
         value,
-        buffer,
+        buffer: params.buffer,
+        byteLength: params.byteLength,
+        writeRange: (range) => {
+          const columnCount = range ? range.columnCount : value.width;
+          const byteOffset = params.write((view) => {
+            view.setUint32(0, value.width, true);
+            view.setUint32(4, value.height, true);
+            view.setFloat32(8, value.sampleRate, true);
+            view.setFloat32(12, value.logMinFrequency, true);
+            view.setFloat32(16, value.logFrequencyRange, true);
+            view.setFloat32(20, value.decibelFactor, true);
+            view.setFloat32(24, value.gain, true);
+            view.setFloat32(28, value.gateFloorDb, true);
+            view.setFloat32(32, value.gateRangeDb, true);
+            view.setFloat32(36, value.frequencyTiltSlope, true);
+            view.setFloat32(40, value.frequencyTiltMinGain, true);
+            view.setFloat32(44, value.frequencyTiltMaxGain, true);
+            view.setFloat32(48, value.displayGamma, true);
+            view.setUint32(
+              slotOffsetByteOffset,
+              range ? range.slotOffset : value.slotOffset,
+              true,
+            );
+            view.setUint32(columnCountByteOffset, columnCount, true);
+            view.setUint32(60, 0, true);
+            value.bands.forEach((band, index) => {
+              const offset = headerByteLength + index * bandByteLength;
+              view.setFloat32(offset, band.windowSize, true);
+              view.setFloat32(offset + 4, band.halfSize, true);
+              view.setFloat32(offset + 8, band.minFrequency, true);
+              view.setFloat32(offset + 12, band.fullMinFrequency, true);
+              view.setFloat32(offset + 16, band.fullMaxFrequency, true);
+              view.setFloat32(offset + 20, band.maxFrequency, true);
+              view.setFloat32(
+                offset + 24,
+                band.inverseReferenceMagnitude,
+                true,
+              );
+              view.setFloat32(offset + 28, 0, true);
+            });
+          });
+          return {
+            columnCount,
+            byteOffset,
+          };
+        },
       };
     },
     dispose: (params) => {

--- a/packages/spectrogram/src/remap/pipeline.ts
+++ b/packages/spectrogram/src/remap/pipeline.ts
@@ -30,7 +30,7 @@ export const createPipeline = (device: GPUDevice, spectrumCount: number) => {
       {
         binding: 1,
         visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform' },
+        buffer: { type: 'uniform', hasDynamicOffset: true },
       },
       ...spectrumEntries,
     ],

--- a/packages/spectrogram/src/remap/shader.ts
+++ b/packages/spectrogram/src/remap/shader.ts
@@ -59,8 +59,8 @@ struct RemapParams {
   frequencyTiltMinGain: f32,
   frequencyTiltMaxGain: f32,
   displayGamma: f32,
-  padding0: f32,
-  padding1: f32,
+  slotOffset: u32,
+  columnCount: u32,
   padding2: f32,
   bands: array<vec4f, ${spectrumCount * 2}>,
 };
@@ -161,11 +161,12 @@ ${createSpectrumSampling(spectrumCount)}
 fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
   let width = params.width;
   let height = params.height;
-  let x = gid.x;
+  let localX = gid.x;
   let y = gid.y;
-  if (x >= width || y >= height) {
+  if (localX >= params.columnCount || y >= height) {
     return;
   }
+  let x = (params.slotOffset + localX) % width;
   let frequency = frequencyAtRow(y);
   let intensity = baseDisplayIntensity(
     x,

--- a/packages/spectrogram/src/remap/state.ts
+++ b/packages/spectrogram/src/remap/state.ts
@@ -49,7 +49,7 @@ export const createStateCell = (
     create: (arg: {
       spectra: SpectrogramBandSpectrum[];
       texture: GPUTextureView;
-      params: GPUBuffer;
+      params: StateParams;
       bindGroupLayout: GPUBindGroupLayout;
     }): GPUBindGroup =>
       device.createBindGroup({
@@ -57,7 +57,13 @@ export const createStateCell = (
         layout: arg.bindGroupLayout,
         entries: [
           { binding: 0, resource: arg.texture },
-          { binding: 1, resource: { buffer: arg.params } },
+          {
+            binding: 1,
+            resource: {
+              buffer: arg.params.buffer,
+              size: arg.params.byteLength,
+            },
+          },
           ...arg.spectra.flatMap((spectrum, index) => [
             {
               binding: 2 + index * 2,
@@ -85,7 +91,7 @@ export const createStateCell = (
       const bindGroup = bindGroupCell.get({
         spectra,
         texture,
-        params: params.buffer,
+        params,
         bindGroupLayout: pipelines.bindGroupLayout,
       });
 

--- a/packages/spectrogram/src/sliceSamples/__test__/sliceSamples.test.ts
+++ b/packages/spectrogram/src/sliceSamples/__test__/sliceSamples.test.ts
@@ -1,0 +1,297 @@
+import { windowFunctions } from '@musetric/fft';
+import { createGpuContext } from '@musetric/utils/gpu';
+import { describe, expect, it } from 'vitest';
+import {
+  assertClose,
+  buildConfig,
+  createRamp,
+  extendConfig,
+  readFloats,
+} from '../../__test__/common.js';
+import {
+  markInvalidatedColumns,
+  markShiftColumns,
+  toColumnRanges,
+} from '../../common/columnRanges.js';
+import {
+  computeBaseColumn,
+  type ExtSpectrogramConfig,
+  floorMod,
+  type SpectrogramColumnRange,
+  windowStartForColumn,
+} from '../../common/extConfig.js';
+import { createSignalBufferCell } from '../../state/signal.js';
+import { createSpectrogramSliceSamplesCell } from '../index.js';
+
+const { device } = await createGpuContext();
+
+type SliceHandle = ReturnType<
+  ReturnType<typeof createSpectrogramSliceSamplesCell>['get']
+>;
+
+const windowSize = 8;
+const width = 5;
+const sampleRate = 16;
+const columnStep = 4;
+const signalStride = windowSize + 2;
+const windowFunction = windowFunctions.hamming(windowSize);
+const samples = createRamp(64);
+
+const config = extendConfig(
+  buildConfig({
+    windowSize,
+    zeroPaddingFactor: 1,
+    windowName: 'hamming',
+    sampleRate,
+    visibleTime: 1,
+    playheadRatio: 0,
+    viewSize: { width, height: 4 },
+  }),
+);
+
+const withSlice = async <T>(
+  sliceConfig: ExtSpectrogramConfig,
+  bandWindowSize: number,
+  windowCount: number,
+  fn: (slice: SliceHandle, signal: GPUBuffer) => Promise<T>,
+): Promise<T> => {
+  const signalCell = createSignalBufferCell(device);
+  const sliceCell = createSpectrogramSliceSamplesCell(device);
+  try {
+    const signal = signalCell.get({ windowSize: bandWindowSize, windowCount });
+    const slice = sliceCell.get({ out: signal, config: sliceConfig });
+    return await fn(slice, signal);
+  } finally {
+    sliceCell.dispose();
+    signalCell.dispose();
+  }
+};
+
+const trackProgressForWindowStart = (windowStart: number): number =>
+  (windowStart + windowSize) / samples.length;
+
+const withTwoSlices = async <T>(
+  sliceConfig: ExtSpectrogramConfig,
+  bandWindowSize: number,
+  windowCount: number,
+  fn: (
+    incremental: SliceHandle,
+    incrementalSignal: GPUBuffer,
+    full: SliceHandle,
+    fullSignal: GPUBuffer,
+  ) => Promise<T>,
+): Promise<T> =>
+  withSlice(
+    sliceConfig,
+    bandWindowSize,
+    windowCount,
+    async (incremental, incrementalSignal) =>
+      withSlice(
+        sliceConfig,
+        bandWindowSize,
+        windowCount,
+        async (full, fullSignal) =>
+          fn(incremental, incrementalSignal, full, fullSignal),
+      ),
+  );
+
+const slotOf = (baseColumn: number, screenColumn: number): number =>
+  floorMod(baseColumn + screenColumn, width);
+
+const assertColumns = (
+  actual: Float32Array,
+  windowStart: number,
+  baseColumn: number,
+): void => {
+  for (let w = 0; w < width; w += 1) {
+    const expected = new Float32Array(windowSize);
+    for (let i = 0; i < windowSize; i += 1) {
+      expected[i] = (windowStart + columnStep * w + i) * windowFunction[i];
+    }
+    const offset = signalStride * slotOf(baseColumn, w);
+    assertClose(
+      `column ${w}`,
+      actual.slice(offset, offset + windowSize),
+      expected,
+    );
+  }
+};
+
+const fullRange = (baseColumn: number): SpectrogramColumnRange => ({
+  screenBase: 0,
+  slotOffset: floorMod(baseColumn, width),
+  columnCount: width,
+});
+
+const runSlice = async (
+  slice: SliceHandle,
+  signal: GPUBuffer,
+  baseColumn: number,
+  range: SpectrogramColumnRange,
+): Promise<Float32Array> => {
+  slice.write(samples, baseColumn, false, false, []);
+  const encoder = device.createCommandEncoder();
+  slice.run(encoder, range);
+  device.queue.submit([encoder.finish()]);
+  await device.queue.onSubmittedWorkDone();
+  return readFloats(device, signal, signalStride * width);
+};
+
+describe('sliceSamples', () => {
+  it('writes windowed slices into the column ring from a fresh upload', async () => {
+    await withSlice(config, windowSize, width, async (slice, signal) => {
+      const baseColumn = computeBaseColumn(
+        config,
+        trackProgressForWindowStart(0),
+        samples.length,
+      );
+      const windowStart = windowStartForColumn(config, windowSize, baseColumn);
+      const result = await runSlice(
+        slice,
+        signal,
+        baseColumn,
+        fullRange(baseColumn),
+      );
+      assertColumns(result, windowStart, baseColumn);
+    });
+  });
+
+  it('reuses the ring and only re-slices the exposed column after a scroll', async () => {
+    await withSlice(config, windowSize, width, async (slice, signal) => {
+      const firstBase = computeBaseColumn(
+        config,
+        trackProgressForWindowStart(0),
+        samples.length,
+      );
+      const first = await runSlice(
+        slice,
+        signal,
+        firstBase,
+        fullRange(firstBase),
+      );
+      assertColumns(
+        first,
+        windowStartForColumn(config, windowSize, firstBase),
+        firstBase,
+      );
+
+      const secondBase = computeBaseColumn(
+        config,
+        trackProgressForWindowStart(columnStep),
+        samples.length,
+      );
+      const delta = secondBase - firstBase;
+      expect(delta).toBe(1);
+      const exposed: SpectrogramColumnRange = {
+        screenBase: width - delta,
+        slotOffset: floorMod(secondBase + width - delta, width),
+        columnCount: delta,
+      };
+      const second = await runSlice(slice, signal, secondBase, exposed);
+      assertColumns(
+        second,
+        windowStartForColumn(config, windowSize, secondBase),
+        secondBase,
+      );
+
+      expect(second).not.toStrictEqual(first);
+    });
+  });
+
+  it('matches a full slice for fractional-step scroll plus invalidation', async () => {
+    const fractionalWidth = 7;
+    const fractionalWindowSize = 16;
+    const fractionalSignalStride = fractionalWindowSize + 2;
+    const fractionalConfig = extendConfig(
+      buildConfig({
+        windowSize: fractionalWindowSize,
+        zeroPaddingFactor: 1,
+        windowName: 'hamming',
+        sampleRate: 31,
+        visibleTime: 1,
+        playheadRatio: 0,
+        viewSize: { width: fractionalWidth, height: 4 },
+      }),
+    );
+    expect(Number.isInteger(fractionalConfig.columnStep)).toBe(false);
+
+    const length = 256;
+    const incrementalSamples = new Float32Array(length);
+    const chunk = { frameIndex: 60, frameCount: 24 };
+
+    const firstBase = computeBaseColumn(fractionalConfig, 0.3, length);
+    const secondBase = firstBase + 2;
+    const columns = new Array<boolean>(fractionalWidth).fill(false);
+    markShiftColumns(columns, secondBase, firstBase);
+    markInvalidatedColumns(
+      columns,
+      fractionalConfig,
+      secondBase,
+      fractionalWindowSize,
+      [chunk],
+    );
+    const ranges = toColumnRanges(fractionalConfig, secondBase, columns);
+    expect(ranges.length).toBeGreaterThan(1);
+
+    const fullRangeAt = (baseColumn: number): SpectrogramColumnRange => ({
+      screenBase: 0,
+      slotOffset: floorMod(baseColumn, fractionalWidth),
+      columnCount: fractionalWidth,
+    });
+
+    const dispatchRanges = async (
+      slice: SliceHandle,
+      columnRanges: readonly SpectrogramColumnRange[],
+    ): Promise<void> => {
+      const encoder = device.createCommandEncoder();
+      const slicePass = encoder.beginComputePass();
+      for (const range of columnRanges) {
+        slice.dispatch(slicePass, range);
+      }
+      slicePass.end();
+      device.queue.submit([encoder.finish()]);
+      await device.queue.onSubmittedWorkDone();
+    };
+
+    await withTwoSlices(
+      fractionalConfig,
+      fractionalWindowSize,
+      fractionalWidth,
+      async (incremental, incrementalSignal, full, fullSignal) => {
+        incremental.write(incrementalSamples, firstBase, false, true, []);
+        await dispatchRanges(incremental, [fullRangeAt(firstBase)]);
+
+        for (
+          let index = chunk.frameIndex;
+          index < chunk.frameIndex + chunk.frameCount;
+          index += 1
+        ) {
+          incrementalSamples[index] = index / 100;
+        }
+
+        incremental.write(incrementalSamples, secondBase, false, false, [
+          chunk,
+        ]);
+        await dispatchRanges(incremental, ranges);
+
+        full.write(
+          Float32Array.from(incrementalSamples),
+          secondBase,
+          false,
+          true,
+          [],
+        );
+        await dispatchRanges(full, [fullRangeAt(secondBase)]);
+
+        const count = fractionalSignalStride * fractionalWidth;
+        const incrementalResult = await readFloats(
+          device,
+          incrementalSignal,
+          count,
+        );
+        const fullResult = await readFloats(device, fullSignal, count);
+        assertClose('fractional partial slice', incrementalResult, fullResult);
+      },
+    );
+  });
+});

--- a/packages/spectrogram/src/sliceSamples/index.ts
+++ b/packages/spectrogram/src/sliceSamples/index.ts
@@ -1,18 +1,25 @@
 import { type ResourceCell } from '@musetric/utils';
-import { ringStartByteOffset } from './params.js';
+import {
+  type SpectrogramColumnRange,
+  type SpectrogramSampleRange,
+} from '../common/extConfig.js';
 import { createPipeline } from './pipeline.js';
 import { createStateCell, type StateArg } from './state.js';
 
 const workgroupSize = 64;
 
 export type SpectrogramSliceSamples = {
-  run: (encoder: GPUCommandEncoder) => void;
-  dispatch: (pass: GPUComputePassEncoder) => void;
+  run: (encoder: GPUCommandEncoder, range: SpectrogramColumnRange) => void;
+  dispatch: (
+    pass: GPUComputePassEncoder,
+    range: SpectrogramColumnRange,
+  ) => void;
   write: (
     samples: Float32Array,
-    trackProgress: number,
+    baseColumn: number,
     truncateAfterPlayhead: boolean,
-    contentChanged: boolean,
+    forceFullUpload: boolean,
+    invalidations: readonly SpectrogramSampleRange[],
   ) => void;
 };
 
@@ -22,54 +29,56 @@ export const createSpectrogramSliceSamplesCell = (
 ): ResourceCell<StateArg, SpectrogramSliceSamples> => {
   const pipeline = createPipeline(device);
   const stateCell = createStateCell(device, pipeline);
-  const ringStartScratch = new Uint32Array(1);
 
   return {
     get: (arg) => {
       const state = stateCell.get(arg);
 
-      const dispatch = (pass: GPUComputePassEncoder) => {
-        const { windowSize, windowCount } = state.params.value;
-        const xGroups = Math.ceil(windowSize / workgroupSize);
+      const dispatch = (
+        pass: GPUComputePassEncoder,
+        range: SpectrogramColumnRange,
+      ) => {
+        if (range.columnCount <= 0) {
+          return;
+        }
+        const { paddedWindowSize } = state.params.value;
+        const byteOffset = state.params.writeRange(range);
+        const xGroups = Math.ceil(paddedWindowSize / workgroupSize);
         pass.setPipeline(state.pipeline);
-        pass.setBindGroup(0, state.bindGroup);
-        pass.dispatchWorkgroups(xGroups, windowCount);
+        pass.setBindGroup(0, state.bindGroup, [byteOffset]);
+        pass.dispatchWorkgroups(xGroups, range.columnCount);
       };
 
       return {
-        run: (encoder) => {
-          const { paddedWindowSize, windowSize } = state.params.value;
-          if (paddedWindowSize > windowSize) {
-            encoder.clearBuffer(state.out);
-          }
+        run: (encoder, range) => {
           const pass = encoder.beginComputePass({
             label: 'slice-samples-pass',
             timestampWrites: marker,
           });
-          dispatch(pass);
+          dispatch(pass, range);
           pass.end();
         },
         dispatch,
         write: (
           samples,
-          trackProgress,
+          baseColumn,
           truncateAfterPlayhead,
-          contentChanged,
+          forceFullUpload,
+          invalidations,
         ) => {
-          const ringStart = state.samples.write(
+          const writeResult = state.samples.write(
             samples,
-            trackProgress,
+            baseColumn,
             state.config,
             truncateAfterPlayhead,
-            state.sampleOffset,
-            contentChanged,
+            forceFullUpload,
+            invalidations,
           );
-          ringStartScratch[0] = ringStart;
-          device.queue.writeBuffer(
-            state.params.buffer,
-            ringStartByteOffset,
-            ringStartScratch,
-          );
+          state.params.setFrame({
+            baseColumn,
+            baseWindowStart: writeResult.baseWindowStart,
+            ringStart: writeResult.ringStart,
+          });
         },
       };
     },

--- a/packages/spectrogram/src/sliceSamples/params.ts
+++ b/packages/spectrogram/src/sliceSamples/params.ts
@@ -1,5 +1,9 @@
 import { createResourceCell } from '@musetric/utils';
-import { type ExtSpectrogramConfig } from '../common/extConfig.js';
+import { createDynamicUniformParams } from '../common/dynamicUniform.js';
+import {
+  type ExtSpectrogramConfig,
+  type SpectrogramColumnRange,
+} from '../common/extConfig.js';
 
 export type SliceSamplesParams = {
   windowSize: number;
@@ -10,9 +14,12 @@ export type SliceSamplesParams = {
   step: number;
 };
 
-// Byte offset of the per-frame `ringStart` field inside the params buffer.
-// Patched every frame from the sample ring without rebuilding the buffer.
 export const ringStartByteOffset = 24;
+export const slotOffsetByteOffset = 28;
+export const screenBaseByteOffset = 32;
+export const baseColumnByteOffset = 36;
+export const baseWindowStartByteOffset = 40;
+const paramsByteLength = 48;
 
 const toParams = (config: ExtSpectrogramConfig): SliceSamplesParams => {
   const {
@@ -24,45 +31,65 @@ const toParams = (config: ExtSpectrogramConfig): SliceSamplesParams => {
   } = config;
   const paddedWindowSize = windowSize * zeroPaddingFactor;
   const visibleSamples = Math.ceil(visibleTime * sampleRate + windowSize);
-  const step = (visibleSamples - windowSize) / (windowCount - 1);
   return {
     windowSize,
     paddedWindowSize,
     signalStride: paddedWindowSize + 2,
     windowCount,
     visibleSamples,
-    step,
+    step: config.columnStep,
   };
 };
 
 export type StateParams = {
   value: SliceSamplesParams;
   buffer: GPUBuffer;
+  byteLength: number;
+  setFrame: (frame: {
+    baseColumn: number;
+    baseWindowStart: number;
+    ringStart: number;
+  }) => void;
+  writeRange: (range: SpectrogramColumnRange) => number;
 };
 
 export const createParamsCell = (device: GPUDevice) =>
   createResourceCell({
     create: (config: ExtSpectrogramConfig): StateParams => {
       const value = toParams(config);
-      const array = new DataView(new ArrayBuffer(32));
-      array.setUint32(0, value.windowSize, true);
-      array.setUint32(4, value.paddedWindowSize, true);
-      array.setUint32(8, value.signalStride, true);
-      array.setUint32(12, value.windowCount, true);
-      array.setUint32(16, value.visibleSamples, true);
-      array.setFloat32(20, value.step, true);
-      array.setUint32(ringStartByteOffset, 0, true);
-
-      const buffer = device.createBuffer({
+      const params = createDynamicUniformParams(device, {
         label: 'slice-samples-params-buffer',
-        size: array.byteLength,
-        usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+        byteLength: paramsByteLength,
+        capacity: value.windowCount,
       });
-      device.queue.writeBuffer(buffer, 0, array.buffer);
+      let ringStart = 0;
+      let baseColumn = 0;
+      let baseWindowStart = 0;
 
       return {
         value,
-        buffer,
+        buffer: params.buffer,
+        byteLength: params.byteLength,
+        setFrame: (frame) => {
+          baseColumn = frame.baseColumn;
+          baseWindowStart = frame.baseWindowStart;
+          ringStart = frame.ringStart;
+        },
+        writeRange: (range) =>
+          params.write((view) => {
+            view.setUint32(0, value.windowSize, true);
+            view.setUint32(4, value.paddedWindowSize, true);
+            view.setUint32(8, value.signalStride, true);
+            view.setUint32(12, value.windowCount, true);
+            view.setUint32(16, value.visibleSamples, true);
+            view.setFloat32(20, value.step, true);
+            view.setUint32(ringStartByteOffset, ringStart, true);
+            view.setUint32(slotOffsetByteOffset, range.slotOffset, true);
+            view.setUint32(screenBaseByteOffset, range.screenBase, true);
+            view.setInt32(baseColumnByteOffset, baseColumn, true);
+            view.setInt32(baseWindowStartByteOffset, baseWindowStart, true);
+            view.setUint32(44, 0, true);
+          }),
       };
     },
     dispose: (params) => {
@@ -73,5 +100,6 @@ export const createParamsCell = (device: GPUDevice) =>
       current.windowCount === next.windowCount &&
       current.sampleRate === next.sampleRate &&
       current.visibleTime === next.visibleTime &&
-      current.zeroPaddingFactor === next.zeroPaddingFactor,
+      current.zeroPaddingFactor === next.zeroPaddingFactor &&
+      current.columnStep === next.columnStep,
   });

--- a/packages/spectrogram/src/sliceSamples/pipeline.ts
+++ b/packages/spectrogram/src/sliceSamples/pipeline.ts
@@ -1,13 +1,42 @@
 import { shader } from './shader.js';
 
 export const createPipeline = (device: GPUDevice) => {
+  const layout = device.createBindGroupLayout({
+    label: 'slice-samples-bind-group-layout',
+    entries: [
+      {
+        binding: 0,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'read-only-storage' },
+      },
+      {
+        binding: 1,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'storage' },
+      },
+      {
+        binding: 2,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'uniform', hasDynamicOffset: true },
+      },
+      {
+        binding: 3,
+        visibility: GPUShaderStage.COMPUTE,
+        buffer: { type: 'read-only-storage' },
+      },
+    ],
+  });
+  const pipelineLayout = device.createPipelineLayout({
+    label: 'slice-samples-pipeline-layout',
+    bindGroupLayouts: [layout],
+  });
   const module = device.createShaderModule({
     label: 'slice-samples-shader',
     code: shader,
   });
   return device.createComputePipeline({
     label: 'slice-samples-pipeline',
-    layout: 'auto',
+    layout: pipelineLayout,
     compute: { module, entryPoint: 'main' },
   });
 };

--- a/packages/spectrogram/src/sliceSamples/samples.ts
+++ b/packages/spectrogram/src/sliceSamples/samples.ts
@@ -1,24 +1,28 @@
 import { createResourceCell } from '@musetric/utils';
-import { type ExtSpectrogramConfig } from '../common/extConfig.js';
+import {
+  type ExtSpectrogramConfig,
+  floorMod,
+  type SpectrogramSampleRange,
+  windowStartForColumn,
+} from '../common/extConfig.js';
+
+export type StateSamplesWriteResult = {
+  baseWindowStart: number;
+  ringStart: number;
+};
 
 export type StateSamples = {
   buffer: GPUBuffer;
   array: Float32Array;
-  /**
-   * Uploads the visible samples into the GPU ring buffer and returns the
-   * `ringStart` rotation (= absolute window start modulo ring length) that the
-   * slice shader uses to read the buffer. Only the samples that actually
-   * changed since the previous frame are uploaded: the window edge exposed by
-   * the playhead movement plus the region whose truncation flipped.
-   */
+
   write: (
     samples: Float32Array,
-    trackProgress: number,
+    baseColumn: number,
     config: ExtSpectrogramConfig,
     truncateAfterPlayhead: boolean,
-    sampleOffset: number,
-    contentChanged: boolean,
-  ) => number;
+    forceFullUpload: boolean,
+    invalidations: readonly SpectrogramSampleRange[],
+  ) => StateSamplesWriteResult;
 };
 
 type ResidentState = {
@@ -28,9 +32,6 @@ type ResidentState = {
   limit: number;
   samples: Float32Array | undefined;
 };
-
-const floorMod = (value: number, modulus: number): number =>
-  ((value % modulus) + modulus) % modulus;
 
 export const createStateSamplesCell = (device: GPUDevice) =>
   createResourceCell({
@@ -56,40 +57,47 @@ export const createStateSamplesCell = (device: GPUDevice) =>
         array,
         write: (
           samples,
-          trackProgress,
+          baseColumn,
           config,
           truncateAfterPlayhead,
-          sampleOffset,
-          contentChanged,
+          forceFullUpload,
+          invalidations,
         ) => {
           const { windowSize, playheadRatio, sampleRate, visibleTime } = config;
           const beforeSamples =
             visibleTime * playheadRatio * sampleRate + windowSize;
           const totalVisibleSamples = visibleTime * sampleRate + windowSize;
-          const windowStart = Math.floor(
-            trackProgress * samples.length - beforeSamples + sampleOffset,
+          const windowStart = windowStartForColumn(
+            config,
+            windowSize,
+            baseColumn,
           );
           const limit = truncateAfterPlayhead
             ? Math.min(totalVisibleSamples, Math.floor(beforeSamples))
             : totalVisibleSamples;
           const ringStart = floorMod(windowStart, ringLength);
 
-          // Writes effective(windowStart + i) for i in [0, count) into the ring
-          // slots ((windowStart + i) mod ringLength), splitting at the wrap.
           const writeRange = (from: number, count: number): void => {
             if (count <= 0) {
               return;
             }
-            const scratch =
-              count === ringLength ? array : new Float32Array(count);
-            for (let i = 0; i < count; i += 1) {
-              const sampleIndex = from + i;
-              const local = sampleIndex - windowStart;
-              const inside =
-                sampleIndex >= 0 &&
-                sampleIndex < samples.length &&
-                local < limit;
-              scratch[i] = inside ? samples[sampleIndex] : 0;
+            const dataEnd = Math.min(samples.length, windowStart + limit);
+            const inStart = Math.max(from, 0);
+            const inEnd = Math.min(from + count, dataEnd);
+            const localInStart = inStart - from;
+            const localInEnd = inEnd - from;
+            const reused = count === ringLength;
+            const scratch = reused ? array : new Float32Array(count);
+            if (reused) {
+              if (localInStart > 0) {
+                scratch.fill(0, 0, localInStart);
+              }
+              if (localInEnd < count) {
+                scratch.fill(0, localInEnd, count);
+              }
+            }
+            if (localInEnd > localInStart) {
+              scratch.set(samples.subarray(inStart, inEnd), localInStart);
             }
             const startSlot = floorMod(from, ringLength);
             const firstCount = Math.min(count, ringLength - startSlot);
@@ -113,7 +121,7 @@ export const createStateSamplesCell = (device: GPUDevice) =>
 
           const full =
             !resident.valid ||
-            contentChanged ||
+            forceFullUpload ||
             resident.samples !== samples ||
             resident.sampleLength !== samples.length ||
             Math.abs(windowStart - resident.windowStart) >= ringLength;
@@ -123,13 +131,10 @@ export const createStateSamplesCell = (device: GPUDevice) =>
           } else {
             const shift = windowStart - resident.windowStart;
             if (shift > 0) {
-              // New samples exposed on the leading (right) edge.
               writeRange(resident.windowStart + ringLength, shift);
             } else if (shift < 0) {
-              // New samples exposed on the trailing (left) edge (rewind/drag).
               writeRange(windowStart, -shift);
             }
-            // Region whose truncation gate flipped between frames.
             const currentTruncation = windowStart + limit;
             const previousTruncation = resident.windowStart + resident.limit;
             const lo = Math.max(
@@ -141,6 +146,14 @@ export const createStateSamplesCell = (device: GPUDevice) =>
               windowStart + ringLength,
             );
             writeRange(lo, hi - lo);
+            for (const invalidation of invalidations) {
+              const from = Math.max(invalidation.frameIndex, windowStart);
+              const to = Math.min(
+                invalidation.frameIndex + invalidation.frameCount,
+                windowStart + ringLength,
+              );
+              writeRange(from, to - from);
+            }
           }
 
           resident.valid = true;
@@ -149,7 +162,10 @@ export const createStateSamplesCell = (device: GPUDevice) =>
           resident.limit = limit;
           resident.samples = samples;
 
-          return ringStart;
+          return {
+            baseWindowStart: windowStart,
+            ringStart,
+          };
         },
       };
     },

--- a/packages/spectrogram/src/sliceSamples/shader.ts
+++ b/packages/spectrogram/src/sliceSamples/shader.ts
@@ -7,6 +7,10 @@ struct SliceSamplesParams {
   visibleSamples : u32,
   step : f32,
   ringStart : u32,
+  slotOffset : u32,
+  screenBase : u32,
+  baseColumn : i32,
+  baseWindowStart : i32,
 };
 
 @group(0) @binding(0) var<storage, read> samples : array<f32>;
@@ -14,26 +18,39 @@ struct SliceSamplesParams {
 @group(0) @binding(2) var<uniform> params : SliceSamplesParams;
 @group(0) @binding(3) var<storage, read> windowFunction : array<f32>;
 
+fn roundToI32(value: f32) -> i32 {
+  return i32(floor(value + 0.5));
+}
+
 @compute @workgroup_size(64)
 fn main(@builtin(global_invocation_id) gid : vec3<u32>) {
   let windowSize = params.windowSize;
+  let paddedWindowSize = params.paddedWindowSize;
   let signalStride = params.signalStride;
   let windowCount = params.windowCount;
   let visibleSamples = params.visibleSamples;
   let step = params.step;
 
   let sampleIndex = gid.x;
-  let windowIndex = gid.y;
-  if (sampleIndex >= windowSize || windowIndex >= windowCount) {
+  let localColumn = gid.y;
+  if (sampleIndex >= paddedWindowSize) {
     return;
   }
 
-  // samples is a circular buffer addressed by absolute track position.
-  // Slot for the window-local index is rotated by ringStart so that already
-  // resident samples stay valid when the playhead slides between frames.
-  let localIndex = u32(f32(windowIndex) * step) + sampleIndex;
-  let ringIndex = (params.ringStart + localIndex) % visibleSamples;
-  let value = samples[ringIndex] * windowFunction[sampleIndex];
-  signal[signalStride * windowIndex + sampleIndex] = value;
+  let screenColumn = params.screenBase + localColumn;
+  let slot = (params.slotOffset + localColumn) % windowCount;
+  let absoluteColumn = params.baseColumn + i32(screenColumn);
+  let windowStart = roundToI32(
+    f32(absoluteColumn) * step - f32(windowSize) * 0.5,
+  );
+  let localOffset = u32(windowStart - params.baseWindowStart);
+
+  var value = 0.0;
+  if (sampleIndex < windowSize) {
+    let localIndex = localOffset + sampleIndex;
+    let ringIndex = (params.ringStart + localIndex) % visibleSamples;
+    value = samples[ringIndex] * windowFunction[sampleIndex];
+  }
+  signal[signalStride * slot + sampleIndex] = value;
 }
 `;

--- a/packages/spectrogram/src/sliceSamples/state.ts
+++ b/packages/spectrogram/src/sliceSamples/state.ts
@@ -10,14 +10,12 @@ import {
 export type StateArg = {
   out: GPUBuffer;
   config: ExtSpectrogramConfig;
-  sampleOffset: number;
 };
 
 export type State = {
   pipeline: GPUComputePipeline;
   config: ExtSpectrogramConfig;
   out: GPUBuffer;
-  sampleOffset: number;
   params: StateParams;
   samples: StateSamples;
   windowFunction: StateWindowFunction;
@@ -34,7 +32,7 @@ export const createStateCell = (
   const bindGroupCell = createResourceCell({
     create: (arg: {
       out: GPUBuffer;
-      params: GPUBuffer;
+      params: StateParams;
       samples: GPUBuffer;
       windowFunction: GPUBuffer;
     }): GPUBindGroup =>
@@ -44,7 +42,13 @@ export const createStateCell = (
         entries: [
           { binding: 0, resource: { buffer: arg.samples } },
           { binding: 1, resource: { buffer: arg.out } },
-          { binding: 2, resource: { buffer: arg.params } },
+          {
+            binding: 2,
+            resource: {
+              buffer: arg.params.buffer,
+              size: arg.params.byteLength,
+            },
+          },
           { binding: 3, resource: { buffer: arg.windowFunction } },
         ],
       }),
@@ -58,13 +62,13 @@ export const createStateCell = (
 
   return {
     get: (arg) => {
-      const { out, config, sampleOffset } = arg;
+      const { out, config } = arg;
       const params = paramsCell.get(config);
       const samples = samplesCell.get(params.value.visibleSamples);
       const windowFunction = windowFunctionCell.get(config);
       const bindGroup = bindGroupCell.get({
         out,
-        params: params.buffer,
+        params,
         samples: samples.buffer,
         windowFunction: windowFunction.buffer,
       });
@@ -73,7 +77,6 @@ export const createStateCell = (
         pipeline,
         config,
         out,
-        sampleOffset,
         params,
         samples,
         windowFunction,

--- a/packages/spectrogram/vitest.bench.config.ts
+++ b/packages/spectrogram/vitest.bench.config.ts
@@ -6,5 +6,8 @@ export default defineConfig({
     ...defaultConfig.test,
     include: ['**/*.bench.ts'],
     testTimeout: 0,
+    fileParallelism: false,
+    pool: 'forks',
+    maxWorkers: 1,
   },
 });


### PR DESCRIPTION
Recompute only the columns a frame actually dirties instead of the full ring: the playhead shift exposes a few edge columns, in-place PCM writes are declared through the new SpectrogramProcessor.invalidateSamples and mapped to the columns whose analysis window overlaps them, and every compute stage dispatches per dirty range via dynamic uniform offsets (one params buffer per stage, one slot per dispatch). A range wrapping the ring seam splits into two FFT batch dispatches, so disjoint ranges in one frame keep their own ring slots. Frames with no dirty columns, no clears and an unchanged scroll skip their GPU submit entirely.

- common/columnRanges.ts: pure shift/invalidation marking, coalescing into ranges, radius expansion for the fundamental filter.
- common/sampleInvalidations.ts: pure overlap-merging of pending invalidations, bounded between renders.
- sliceSamples uploads only changed samples (exposed edge, truncation flips, invalidated ranges) as block copies into the sample ring.
- processor.ts: per-track render plans (full upload vs dirty ranges), per-track config invalidation scope, fused single compute pass without profiling / per-stage timestamped passes with it.
- engine: the render loop runs only while playing; paused seeks, config patches and invalidations render once on demand.
- Tests: incremental-vs-full-render parity (slide + recording chunks, fundamental radius, lane-only gain change, profiling on/off), slice ring reuse, column-range marking vs brute force, invalidation merge, ring-seam dispatch split.
- Bench: vitest bench project with full-mount / playback / recording scenarios per preset, per-stage GPU metrics plus wall time, markdown reports via scripts/bench.ts.