### PR TITLE
feat(lint): add no-alias-types and inline aliased types

### DIFF
--- a/packages/backend-db/src/entity/projectAudioAnalysis/upsert.ts
+++ b/packages/backend-db/src/entity/projectAudioAnalysis/upsert.ts
@@ -2,8 +2,6 @@ import { type DatabaseSync } from 'node:sqlite';
 import { transaction } from '../../common/index.js';
 import { type table } from '../../schema/index.js';
 
-export type UpsertProjectAudioAnalysisArg = table.projectAudioAnalysis.Item;
-
 export const upsert = (database: DatabaseSync) => {
   const statement = database.prepare(
     `INSERT INTO ProjectAudioAnalysis (
@@ -26,7 +24,7 @@ export const upsert = (database: DatabaseSync) => {
        leadSpectrogramGainDb = excluded.leadSpectrogramGainDb`,
   );
 
-  return async (arg: UpsertProjectAudioAnalysisArg): Promise<void> => {
+  return async (arg: table.projectAudioAnalysis.Item): Promise<void> => {
     await transaction(database, async () => {
       await Promise.resolve(
         statement.run(

--- a/packages/backend/src/services/processingWorker/processingSummary.ts
+++ b/packages/backend/src/services/processingWorker/processingSummary.ts
@@ -19,12 +19,10 @@ const stepOrder: ProcessingStepKind[] = [
 const doneStep: api.project.ProcessingStep = { status: 'done', progress: 1 };
 const pendingStep: api.project.ProcessingStep = { status: 'pending' };
 
-type Steps = api.project.ProcessingSteps;
-
 const buildSteps = (
   step: ProcessingStepKind,
   current: api.project.ProcessingStep,
-): Steps => {
+): api.project.ProcessingSteps => {
   const targetIndex = stepOrder.indexOf(step);
   const stepValue = (name: ProcessingStepKind): api.project.ProcessingStep => {
     const index = stepOrder.indexOf(name);

--- a/packages/engine/src/player/recordingStream.cross.ts
+++ b/packages/engine/src/player/recordingStream.cross.ts
@@ -18,11 +18,9 @@ export type RecordingStreamInboundMethods = {
   flush: (message: RecordingStreamFlushMessage) => void;
 };
 
-export type RecordingStreamOutboundMethods = EmptyPortMethods;
-
 export const recordingStreamChannel = createMessageChannel<
   RecordingStreamInboundMethods,
-  RecordingStreamOutboundMethods
+  EmptyPortMethods
 >({
   inbound: {
     keys: ['chunk', 'flush'],

--- a/packages/eslint-config/src/plugin.ts
+++ b/packages/eslint-config/src/plugin.ts
@@ -3,6 +3,7 @@ import { musetricRules } from './rules/index.js';
 
 export const musetricRecommendedRules: Linter.RulesRecord = {
   'musetric/no-alias-constants': 'error',
+  'musetric/no-alias-types': 'error',
   'musetric/no-aliased-reexports': 'error',
   'musetric/no-classes': 'error',
   'musetric/no-component-spacing-prop': 'error',

--- a/packages/eslint-config/src/rules/index.ts
+++ b/packages/eslint-config/src/rules/index.ts
@@ -1,5 +1,6 @@
 import { noAliasConstantsRule } from './noAliasConstants.js';
 import { noAliasedReexportsRule } from './noAliasedReexports.js';
+import { noAliasTypesRule } from './noAliasTypes.js';
 import { noClassesRule } from './noClasses.js';
 import { noComponentSpacingPropRule } from './noComponentSpacingProp.js';
 import { noDefensiveThrowGuardsRule } from './noDefensiveThrowGuards.js';
@@ -26,6 +27,7 @@ import { noUntrustedValueChecksRule } from './noUntrustedValueChecks.js';
 
 export const musetricRules = {
   'no-alias-constants': noAliasConstantsRule,
+  'no-alias-types': noAliasTypesRule,
   'no-aliased-reexports': noAliasedReexportsRule,
   'no-classes': noClassesRule,
   'no-component-spacing-prop': noComponentSpacingPropRule,

--- a/packages/eslint-config/src/rules/noAliasTypes.ts
+++ b/packages/eslint-config/src/rules/noAliasTypes.ts
@@ -1,0 +1,15 @@
+import { createRestrictedSyntaxRule } from './createRestrictedSyntaxRule.js';
+
+const message =
+  'Do not create alias types (`type A = B`); use the original type directly instead of renaming it through a type alias.';
+
+export const noAliasTypesRule = createRestrictedSyntaxRule(
+  'Disallow type aliases that only rename another type',
+  [
+    {
+      selector:
+        'TSTypeAliasDeclaration > TSTypeReference.typeAnnotation:not([typeArguments])',
+      message,
+    },
+  ],
+);


### PR DESCRIPTION
Ban type aliases whose right-hand side is a bare type reference, so `type Steps = api.project.ProcessingSteps` is reported. The existing no-alias-constants rule only matches VariableDeclarator, and sonarjs redundant-type-aliases misses qualified names like `ns.A.B`.

Generic instantiations, object shapes, function types and unions are left alone: they build a type instead of renaming one.

Inline the three aliases this reports; each had a single use site.