### PR TITLE
test(fft): drop batch range cases for removed value guards

### DIFF
--- a/packages/fft/src/fourier/__test__/batchRange.test.ts
+++ b/packages/fft/src/fourier/__test__/batchRange.test.ts
@@ -39,14 +39,8 @@ describe('resolveFourierBatchRange', () => {
     expect(resolved).toEqual({ batchOffset: 8, batchCount: 0 });
   });
 
-  it.each([
-    { batchOffset: -1, batchCount: 2 },
-    { batchOffset: 1, batchCount: -2 },
-    { batchOffset: 0.5, batchCount: 2 },
-    { batchOffset: 1, batchCount: 1.5 },
-    { batchOffset: Number.NaN, batchCount: 2 },
-    { batchOffset: 4, batchCount: 5 },
-  ])('rejects ($batchOffset, $batchCount)', (range) => {
+  it('rejects a range that overruns the window span', () => {
+    const range = { batchOffset: 4, batchCount: 5 };
     expect(() => resolveFourierBatchRange(range, 8)).toThrow(RangeError);
   });
 });


### PR DESCRIPTION
resolveFourierBatchRange stopped validating negative, fractional and NaN inputs when #647 and #648 landed the defensive-throw-guards and untrusted-value-checks lint rules, but the rejection cases stayed and have been failing since. Keep only the overrun case, which the source still guards, and inline it now that it.each holds a single entry.