### PR TITLE
fix(ai): short-circuit favicon.ico in transcription server

### DIFF
--- a/packages/ai/src/service/headlessTranscriptionService.node.ts
+++ b/packages/ai/src/service/headlessTranscriptionService.node.ts
@@ -158,6 +158,12 @@ const createModuleServer = async (
       return;
     }
 
+    if (url.pathname === '/favicon.ico') {
+      response.writeHead(204);
+      response.end();
+      return;
+    }
+
     if (url.pathname.startsWith('/hf/')) {
       await serveHfFile({
         relPath: url.pathname.slice('/hf/'.length),


### PR DESCRIPTION
The headless chromium auto-requests /favicon.ico, which fell through to the vite fallback and logged a spurious 'route not found' warning on every run. Answer it with 204.