### PR TITLE
feat(lint): add no-inline-return-object-types and name results

### DIFF
--- a/packages/ai/src/chords/chordSegments.ts
+++ b/packages/ai/src/chords/chordSegments.ts
@@ -2,9 +2,12 @@ import { chordLabelAt, noChordLabel, unknownChordLabel } from './chordVocab.js';
 
 const round3 = (value: number): number => Math.round(value * 1000) / 1000;
 
-const splitLabel = (
-  label: string,
-): { root: string; quality: string | undefined } => {
+type SplitLabel = {
+  root: string;
+  quality: string | undefined;
+};
+
+const splitLabel = (label: string): SplitLabel => {
   if (label === noChordLabel || label === unknownChordLabel) {
     return { root: label, quality: undefined };
   }

--- a/packages/ai/src/separation/separateVocals.ts
+++ b/packages/ai/src/separation/separateVocals.ts
@@ -89,10 +89,12 @@ const validateAudio = (audio: StereoAudio): void => {
   }
 };
 
-const getChunkWindow = (
-  offset: number,
-  samples: number,
-): { start: number; length: number } => {
+type ChunkWindow = {
+  start: number;
+  length: number;
+};
+
+const getChunkWindow = (offset: number, samples: number): ChunkWindow => {
   if (offset + vocalsModel.chunkSamples <= samples) {
     return {
       start: offset,

--- a/packages/ai/src/transcription/spectralChunker.ts
+++ b/packages/ai/src/transcription/spectralChunker.ts
@@ -64,7 +64,12 @@ export const hanningWindow = (size: number): Float64Array => {
   return window;
 };
 
-const bandBins = (): { lo: number; hi: number } => {
+type BandBins = {
+  lo: number;
+  hi: number;
+};
+
+const bandBins = (): BandBins => {
   const binHz = sampleRate / win;
   let lo = Math.ceil(bandHz[0] / binHz);
   let hi = Math.floor(bandHz[1] / binHz);

--- a/packages/eslint-config/src/plugin.ts
+++ b/packages/eslint-config/src/plugin.ts
@@ -14,6 +14,7 @@ export const musetricRecommendedRules: Linter.RulesRecord = {
   'musetric/no-immediate-inline-function-calls': 'error',
   'musetric/no-inline-parameter-destructuring': 'error',
   'musetric/no-inline-parameter-object-types': 'error',
+  'musetric/no-inline-return-object-types': 'error',
   'musetric/no-mixed-reexports': 'error',
   'musetric/no-named-reexports': 'error',
   'musetric/no-null-literal': 'error',

--- a/packages/eslint-config/src/rules/index.ts
+++ b/packages/eslint-config/src/rules/index.ts
@@ -10,6 +10,7 @@ import { noFunctionDeclarationsRule } from './noFunctionDeclarations.js';
 import { noImmediateInlineFunctionCallsRule } from './noImmediateInlineFunctionCalls.js';
 import { noInlineParameterDestructuringRule } from './noInlineParameterDestructuring.js';
 import { noInlineParameterObjectTypesRule } from './noInlineParameterObjectTypes.js';
+import { noInlineReturnObjectTypesRule } from './noInlineReturnObjectTypes.js';
 import { noMixedReexportsRule } from './noMixedReexports.js';
 import { noNamedReexportsRule } from './noNamedReexports.js';
 import { noNullLiteralRule } from './noNullLiteral.js';
@@ -38,6 +39,7 @@ export const musetricRules = {
   'no-immediate-inline-function-calls': noImmediateInlineFunctionCallsRule,
   'no-inline-parameter-destructuring': noInlineParameterDestructuringRule,
   'no-inline-parameter-object-types': noInlineParameterObjectTypesRule,
+  'no-inline-return-object-types': noInlineReturnObjectTypesRule,
   'no-mixed-reexports': noMixedReexportsRule,
   'no-named-reexports': noNamedReexportsRule,
   'no-null-literal': noNullLiteralRule,

--- a/packages/eslint-config/src/rules/noInlineReturnObjectTypes.ts
+++ b/packages/eslint-config/src/rules/noInlineReturnObjectTypes.ts
@@ -1,0 +1,21 @@
+import { createRestrictedSyntaxRule } from './createRestrictedSyntaxRule.js';
+
+const message =
+  'Do not use inline object types in function return types; declare a named result type instead';
+
+const functionSelector =
+  ':matches(FunctionDeclaration, FunctionExpression, ArrowFunctionExpression, TSDeclareFunction)';
+
+export const noInlineReturnObjectTypesRule = createRestrictedSyntaxRule(
+  'Disallow inline object types in function return types',
+  [
+    {
+      selector: `${functionSelector} > TSTypeAnnotation.returnType > TSTypeLiteral`,
+      message,
+    },
+    {
+      selector: `${functionSelector} > TSTypeAnnotation.returnType > TSTypeReference > TSTypeParameterInstantiation > TSTypeLiteral`,
+      message,
+    },
+  ],
+);

--- a/packages/performance/src/runPipeline.ts
+++ b/packages/performance/src/runPipeline.ts
@@ -85,13 +85,15 @@ export type RunPipelineOptions = {
 
 type Spread = { low: number; high: number };
 
-export const runPipeline = async (
-  options: RunPipelineOptions,
-): Promise<{
+export type RunPipelineResult = {
   first: Record<string, number>;
   median: Record<string, number>;
   spread: Record<string, Spread>;
-}> => {
+};
+
+export const runPipeline = async (
+  options: RunPipelineOptions,
+): Promise<RunPipelineResult> => {
   const { device, canvas, fourierMode, windowSize, params } = options;
   const viewSize = viewSizePresets[params.viewSizeKey];
   const metricsArray: Record<string, number>[] = [];

--- a/packages/spectrogram/src/__test__/benchRunner.ts
+++ b/packages/spectrogram/src/__test__/benchRunner.ts
@@ -22,12 +22,14 @@ import {
 const profiledContext = await createGpuContext(true);
 const wallContext = await createGpuContext();
 
-const measureProfiled = async (
-  benchCase: SpectrogramBenchCase,
-): Promise<{
+type ProfiledMeasurement = {
   metrics: SpectrogramBenchMetric[];
   sampleCount: number;
-}> => {
+};
+
+const measureProfiled = async (
+  benchCase: SpectrogramBenchCase,
+): Promise<ProfiledMeasurement> => {
   const driver = createDriver(benchCase);
   const metricsArray: SpectrogramProcessorMetrics[] = [];
   const sampleMetrics: SpectrogramProcessorMetrics[] = [];

--- a/packages/spectrogram/src/__test__/processor.fixtures.ts
+++ b/packages/spectrogram/src/__test__/processor.fixtures.ts
@@ -117,10 +117,16 @@ export const writeToneRange = (options: WriteToneRangeOptions): void => {
   }
 };
 
+export type CentreTone = {
+  trackKey: 'lead';
+  frameIndex: number;
+  frameCount: number;
+};
+
 export const writeCentreTone = (
   lead: Float32Array,
   sampleRate: number,
-): { trackKey: 'lead'; frameIndex: number; frameCount: number } => {
+): CentreTone => {
   const chunkLength = windowSize * 2;
   const chunkStart = Math.floor(lead.length * 0.5 - chunkLength * 0.5);
   writeToneRange({

--- a/packages/spectrogram/src/lane/__test__/columnRangeDispatch.test.ts
+++ b/packages/spectrogram/src/lane/__test__/columnRangeDispatch.test.ts
@@ -5,7 +5,12 @@ import { dispatchFourierColumnRange } from '../index.js';
 
 type RecordedDispatch = FourierBatchRange | 'full';
 
-const record = (): { fourier: Fourier; calls: RecordedDispatch[] } => {
+type RecordedFourier = {
+  fourier: Fourier;
+  calls: RecordedDispatch[];
+};
+
+const record = (): RecordedFourier => {
   const calls: RecordedDispatch[] = [];
   const fourier: Fourier = {
     run: () => undefined,


### PR DESCRIPTION
Ban inline object types in return annotations, mirroring the existing no-inline-parameter-object-types rule:

  const bandBins = (): { lo: number; hi: number } => ...

Async returns are covered too, since `Promise<{ ... }>` is the same defect wearing a wrapper. Type-level signatures such as `type Cb = () => { a: number }` are left alone, matching the parameter rule, which also only looks at implementations.

Name the result type at the seven sites this reports.