### PR TITLE
fix(deps): force adm-zip 0.6.0 to clear high-severity advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "editorconfig-checker": "catalog:",
     "knip": "catalog:",
     "prettier": "catalog:"
+  },
+  "resolutions": {
+    "adm-zip": "^0.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3925,10 +3925,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"adm-zip@npm:^0.5.16":
-  version: 0.5.18
-  resolution: "adm-zip@npm:0.5.18"
-  checksum: 10c0/9b734aa7126a01913baec02bf495d086b5d7e63315522b7087620e3fc8279c8ebd65109da4d99f16fcf873d87522ae6ffd913aef65449fd22c68777b772685e9
+"adm-zip@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "adm-zip@npm:0.6.0"
+  checksum: 10c0/440f37590c62255226f1db4cb1a5a618879347f5106ad5b9a24c67c20f9a54bd5b4efcd2b35af858e39c7885d05f4bd35f4c2f42378c98d13f779be380bc9ae4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
onnxruntime-node@1.24.3 pulled adm-zip@0.5.18 (GHSA-xcpc-8h2w-3j85, crafted ZIP triggers 4GB allocation). Add a resolution to ^0.6.0; yarn npm audit --severity high is now clean.