### PR TITLE
feat(lint): add untrusted-value-checks and defensive-throw-guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,6 +65,20 @@
 
 - Do not add `minHeight` or `minWidth` without extreme necessity.
 
+**Contracts And Validation**
+
+- TypeScript types are the contract: never re-validate what a type already guarantees, and never guard obvious expectations of a well-named value (a `count` is a valid count by contract). Invalid input is the caller's bug and must fail at the caller, not be absorbed downstream.
+- Never coerce an invalid value into a valid one (clamping a negative count to zero, substituting a default for a broken required argument): silent repair fakes the input and hides the caller's bug.
+- Validate only at real boundaries: API schemas between backend and frontend, user input inside its input or submit handler, and external data such as wire payloads, file contents, and process output.
+- A value that is allowed to be invalid must carry a `raw` name prefix; raw values stay inside the boundary component, handler, or an explicitly raw-named store field, and must not flow into shared functions or public contracts.
+- Non-obvious multi-value invariants that types cannot express (`batchOffset + batchCount <= windowCount`) may throw; single-value shape and sign guards may not.
+- When a contract changes, replace it completely: do not keep wrappers, overloads, optional parameters, or defaults for backward compatibility. Ask before breaking only when the contract is a top-level public API of a package.
+
+**Tests**
+
+- Scale test effort with algorithmic complexity and business criticality: complex algorithmic cores (FFT, spectrogram) require unit tests and benchmarks.
+- Do not write tests for field mappings, pass-through wiring, or anything TypeScript already guarantees.
+
 ## Runtime Boundaries
 
 - Runtime boundaries are defined by `tsconfigs/` and each package `tsconfig.*.json`.

