### PR TITLE
feat(lint): add no-comments rule and strip existing comments

### DIFF
--- a/packages/ai/src/models/leadBackingModel.ts
+++ b/packages/ai/src/models/leadBackingModel.ts
@@ -3,9 +3,6 @@ const hop = 1024;
 const dimF = 2048;
 const dimT = 256;
 
-// UVR MDX-Net karaoke model and inference parameters. The model is trained for
-// the MDX tensor contract used by Ultimate Vocal Remover GUI (MIT); see
-// thirdPartyNotices.md.
 export const leadBackingModel = {
   sourceUrl:
     'https://huggingface.co/AI4future/RVC/resolve/main/UVR_MDXNET_KARA_2.onnx',

--- a/packages/ai/src/models/vocalsModel.ts
+++ b/packages/ai/src/models/vocalsModel.ts
@@ -3,8 +3,6 @@ const hop = 441;
 const frames = 1101;
 const packedBins = (nFft / 2 + 1) * 2;
 
-// Mel-Band RoFormer / SYHFT vocal separation ONNX artifact and tensor contract.
-// See thirdPartyNotices.md for source and license details.
 export const vocalsModel = {
   repo: 'https://huggingface.co/musetric/vocal-separation-roformer-onnx',
   revision: 'main',

--- a/packages/ai/src/runtime/leadBacking/frame.wgsl.ts
+++ b/packages/ai/src/runtime/leadBacking/frame.wgsl.ts
@@ -1,5 +1,3 @@
-// Cuts the chunk into reflect-padded, periodic-Hann-windowed frames laid out
-// in the packed (nFft + 2) complex stride expected by the FFT.
 export const leadBackingFrameShader = `
 override nFft: u32;
 override hop: u32;

--- a/packages/ai/src/runtime/leadBacking/overlapAdd.wgsl.ts
+++ b/packages/ai/src/runtime/leadBacking/overlapAdd.wgsl.ts
@@ -1,5 +1,3 @@
-// Overlap-adds the inverse-FFT frames with the synthesis Hann window and
-// normalizes by the squared-window envelope, undoing the analysis padding.
 export const leadBackingOverlapAddShader = `
 override nFft: u32;
 override hop: u32;

--- a/packages/ai/src/runtime/leadBacking/pack.wgsl.ts
+++ b/packages/ai/src/runtime/leadBacking/pack.wgsl.ts
@@ -1,6 +1,3 @@
-// Packs the FFT half-spectra into the model input tensor [1, 4, dimF, dimT]
-// (planar [channel, re/im, freq, frame]); the first 3 frequency bins are
-// zeroed to match the UVR MDX-Net reference contract.
 export const leadBackingPackShader = `
 override nFft: u32;
 override frames: u32;

--- a/packages/ai/src/runtime/leadBacking/unpack.wgsl.ts
+++ b/packages/ai/src/runtime/leadBacking/unpack.wgsl.ts
@@ -1,5 +1,3 @@
-// Unpacks the model output tensor into the packed (nFft + 2) half-spectrum
-// for the inverse FFT; bins at or above dimF are zero.
 export const leadBackingUnpackShader = `
 override nFft: u32;
 override frames: u32;

--- a/packages/ai/src/runtime/rhythm/frame.wgsl.ts
+++ b/packages/ai/src/runtime/rhythm/frame.wgsl.ts
@@ -1,5 +1,3 @@
-// Cuts the track into reflect-padded, Hann-windowed frames laid out in the
-// packed (nFft + 2) complex stride expected by the FFT.
 export const rhythmFrameShader = `
 override nFft: u32;
 override hop: u32;

--- a/packages/ai/src/runtime/rhythm/mel.wgsl.ts
+++ b/packages/ai/src/runtime/rhythm/mel.wgsl.ts
@@ -1,7 +1,3 @@
-// Projects the FFT half-spectra onto the mel filterbank and takes log1p, the
-// torchaudio MelSpectrogram(normalized='frame_length', power=1) contract.
-// WGSL has no log1p, so it is evaluated in the form that stays accurate as the
-// magnitude approaches zero.
 export const rhythmMelShader = `
 override nFft: u32;
 override bins: u32;

--- a/packages/ai/src/runtime/rhythm/windows.wgsl.ts
+++ b/packages/ai/src/runtime/rhythm/windows.wgsl.ts
@@ -1,7 +1,3 @@
-// Cuts the spectrogram into the tracker's overlapping windows, zero-filling
-// outside the piece. Ports split_piece: a window starting at starts[w] reads
-// spect[starts[w] + i], and the caller shifts the final start left so it ends
-// at the piece end.
 export const rhythmWindowsShader = `
 override melBins: u32;
 override frames: i32;

--- a/packages/ai/src/runtime/vocals/applyMasks.wgsl.ts
+++ b/packages/ai/src/runtime/vocals/applyMasks.wgsl.ts
@@ -1,6 +1,3 @@
-// Applies the complex masks predicted by the model to the source STFT and
-// scatters the result back into the packed (nFft + 2) spectrum layout for the
-// inverse FFT.
 export const vocalsApplyMasksShader = `
 override nFft: u32;
 override frames: u32;

--- a/packages/ai/src/runtime/vocals/frame.wgsl.ts
+++ b/packages/ai/src/runtime/vocals/frame.wgsl.ts
@@ -1,5 +1,3 @@
-// Cuts the chunk into reflect-padded, Hann-windowed frames laid out in the
-// packed (nFft + 2) complex stride expected by the FFT.
 export const vocalsFrameShader = `
 override nFft: u32;
 override hop: u32;

--- a/packages/ai/src/runtime/vocals/overlapAdd.wgsl.ts
+++ b/packages/ai/src/runtime/vocals/overlapAdd.wgsl.ts
@@ -1,5 +1,3 @@
-// Overlap-adds the inverse-FFT frames with the synthesis Hann window and
-// normalizes by the squared-window envelope, undoing the analysis padding.
 export const vocalsOverlapAddShader = `
 override nFft: u32;
 override hop: u32;

--- a/packages/ai/src/runtime/vocals/pack.wgsl.ts
+++ b/packages/ai/src/runtime/vocals/pack.wgsl.ts
@@ -1,6 +1,3 @@
-// Packs the FFT half-spectra into the model input tensor
-// [1, packedBins, frames, 2] where packedBins interleaves frequency bins of
-// both channels: packed = 2 * freq + channel.
 export const vocalsPackShader = `
 override nFft: u32;
 override frames: u32;

--- a/packages/ai/src/runtime/vocals/vocalsRuntime.ts
+++ b/packages/ai/src/runtime/vocals/vocalsRuntime.ts
@@ -20,8 +20,6 @@ import { vocalsPackShader } from './pack.wgsl.js';
 
 ort.env.logLevel = 'error';
 
-// WebGPU host stages around the Mel-Band RoFormer / SYHFT ONNX core.
-// See thirdPartyNotices.md for source and license details.
 export type VocalsProcessChunkOptions = {
   input: Float32Array<ArrayBuffer>;
   output: Float32Array<ArrayBuffer>;

--- a/packages/ai/src/separation/separateLeadBacking.ts
+++ b/packages/ai/src/separation/separateLeadBacking.ts
@@ -8,8 +8,6 @@ const trim = nFft / 2;
 const genSamples = chunkSamples - 2 * trim;
 const overlap = 0.25;
 
-// Chunking and overlap-add follow the MDX-Net demix flow used by Ultimate
-// Vocal Remover GUI, reimplemented for the browser runtime.
 const createHanning = (size: number): Float32Array<ArrayBuffer> => {
   const window = new Float32Array(size);
   if (size === 1) {
@@ -194,13 +192,10 @@ export const separateLeadBacking = async (
   const backingData = new Float32Array(primary.length);
   const leadData = new Float32Array(primary.length);
   for (let i = 0; i < primary.length; i++) {
-    const backingSample = primary[i];
-    // UVR/MDX residual separation is mix - primary * compensate. Since this
-    // path normalizes mix before demix, compute that residual before restoring
-    // the original peak to avoid mixing normalized and denormalized amplitudes.
-    const leadSample = mixture[i] - backingSample * compensate;
-    backingData[i] = backingSample * peak;
-    leadData[i] = leadSample * peak;
+    const normalizedBacking = primary[i];
+    const normalizedLeadResidual = mixture[i] - normalizedBacking * compensate;
+    backingData[i] = normalizedBacking * peak;
+    leadData[i] = normalizedLeadResidual * peak;
   }
 
   return {

--- a/packages/api/src/common/coerceSchema.ts
+++ b/packages/api/src/common/coerceSchema.ts
@@ -32,7 +32,7 @@ const coerceValues = {
           return parsed;
         }
       } catch {
-        // Ignore JSON parse errors
+        return value;
       }
     }
     return value;

--- a/packages/backend-db/src/migrations/index.ts
+++ b/packages/backend-db/src/migrations/index.ts
@@ -1,8 +1,5 @@
 import { type DatabaseSync } from 'node:sqlite';
 
-// Do not attempt to migrate or preserve old tables/data.
-// Project is still early in development.
-
 const createProject = `
   CREATE TABLE IF NOT EXISTS Project (
     id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/packages/backend/src/services/multipart.ts
+++ b/packages/backend/src/services/multipart.ts
@@ -1,7 +1,7 @@
 import { fastifyMultipart } from '@fastify/multipart';
 import { type FastifyInstance } from 'fastify';
 
-// https://github.com/fastify/fastify-multipart/issues/574
+// @see https://github.com/fastify/fastify-multipart/issues/574
 declare module '@fastify/multipart' {
   // eslint-disable-next-line @typescript-eslint/consistent-type-definitions
   interface MultipartFile {

--- a/packages/engine/src/audioOutput/index.ts
+++ b/packages/engine/src/audioOutput/index.ts
@@ -32,12 +32,8 @@ export const createEngineAudioOutput = (
       outputNode: context.destination,
       supportsDeviceSelection: false,
       getDeviceId: () => deviceId,
-      setDeviceId: async () => {
-        // Device selection is not supported by this browser.
-      },
-      play: async () => {
-        // The AudioContext destination is driven directly.
-      },
+      setDeviceId: async () => Promise.resolve(),
+      play: async () => Promise.resolve(),
     };
   }
 
@@ -49,8 +45,6 @@ export const createEngineAudioOutput = (
       await setSinkId(nextDeviceId ?? '');
       deviceId = nextDeviceId;
     },
-    play: async () => {
-      // The AudioContext destination is driven directly.
-    },
+    play: async () => Promise.resolve(),
   };
 };

--- a/packages/engine/src/decoder/protocol.cross.ts
+++ b/packages/engine/src/decoder/protocol.cross.ts
@@ -1,8 +1,5 @@
 import { createMessageChannel } from '@musetric/utils/cross/messageChannel';
 
-// Int32Array<SharedArrayBuffer>; slot 0 = frameIndex (layout owned by
-// playhead.cross.ts in @musetric/audio). Typed locally so this cross-thread
-// module stays free of DOM-dependent imports.
 type Playhead = Int32Array<SharedArrayBuffer>;
 
 export type EngineDecoderOutboundMethods = {

--- a/packages/engine/src/player/playback.ts
+++ b/packages/engine/src/player/playback.ts
@@ -12,6 +12,8 @@ import playerWorkletUrl from './player.worklet.ts?worker&url';
 import { type Playhead, readPlayhead } from './playhead.cross.js';
 import { playerChannel, playerProcessorName } from './protocol.cross.js';
 
+const noop = (): void => undefined;
+
 export type EnginePlayback = {
   boot: () => Promise<void>;
   play: () => Promise<void>;
@@ -32,25 +34,13 @@ export type EnginePlayback = {
 };
 
 export const createEngineStubPlayback = (): EnginePlayback => ({
-  boot: async () => {
-    // nothing
-  },
-  play: async () => {
-    // nothing
-  },
+  boot: async () => Promise.resolve(),
+  play: async () => Promise.resolve(),
   stop: async () => Promise.resolve(0),
-  setFrozen: () => {
-    // nothing
-  },
-  seek: () => {
-    // nothing
-  },
-  connectRecordingSource: () => () => {
-    // nothing
-  },
-  startRecording: () => {
-    // nothing
-  },
+  setFrozen: noop,
+  seek: noop,
+  connectRecordingSource: () => noop,
+  startRecording: noop,
   flushRecording: async () => Promise.resolve(0),
 });
 

--- a/packages/engine/src/player/playhead.cross.ts
+++ b/packages/engine/src/player/playhead.cross.ts
@@ -1,9 +1,3 @@
-// Shared playback position between the audio worklet (writer) and the main
-// thread / workers (readers). The worklet stores the current frameIndex every
-// render quantum via Atomics; readers poll it from requestAnimationFrame instead
-// of receiving a postMessage per quantum. The revision lets readers ignore
-// values produced before the latest seek/play command.
-
 const frameIndexSlot = 0;
 const revisionSlot = 1;
 const slotCount = 2;

--- a/packages/engine/src/spectrogram/index.ts
+++ b/packages/engine/src/spectrogram/index.ts
@@ -60,10 +60,9 @@ export const createEngineSpectrogram = (
     },
   });
 
-  // While playing, the spectrogram worker polls the shared playhead itself, so
-  // only push discrete progress changes (e.g. seeks while paused) from here.
   store.subscribe(getTrackProgress, (trackProgress) => {
-    if (store.get().playing) {
+    const spectrogramWorkerPollsPlayheadWhilePlaying = store.get().playing;
+    if (spectrogramWorkerPollsPlayheadWhilePlaying) {
       return;
     }
     port.methods.setTrackProgress({

--- a/packages/eslint-config/src/config/silenceSonarjsCatalogLog.ts
+++ b/packages/eslint-config/src/config/silenceSonarjsCatalogLog.ts
@@ -1,18 +1,4 @@
-/**
- * Workaround for eslint-plugin-sonarjs (as of 4.1.0).
- *
- * SonarJS resolves the `catalog:` protocol by reading catalogs only from a
- * package.json (`catalog`/`catalogs` fields) or a pnpm-workspace.yaml. It does
- * not know about Yarn's `.yarnrc.yml` catalogs, which is where our catalog is
- * defined. As a result it emits an unconditional `console.debug` for every
- * `catalog:` dependency in every workspace, spamming lint stdout.
- *
- * The messages are harmless (SonarJS falls back to the literal version string
- * and still knows the dependency names), so we drop just those lines. Remove
- * this once SonarJS supports Yarn catalogs or gates the log behind a debug flag.
- *
- * See: node_modules/eslint-plugin-sonarjs/cjs/helpers/dependency-manifests/resolvers/package-json.js
- */
+// @see node_modules/eslint-plugin-sonarjs/cjs/helpers/dependency-manifests/resolvers/package-json.js
 let patched = false;
 
 export const silenceSonarjsCatalogLog = (): void => {

--- a/packages/eslint-config/src/plugin.ts
+++ b/packages/eslint-config/src/plugin.ts
@@ -6,6 +6,7 @@ export const musetricRecommendedRules: Linter.RulesRecord = {
   'musetric/no-alias-types': 'error',
   'musetric/no-aliased-reexports': 'error',
   'musetric/no-classes': 'error',
+  'musetric/no-comments': 'error',
   'musetric/no-component-spacing-prop': 'error',
   'musetric/no-defensive-throw-guards': 'error',
   'musetric/no-dynamic-translation-keys': 'error',

--- a/packages/eslint-config/src/rules/index.ts
+++ b/packages/eslint-config/src/rules/index.ts
@@ -2,6 +2,7 @@ import { noAliasConstantsRule } from './noAliasConstants.js';
 import { noAliasedReexportsRule } from './noAliasedReexports.js';
 import { noAliasTypesRule } from './noAliasTypes.js';
 import { noClassesRule } from './noClasses.js';
+import { noCommentsRule } from './noComments.js';
 import { noComponentSpacingPropRule } from './noComponentSpacingProp.js';
 import { noDefensiveThrowGuardsRule } from './noDefensiveThrowGuards.js';
 import { noDynamicTranslationKeysRule } from './noDynamicTranslationKeys.js';
@@ -31,6 +32,7 @@ export const musetricRules = {
   'no-alias-types': noAliasTypesRule,
   'no-aliased-reexports': noAliasedReexportsRule,
   'no-classes': noClassesRule,
+  'no-comments': noCommentsRule,
   'no-component-spacing-prop': noComponentSpacingPropRule,
   'no-defensive-throw-guards': noDefensiveThrowGuardsRule,
   'no-dynamic-translation-keys': noDynamicTranslationKeysRule,

--- a/packages/eslint-config/src/rules/noComments.ts
+++ b/packages/eslint-config/src/rules/noComments.ts
@@ -1,0 +1,36 @@
+import { type Rule } from 'eslint';
+
+const directiveComment =
+  /^(eslint-|global\s|globals\s|exported\s|@ts-(expect-error|ignore|nocheck|check)|\/\s*<reference)/;
+
+const referenceComment = /^@(see|todo|fixme)(\s|$)/;
+
+const isAllowedComment = (value: string): boolean =>
+  directiveComment.test(value) || referenceComment.test(value);
+
+export const noCommentsRule: Rule.RuleModule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow comments',
+    },
+    schema: [],
+  },
+  create: (context) => ({
+    Program: () => {
+      const comments = context.sourceCode.getAllComments();
+      for (const comment of comments) {
+        if (isAllowedComment(comment.value.trim())) {
+          continue;
+        }
+        if (!comment.loc) {
+          continue;
+        }
+        context.report({
+          loc: comment.loc,
+          message: 'Do not use comments',
+        });
+      }
+    },
+  }),
+};

--- a/packages/fft/scripts/benchCufft/benchmark.ts
+++ b/packages/fft/scripts/benchCufft/benchmark.ts
@@ -66,7 +66,6 @@ const computeDirectionSpec = (
   windowCount: number,
   inverse: boolean,
 ): DirectionSpec => {
-  // Forward R2C: real (windowSize) -> complex (N/2+1). Inverse C2R reverses it.
   const positiveSize = Math.floor(windowSize / 2) + 1;
   return {
     input: inverse

--- a/packages/fft/scripts/benchCufft/cudaLibs.ts
+++ b/packages/fft/scripts/benchCufft/cudaLibs.ts
@@ -63,7 +63,7 @@ export const loadCudaLibs = (): CudaLibs | undefined => {
         cufft: koffi.load(`${pair.cufft}.dll`),
       };
     } catch {
-      /* try next pair */
+      continue;
     }
   }
 

--- a/packages/fft/src/fourier/factorization.es.ts
+++ b/packages/fft/src/fourier/factorization.es.ts
@@ -49,8 +49,6 @@ type RadixStage = 2 | 3 | 4 | 5;
 
 export type MultiPassRadixStage = RadixStage | 8;
 
-// Greedy radix-8-preferring stage list (then 4, 2, 3, 5) to minimise the
-// number of global-memory passes in the multi-pass pipelines.
 export const expandRadix8PreferredStages = (
   size: number,
 ): MultiPassRadixStage[] | undefined => {

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/pipeline.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/pipeline.ts
@@ -21,8 +21,6 @@ const selectStockhamThreadCount = (packedWindowSize: number): number => {
 
 const isPowerOfTwo = (value: number): boolean => (value & (value - 1)) === 0;
 
-// For power-of-two sizes prefer radix-8 stages to reduce stage/barrier count
-// (e.g. 2^11 -> 8,8,8,4 = 4 stages instead of 4,4,4,4,4,2 = 6 stages).
 const createRadix8StageCounts = (
   packedWindowSize: number,
 ): Record<string, number> => {
@@ -73,8 +71,6 @@ const createInPlaceMixedConstants = (
     counts.radix2StageCount +
     counts.radix3StageCount +
     counts.radix5StageCount;
-  // Fewer-stage transforms favour more, smaller workgroups; deeper ones favour
-  // the wider 256-thread groups for the high-butterfly-count radix-2/4 stages.
   const threadCount = stageCount <= 4 ? 128 : 256;
   return {
     packedWindowSize: variant.packedWindowSize,

--- a/packages/fft/src/fourier/fftPackedStockhamR2c/support.ts
+++ b/packages/fft/src/fourier/fftPackedStockhamR2c/support.ts
@@ -12,8 +12,6 @@ const pairThreadsPerGroup = 8;
 const isPowerOfTwo = (value: number): boolean =>
   Number.isInteger(Math.log2(value));
 
-// Greedy radix-8-preferring factorization (then 4, 2, 3, 5) used by the
-// in-place single-pass kernel to minimise the stage/barrier count.
 export type InPlaceMixedStageCounts = {
   radix8StageCount: number;
   radix4StageCount: number;
@@ -51,12 +49,6 @@ const createRadix8PreferredCounts = (
 
 const maxPairGroupSize = 64;
 
-// Builds the kernel plan: adjacent stages with a combined group of at most 64
-// points are fused into pair kernels (two stages through shared memory per
-// global round trip); the last stage stays single because it fuses the R2C
-// pack instead. Full radix-64 pairs and single stages measured fastest with
-// 64-thread workgroups; narrower pairs (fewer butterflies per group set)
-// prefer 128.
 const selectPairThreadCount = (groupSize: number): number =>
   groupSize === 64 ? 64 : 128;
 
@@ -128,9 +120,8 @@ const createMultiPassKernels = (
 
     const isLast = stageIndex === radixStageList.length - 1;
     const singleThreadCount = 64;
-    // The fused-pack last stage runs the butterfly pair (k, stageStride - k)
-    // per thread, so it only needs threads for k in [0, stride / 2].
-    const threadTotal = isLast
+    const fusedPackHalvesButterflyThreads = isLast;
+    const threadTotal = fusedPackHalvesButterflyThreads
       ? Math.floor(packedWindowSize / factor / 2) + 1
       : packedWindowSize / factor;
     kernels.push({
@@ -218,9 +209,6 @@ export const getPackedStockhamR2cVariant = (
     };
   }
 
-  // Non-power-of-two sizes that still fit a single shared buffer (8 B/elem) run
-  // as an in-place mixed-radix single pass instead of the global-memory-bound
-  // multi-pass path, keeping the whole transform resident in shared memory.
   const inPlaceStageCounts = createRadix8PreferredCounts(packedWindowSize);
   if (
     packedWindowSize <= maxInPlacePackedWindowSize &&

--- a/packages/fft/src/fourier/fftPackedTiledR2c/pipeline.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/pipeline.ts
@@ -5,16 +5,13 @@ import { secondPassShader } from './secondPass.wgsl.js';
 import { secondPassMixedShader } from './secondPassMixed.wgsl.js';
 import { type PackedTiledR2cVariant } from './support.js';
 
-// Power-of-two tile FFTs of >= 128 points prefer radix-8 stages to minimise
-// the shared-memory round-trip/barrier count (e.g. 128 -> 8,8,2 = 3 stages
-// instead of 7). Smaller tiles keep radix-2: their butterfly count is already
-// below the thread count, so wider codelets only serialise work into fewer
-// threads (measured regressions at 64-point tiles under low window counts).
+const minRadix8Log2TileSize = 7;
+
 const createRadix8StageCounts = (
   log2Size: number,
   prefix: 'row' | 'column',
 ): Record<string, number> => {
-  if (log2Size < 7) {
+  if (log2Size < minRadix8Log2TileSize) {
     return {
       [`${prefix}Radix8StageCount`]: 0,
       [`${prefix}Radix4StageCount`]: 0,

--- a/packages/fft/src/fourier/fftPackedTiledR2c/support.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/support.ts
@@ -14,9 +14,9 @@ const maxPackedWindowSize = maxWindowSize / 2;
 const isPowerOfTwo = (value: number): boolean =>
   Number.isInteger(Math.log2(value));
 
-// The second pass holds 8 padded arrays (pad 8 up to tileSize 248; larger
-// tiles drop the padding so they still fit the 32 KB budget); the first pass
-// only holds 4.
+const maxPaddedSecondPassTileSize = 248;
+const secondPassPadColumns = 8;
+
 type BaseVariant = {
   windowSize: number;
   packedWindowSize: number;
@@ -43,7 +43,8 @@ export type PackedTiledR2cVariant =
 const getRequiredWorkgroupStorageSize = (
   variant: PackedTiledR2cVariant,
 ): number => {
-  const secondPassPad = variant.tileSize <= 248 ? 8 : 0;
+  const secondPassPad =
+    variant.tileSize <= maxPaddedSecondPassTileSize ? secondPassPadColumns : 0;
   return (
     8 *
     batchSize *
@@ -52,7 +53,6 @@ const getRequiredWorkgroupStorageSize = (
   );
 };
 
-// Power-of-two sizes keep the original balanced radix-2 tiling untouched.
 const createPowerOfTwoVariant = (
   windowSize: number,
   packedWindowSize: number,
@@ -79,8 +79,6 @@ const createPowerOfTwoVariant = (
   };
 };
 
-// Non-power-of-two (radix-3/5) sizes pick a balanced mixed-radix tile shape and
-// run the generalized first/second-pass shaders.
 const createMixedVariant = (
   windowSize: number,
   packedWindowSize: number,

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/pipeline.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/pipeline.ts
@@ -24,8 +24,6 @@ const stageCount = (counts: TransformStageCounts): number =>
 
 const isPowerOfTwo = (value: number): boolean => (value & (value - 1)) === 0;
 
-// Greedy radix-8-preferring factorization (then 4, 2, 3, 5) to minimise the
-// stage/barrier count, mirroring the forward pipeline.
 const createRadix8PreferredCounts = (
   packedWindowSize: number,
 ): TransformStageCounts => {
@@ -69,9 +67,6 @@ const selectTransformThreadCount = (
   counts: TransformStageCounts,
 ): number => {
   if (variant.kind === 'inPlaceMixed') {
-    // Power-of-two in-place sizes (packed 4096) prefer the wide 256-thread
-    // groups like the forward radix-8 path; non-power-of-two keeps the
-    // stage-count rule tuned on 2560/3072/3840.
     if (isPowerOfTwo(variant.packedWindowSize)) {
       return 256;
     }
@@ -103,8 +98,6 @@ const createTransformConstants = (
   };
 };
 
-// The first kernel fuses the C2R prepack read and the last kernel fuses the
-// scaled unpack write, dropping two full global-memory passes.
 const createKernelConstants = (
   variant: Extract<PackedStockhamC2rVariant, { kind: 'multiPass' }>,
   kernel: PackedStockhamC2rKernel,

--- a/packages/fft/src/fourier/ifftPackedStockhamC2r/support.ts
+++ b/packages/fft/src/fourier/ifftPackedStockhamC2r/support.ts
@@ -9,12 +9,6 @@ import {
 const pairThreadsPerGroup = 8;
 const maxPairGroupSize = 64;
 
-// Builds the kernel plan: adjacent stages with a combined group of at most 64
-// points are fused into pair kernels (two stages through shared memory per
-// global round trip). The first kernel fuses the C2R prepack read, the last
-// one (single or pair) the scaled unpack write. Full radix-64 pairs and
-// single stages measured fastest with 64-thread workgroups; narrower pairs
-// prefer 128.
 const selectPairThreadCount = (groupSize: number): number =>
   groupSize === 64 ? 64 : 128;
 
@@ -139,8 +133,6 @@ export const getPackedStockhamC2rVariant = (
     positiveWindowSize: packedWindowSize + 1,
   };
 
-  // Any factorization that fits the ping-pong shared budget (16 B/elem) runs
-  // the generic mixed-radix single-pass inverse.
   const maxSinglePassPacked = Math.floor(
     device.limits.maxComputeWorkgroupStorageSize / 16,
   );
@@ -148,8 +140,6 @@ export const getPackedStockhamC2rVariant = (
     return { kind: 'singlePass', ...base, radixStageCounts };
   }
 
-  // Sizes that still fit one shared buffer (8 B/elem) run an in-place
-  // mixed-radix single pass instead of the global multi-pass path.
   const maxInPlacePacked = Math.floor(
     device.limits.maxComputeWorkgroupStorageSize / 8,
   );
@@ -157,8 +147,6 @@ export const getPackedStockhamC2rVariant = (
     return { kind: 'inPlaceMixed', ...base, radixStageCounts };
   }
 
-  // Larger sizes run a generic multi-pass inverse through two global scratch
-  // buffers.
   const radixStageList = expandRadix8PreferredStages(packedWindowSize);
   if (radixStageList === undefined) {
     return undefined;

--- a/packages/frontend/src/pages/project/player/PlayerProgress.tsx
+++ b/packages/frontend/src/pages/project/player/PlayerProgress.tsx
@@ -24,8 +24,6 @@ export const PlayerProgress: FC = () => {
 
   const initialProgress = getTrackProgress(engine.store.get());
 
-  // High-frequency progress is driven straight into the DOM, bypassing React
-  // render: the Slider stays uncontrolled and we move its thumb/track manually.
   useEffect(() => {
     const root = ref.current;
 

--- a/packages/performance/src/components/BenchmarkCanvas.tsx
+++ b/packages/performance/src/components/BenchmarkCanvas.tsx
@@ -15,8 +15,6 @@ export const BenchmarkCanvas: FC = () => {
         canvasRef.current,
         'Canvas element not found',
       );
-      // Set initial dimensions before transfer; later resizes are handled
-      // inside the processor via setOffscreenCanvasSize on each render.
       const preset =
         viewSizePresets[useProcessingStore.getState().params.viewSizeKey];
       canvas.width = preset.width;

--- a/packages/performance/src/processor.ts
+++ b/packages/performance/src/processor.ts
@@ -7,13 +7,6 @@ const { device } = await createGpuContext(true);
 let canvas: OffscreenCanvas | undefined = undefined;
 let running = false;
 
-/**
- * Drains the toDo queue one task at a time. Stale tasks (whose epoch no
- * longer matches the store) are rejected atomically inside the reducer, so
- * the only thing the loop has to remember is which epoch its task belonged
- * to. After a stale-rejection the next iteration re-reads the store and
- * picks up the new queue head.
- */
 const drain = async () => {
   if (running) return;
   running = true;
@@ -35,9 +28,6 @@ const drain = async () => {
         params,
       });
 
-      // Reducer atomically validates epoch + queue head. If anything changed
-      // (param click, queue reset) it returns state unchanged and the next
-      // iteration reads the latest state.
       useProcessingStore.getState().recordResult(task, taskEpoch, metrics);
     }
   } finally {
@@ -54,9 +44,6 @@ export const detachCanvas = () => {
   canvas = undefined;
 };
 
-// Kick the loop whenever the queue is rebuilt. The reducer already discards
-// in-flight results that belong to the previous epoch, so the only extra
-// concern is making sure the loop is actively running.
 useProcessingStore.subscribe(
   (state) => state.epoch,
   () => {

--- a/packages/performance/src/store.ts
+++ b/packages/performance/src/store.ts
@@ -40,11 +40,6 @@ export type ProcessingState = {
 
   data: BenchmarkData;
   toDo: Task[];
-  /**
-   * Bumped each time the queue is reset (e.g. on param change). The processor
-   * captures it before a benchmark run and the reducer rejects results whose
-   * epoch is stale — no off-by-one possible.
-   */
   epoch: number;
 
   setParam: <K extends keyof BenchmarkParams>(

--- a/packages/spectrogram/src/common/frequencyRange.ts
+++ b/packages/spectrogram/src/common/frequencyRange.ts
@@ -1,10 +1,7 @@
 import { createNumberLimit } from '@musetric/utils';
 
-/** C0 keeps the logarithmic scale in the musical range without negative MIDI notes */
 export const minimumSpectrogramFrequency = 16.351597831287414;
-/** 20 kHz is the practical upper bound of the human hearing range */
 export const maximumSpectrogramFrequency = 20_000;
-/** Visible frequency window must span at least one octave */
 export const minimumSpectrogramFrequencyRatio = 2;
 
 export const normalizeSpectrogramMinFrequency = (

--- a/packages/utils/src/callLatest.ts
+++ b/packages/utils/src/callLatest.ts
@@ -12,9 +12,7 @@ const createCallLatestInternal = <Args extends unknown[], Result>(
 ): AsyncFunction<Args, Result> => {
   let currentPromise: ControlledPromise<Result> | undefined = undefined;
   let nextPromise: ControlledPromise<Result> | undefined = undefined;
-  let call = () => {
-    /** Nothing */
-  };
+  let call: () => void = () => undefined;
 
   const getPromise = () => {
     if (!currentPromise) {

--- a/packages/utils/src/gpuContext.gpu.ts
+++ b/packages/utils/src/gpuContext.gpu.ts
@@ -8,7 +8,7 @@ export const createGpuContext = async (
   const adapter = assertDefined(
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     await navigator.gpu?.requestAdapter(
-      // https://issues.chromium.org/issues/369219127
+      // @see https://issues.chromium.org/issues/369219127
       navigator.userAgent.includes('Windows')
         ? {}
         : { powerPreference: 'high-performance' },

--- a/packages/utils/src/spawnScript/spawnStderr.node.ts
+++ b/packages/utils/src/spawnScript/spawnStderr.node.ts
@@ -29,9 +29,7 @@ export type StderrOptions =
 
 const defaultStderr: StderrOptions = {
   mode: 'binary',
-  onChunk: () => {
-    /* ignore */
-  },
+  onChunk: () => undefined,
 };
 
 export type AttachStderrOptions = {

--- a/packages/utils/src/spawnScript/spawnStdout.node.ts
+++ b/packages/utils/src/spawnScript/spawnStdout.node.ts
@@ -28,9 +28,7 @@ export type StdoutOptions<Message extends { type: string }> =
 
 const defaultStdout: StdoutOptions<never> = {
   mode: 'binary',
-  onChunk: () => {
-    /* ignore */
-  },
+  onChunk: () => undefined,
 };
 
 export type AttachStdoutOptions<Message extends { type: string }> = {


### PR DESCRIPTION
Add musetric/no-comments (error) to @musetric/eslint-config, disallowing all comments except tooling directives and strict reference tags (@see/@todo/@fixme at the start of the comment).

Remove comments across all packages, expressing intent through names and implementation where they carried meaning: named constants for FFT magic numbers, descriptive locals, and no-op idioms in place of empty bodies that only existed to satisfy no-empty-function.