### PR TITLE
fix(ai): create blob shard dir before writing transcript

### DIFF
--- a/packages/ai/src/transcription/transcribeAudio.node.ts
+++ b/packages/ai/src/transcription/transcribeAudio.node.ts
@@ -1,4 +1,5 @@
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
 import { type Logger, type MessageHandlers } from '@musetric/utils';
 import { whisperModel } from '../models/whisperModel.js';
 import { decodeMonoPcm } from '../service/audioCodec.node.js';
@@ -58,5 +59,6 @@ export const transcribeAudio = async (
     },
   });
 
+  await mkdir(dirname(resultPath), { recursive: true });
   await writeFile(resultPath, JSON.stringify(segments, undefined, 2), 'utf-8');
 };


### PR DESCRIPTION
createPath() only computes the sharded blob path; it does not create the parent directory (only add() does). transcribeAudio wrote the result via writeFile directly, so it crashed with ENOENT whenever the random uuid landed in a not-yet-created shard. mkdir the parent first, mirroring blobStorage.add().