--- a/packages/eslint-config/src/plugin.ts
+++ b/packages/eslint-config/src/plugin.ts
@@ -6,6 +6,7 @@ export const musetricRecommendedRules: Linter.RulesRecord = {
   'musetric/no-aliased-reexports': 'error',
   'musetric/no-classes': 'error',
   'musetric/no-component-spacing-prop': 'error',
+  'musetric/no-defensive-throw-guards': 'error',
   'musetric/no-dynamic-translation-keys': 'error',
   'musetric/no-immediate-inline-function-calls': 'error',
   'musetric/no-inline-parameter-destructuring': 'error',
@@ -23,6 +24,7 @@ export const musetricRecommendedRules: Linter.RulesRecord = {
   'musetric/no-this-expression': 'error',
   'musetric/no-trivial-function-wrappers': 'error',
   'musetric/no-type-method-signatures': 'error',
+  'musetric/no-untrusted-value-checks': 'error',
 };
 
 export const musetricPlugin: ESLint.Plugin = {

--- a/packages/eslint-config/src/rules/index.ts
+++ b/packages/eslint-config/src/rules/index.ts
@@ -2,6 +2,7 @@ import { noAliasConstantsRule } from './noAliasConstants.js';
 import { noAliasedReexportsRule } from './noAliasedReexports.js';
 import { noClassesRule } from './noClasses.js';
 import { noComponentSpacingPropRule } from './noComponentSpacingProp.js';
+import { noDefensiveThrowGuardsRule } from './noDefensiveThrowGuards.js';
 import { noDynamicTranslationKeysRule } from './noDynamicTranslationKeys.js';
 import { noImmediateInlineFunctionCallsRule } from './noImmediateInlineFunctionCalls.js';
 import { noInlineParameterDestructuringRule } from './noInlineParameterDestructuring.js';
@@ -19,12 +20,14 @@ import { noSwitchStatementsRule } from './noSwitchStatements.js';
 import { noThisExpressionRule } from './noThisExpression.js';
 import { noTrivialFunctionWrappersRule } from './noTrivialFunctionWrappers.js';
 import { noTypeMethodSignaturesRule } from './noTypeMethodSignatures.js';
+import { noUntrustedValueChecksRule } from './noUntrustedValueChecks.js';
 
 export const musetricRules = {
   'no-alias-constants': noAliasConstantsRule,
   'no-aliased-reexports': noAliasedReexportsRule,
   'no-classes': noClassesRule,
   'no-component-spacing-prop': noComponentSpacingPropRule,
+  'no-defensive-throw-guards': noDefensiveThrowGuardsRule,
   'no-dynamic-translation-keys': noDynamicTranslationKeysRule,
   'no-immediate-inline-function-calls': noImmediateInlineFunctionCallsRule,
   'no-inline-parameter-destructuring': noInlineParameterDestructuringRule,
@@ -42,4 +45,5 @@ export const musetricRules = {
   'no-this-expression': noThisExpressionRule,
   'no-trivial-function-wrappers': noTrivialFunctionWrappersRule,
   'no-type-method-signatures': noTypeMethodSignaturesRule,
+  'no-untrusted-value-checks': noUntrustedValueChecksRule,
 };

--- a/packages/eslint-config/src/rules/noDefensiveThrowGuards.ts
+++ b/packages/eslint-config/src/rules/noDefensiveThrowGuards.ts
@@ -1,0 +1,91 @@
+import { type Rule } from 'eslint';
+import { type BinaryExpression, type Node, type Statement } from 'estree';
+import {
+  getCheckedValueName,
+  isTestFile,
+  rawNamePattern,
+} from './untrustedNames.js';
+
+const isZeroLiteral = (node: Node): boolean =>
+  node.type === 'Literal' && node.value === 0;
+
+const getSignCheckedName = (node: BinaryExpression): string | undefined => {
+  if (
+    (node.operator === '<' || node.operator === '<=') &&
+    isZeroLiteral(node.right)
+  ) {
+    return getCheckedValueName(node.left);
+  }
+  if (
+    (node.operator === '>' || node.operator === '>=') &&
+    isZeroLiteral(node.left)
+  ) {
+    return getCheckedValueName(node.right);
+  }
+  return undefined;
+};
+
+const containsThrow = (statement: Statement): boolean => {
+  if (statement.type === 'ThrowStatement') {
+    return true;
+  }
+  if (statement.type === 'BlockStatement') {
+    return statement.body.some((child) => child.type === 'ThrowStatement');
+  }
+  return false;
+};
+
+const isThrowGuardTest = (node: Rule.Node): boolean => {
+  const { parent } = node;
+  if (!parent) {
+    return false;
+  }
+  if (parent.type === 'IfStatement') {
+    return parent.test === node && containsThrow(parent.consequent);
+  }
+  if (
+    parent.type === 'Program' ||
+    parent.type.endsWith('Statement') ||
+    parent.type.endsWith('Declaration')
+  ) {
+    return false;
+  }
+  return isThrowGuardTest(parent);
+};
+
+export const noDefensiveThrowGuardsRule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow throw guards built on sign checks of contract-typed values',
+    },
+    messages: {
+      signGuard:
+        "Sign guard on '{{name}}' is defensive validation: the TypeScript contract already promises a sane value, and a negative '{{name}}' is the caller's bug. Throw only for non-obvious multi-value invariants. If the value is genuinely raw boundary data, rename it with a 'raw' prefix and validate it where it enters.",
+    },
+    schema: [],
+  },
+  create: (context) => {
+    if (isTestFile(context.filename)) {
+      return {};
+    }
+
+    return {
+      BinaryExpression: (node) => {
+        const name = getSignCheckedName(node);
+        if (name === undefined || rawNamePattern.test(name)) {
+          return;
+        }
+        if (!isThrowGuardTest(node)) {
+          return;
+        }
+        context.report({
+          node,
+          messageId: 'signGuard',
+          data: { name },
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-config/src/rules/noUntrustedValueChecks.ts
+++ b/packages/eslint-config/src/rules/noUntrustedValueChecks.ts
@@ -1,0 +1,160 @@
+import { type Rule } from 'eslint';
+import {
+  type BinaryExpression,
+  type CallExpression,
+  type Expression,
+  type SpreadElement,
+} from 'estree';
+import { type Node, type Program, type Type, TypeFlags } from 'typescript';
+import {
+  getCheckedValueName,
+  isTestFile,
+  rawNamePattern,
+} from './untrustedNames.js';
+
+type TsParserServices = {
+  program?: Program;
+  esTreeNodeToTSNodeMap?: {
+    get: (node: Expression | SpreadElement) => Node | undefined;
+  };
+};
+
+const numberCheckNames = new Set(['isInteger', 'isFinite', 'isNaN']);
+const globalCheckNames = new Set(['isNaN', 'isFinite']);
+const equalityOperators = new Set(['==', '!=', '===', '!==']);
+const typeofPrimitiveFlags = new Map<string, TypeFlags>([
+  ['number', TypeFlags.NumberLike],
+  ['string', TypeFlags.StringLike],
+  ['boolean', TypeFlags.BooleanLike],
+]);
+
+const isValueCheckCallee = (callee: CallExpression['callee']): boolean => {
+  if (callee.type === 'Identifier') {
+    return globalCheckNames.has(callee.name);
+  }
+  return (
+    callee.type === 'MemberExpression' &&
+    !callee.computed &&
+    callee.object.type === 'Identifier' &&
+    callee.object.name === 'Number' &&
+    callee.property.type === 'Identifier' &&
+    numberCheckNames.has(callee.property.name)
+  );
+};
+
+type TypeofCheck = {
+  operand: Expression;
+  flags: TypeFlags;
+};
+
+const getTypeofCheck = (node: BinaryExpression): TypeofCheck | undefined => {
+  if (!equalityOperators.has(node.operator)) {
+    return undefined;
+  }
+  const sides = [
+    { operand: node.left, literal: node.right },
+    { operand: node.right, literal: node.left },
+  ];
+  for (const side of sides) {
+    if (
+      side.operand.type === 'UnaryExpression' &&
+      side.operand.operator === 'typeof' &&
+      side.literal.type === 'Literal' &&
+      typeof side.literal.value === 'string'
+    ) {
+      const flags = typeofPrimitiveFlags.get(side.literal.value);
+      if (flags !== undefined) {
+        return { operand: side.operand.argument, flags };
+      }
+    }
+  }
+  return undefined;
+};
+
+const isPlainPrimitiveType = (type: Type, flags: TypeFlags): boolean => {
+  if (type.isUnion()) {
+    return type.types.every((member) => isPlainPrimitiveType(member, flags));
+  }
+  return (type.flags & flags) !== 0;
+};
+
+export const noUntrustedValueChecksRule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow runtime type and shape checks on values whose TypeScript type already guarantees the contract',
+    },
+    messages: {
+      untrustedCheck:
+        "Do not runtime-check '{{name}}': its TypeScript type is the contract, and invalid input is the caller's bug, not this code's job to absorb. If the value is genuinely raw boundary data (user input, wire payload, external process output), rename it with a 'raw' prefix and validate it where it enters; if the check is real math (such as divisibility), express it as math (`value % 2 === 0`) instead of a shape check.",
+    },
+    schema: [],
+  },
+  create: (context) => {
+    if (isTestFile(context.filename)) {
+      return {};
+    }
+    const services: TsParserServices | undefined =
+      context.sourceCode.parserServices;
+    const program = services?.program;
+    const nodeMap = services?.esTreeNodeToTSNodeMap;
+    if (!program || !nodeMap) {
+      return {};
+    }
+    const checker = program.getTypeChecker();
+
+    const isContractPrimitive = (
+      node: Expression | SpreadElement,
+      flags: TypeFlags,
+    ): boolean => {
+      const tsNode = nodeMap.get(node);
+      if (!tsNode) {
+        return false;
+      }
+      return isPlainPrimitiveType(checker.getTypeAtLocation(tsNode), flags);
+    };
+
+    const report = (node: Rule.Node, name: string): void => {
+      context.report({
+        node,
+        messageId: 'untrustedCheck',
+        data: { name },
+      });
+    };
+
+    return {
+      CallExpression: (node) => {
+        if (!isValueCheckCallee(node.callee)) {
+          return;
+        }
+        if (node.arguments.length === 0) {
+          return;
+        }
+        const [argument] = node.arguments;
+        const name = getCheckedValueName(argument);
+        if (name === undefined || rawNamePattern.test(name)) {
+          return;
+        }
+        if (!isContractPrimitive(argument, TypeFlags.NumberLike)) {
+          return;
+        }
+        report(node, name);
+      },
+      BinaryExpression: (node) => {
+        const check = getTypeofCheck(node);
+        if (!check) {
+          return;
+        }
+        const name = getCheckedValueName(check.operand);
+        if (name === undefined || rawNamePattern.test(name)) {
+          return;
+        }
+        if (!isContractPrimitive(check.operand, check.flags)) {
+          return;
+        }
+        report(node, name);
+      },
+    };
+  },
+};

--- a/packages/eslint-config/src/rules/untrustedNames.ts
+++ b/packages/eslint-config/src/rules/untrustedNames.ts
@@ -1,0 +1,20 @@
+import { type Node } from 'estree';
+
+export const rawNamePattern = /^raw(?:$|[A-Z])/;
+
+export const getCheckedValueName = (node: Node): string | undefined => {
+  if (node.type === 'Identifier') {
+    return node.name;
+  }
+  if (
+    node.type === 'MemberExpression' &&
+    !node.computed &&
+    node.property.type === 'Identifier'
+  ) {
+    return node.property.name;
+  }
+  return undefined;
+};
+
+export const isTestFile = (filename: string): boolean =>
+  filename.split(/[\\/]/).includes('__test__');


### PR DESCRIPTION
## What

Two new `musetric` ESLint rules that ban defensive validation of contract-typed values, plus AGENTS.md ground rules for the parts a linter cannot see.

### `musetric/no-untrusted-value-checks` (type-aware)

Flags `Number.isInteger/isFinite/isNaN`, global `isNaN`/`isFinite`, and `typeof x === 'number' | 'string' | 'boolean'` when the checked value is a named binding or property whose TypeScript type is already the plain matching primitive. The type is the contract; garbage input is the caller's bug.

Not flagged:
- `raw`-prefixed names (`rawValue`, `message.rawFrameCount`) — the naming convention for genuinely raw boundary data (user input, wire payloads, external process output).
- Union/`unknown`/`any` operands — `typeof value === 'string'` on `string | number` is legitimate narrowing, not validation.
- Computed expressions (`Number.isInteger(Math.log2(size))`) — math, not shape checks.
- `__test__` folders.

### `musetric/no-defensive-throw-guards`

Flags sign checks against literal zero (`x < 0`, `x <= 0`) inside `if (...) throw` guards on non-`raw` named values. Multi-value domain invariants (`batchOffset + batchCount > windowCount`) stay allowed — they compare runtime values, not a value against zero.

### AGENTS.md

New `Contracts And Validation` and `Tests` ground rules: no silent coercion of invalid values to valid ones, validation only at real boundaries, `raw` values must not leak past their boundary, contract changes replace the old contract without back-compat shims, and test effort scales with algorithmic complexity (no tests for field mappings).

## Status

`check:ts`, `check:unused`, and self-lint of `eslint-config` are green. **`check:lint` is intentionally left red**: the new rules currently report 36 violations in 17 files (fft batchRange/support, toolkit ffprobe parsing, backend recording wire checks, frontend settings fields, bench stats). The refactor to `raw` naming / removed guards lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)