### PR TITLE
feat(lint): cap cyclomatic complexity and decompose the offenders

### DIFF
--- a/packages/engine/src/calibration/devices.ts
+++ b/packages/engine/src/calibration/devices.ts
@@ -17,6 +17,88 @@ const enumerateAudioDevices = async () => {
   );
 };
 
+type DeviceAvailability = {
+  inputDeviceAvailable: boolean;
+  outputDeviceAvailable: boolean;
+  outputSelectionAvailable: boolean;
+};
+
+const getDeviceAvailability = (
+  state: EngineState,
+  devices: MediaDeviceInfo[],
+  outputSelectionSupported: boolean,
+): DeviceAvailability => {
+  const realInputDevices = getRealAudioInputDevices(devices);
+  const realOutputDevices = getRealAudioOutputDevices(devices);
+  const inputDeviceAvailable =
+    state.microphoneDeviceId === undefined ||
+    realInputDevices.some(
+      (device) => device.deviceId === state.microphoneDeviceId,
+    );
+  const outputDeviceAvailable =
+    state.audioOutputDeviceId === undefined ||
+    realOutputDevices.some(
+      (device) => device.deviceId === state.audioOutputDeviceId,
+    );
+  const outputSelectionAvailable =
+    outputSelectionSupported || state.audioOutputDeviceId === undefined;
+  return {
+    inputDeviceAvailable,
+    outputDeviceAvailable,
+    outputSelectionAvailable,
+  };
+};
+
+const resolveNextDevices = (
+  state: EngineState,
+  devices: MediaDeviceInfo[],
+  availability: DeviceAvailability,
+) => {
+  const nextMicrophoneDeviceId = availability.inputDeviceAvailable
+    ? state.microphoneDeviceId
+    : undefined;
+  const nextOutputDeviceId =
+    availability.outputDeviceAvailable && availability.outputSelectionAvailable
+      ? state.audioOutputDeviceId
+      : undefined;
+  const nextInputDevice = resolveAudioInputDevice(devices, {
+    explicitDeviceId: nextMicrophoneDeviceId,
+    preferBuiltIn: mobileUserAgentPattern.test(navigator.userAgent),
+  });
+  const nextOutputDevice = resolveAudioOutputDevice(devices, {
+    explicitDeviceId: nextOutputDeviceId,
+  });
+  return { nextInputDevice, nextOutputDevice };
+};
+
+const resetLostDevices = async (
+  audioOutput: EngineAudioOutput,
+  store: Store<EngineState>,
+  availability: DeviceAvailability,
+): Promise<void> => {
+  const {
+    inputDeviceAvailable,
+    outputDeviceAvailable,
+    outputSelectionAvailable,
+  } = availability;
+  const resetOutput = !outputDeviceAvailable || !outputSelectionAvailable;
+  if (resetOutput) {
+    try {
+      await audioOutput.setDeviceId(undefined);
+    } catch (outputError) {
+      console.error('Failed to reset audio output', outputError);
+    }
+  }
+  store.update((draft) => {
+    if (!inputDeviceAvailable) {
+      draft.microphoneDeviceId = undefined;
+    }
+    if (resetOutput) {
+      draft.audioOutputDeviceId = undefined;
+    }
+  });
+};
+
 export type CalibrationDevicesOptions = {
   store: Store<EngineState>;
   audioOutput: EngineAudioOutput;
@@ -47,35 +129,16 @@ export const createCalibrationDevices = (
   const apply = async (): Promise<MediaDeviceInfo[]> => {
     const devices = await enumerateAudioDevices();
     const state = store.get();
-    const realInputDevices = getRealAudioInputDevices(devices);
-    const realOutputDevices = getRealAudioOutputDevices(devices);
-    const outputSelectionSupported = audioOutput.supportsDeviceSelection;
-    const inputDeviceAvailable =
-      state.microphoneDeviceId === undefined ||
-      realInputDevices.some(
-        (device) => device.deviceId === state.microphoneDeviceId,
-      );
-    const outputDeviceAvailable =
-      state.audioOutputDeviceId === undefined ||
-      realOutputDevices.some(
-        (device) => device.deviceId === state.audioOutputDeviceId,
-      );
-    const outputSelectionAvailable =
-      outputSelectionSupported || state.audioOutputDeviceId === undefined;
-    const nextMicrophoneDeviceId = inputDeviceAvailable
-      ? state.microphoneDeviceId
-      : undefined;
-    const nextOutputDeviceId =
-      outputDeviceAvailable && outputSelectionAvailable
-        ? state.audioOutputDeviceId
-        : undefined;
-    const nextInputDevice = resolveAudioInputDevice(devices, {
-      explicitDeviceId: nextMicrophoneDeviceId,
-      preferBuiltIn: mobileUserAgentPattern.test(navigator.userAgent),
-    });
-    const nextOutputDevice = resolveAudioOutputDevice(devices, {
-      explicitDeviceId: nextOutputDeviceId,
-    });
+    const availability = getDeviceAvailability(
+      state,
+      devices,
+      audioOutput.supportsDeviceSelection,
+    );
+    const { nextInputDevice, nextOutputDevice } = resolveNextDevices(
+      state,
+      devices,
+      availability,
+    );
     const nextDevicePairKey = getRecordingLatencyDevicePairKey(
       nextInputDevice,
       nextOutputDevice,
@@ -98,26 +161,12 @@ export const createCalibrationDevices = (
       onActiveDeviceChanged(nextDevicePairKey);
     }
 
-    if (
-      !inputDeviceAvailable ||
-      !outputDeviceAvailable ||
-      !outputSelectionAvailable
-    ) {
-      if (!outputDeviceAvailable || !outputSelectionAvailable) {
-        try {
-          await audioOutput.setDeviceId(undefined);
-        } catch (outputError) {
-          console.error('Failed to reset audio output', outputError);
-        }
-      }
-      store.update((draft) => {
-        if (!inputDeviceAvailable) {
-          draft.microphoneDeviceId = undefined;
-        }
-        if (!outputDeviceAvailable || !outputSelectionAvailable) {
-          draft.audioOutputDeviceId = undefined;
-        }
-      });
+    const deviceLost =
+      !availability.inputDeviceAvailable ||
+      !availability.outputDeviceAvailable ||
+      !availability.outputSelectionAvailable;
+    if (deviceLost) {
+      await resetLostDevices(audioOutput, store, availability);
       onDeviceLost(nextDevicePairKey);
     }
 

--- a/packages/eslint-config/src/config/js.ts
+++ b/packages/eslint-config/src/config/js.ts
@@ -45,6 +45,7 @@ export const jsConfig: Linter.Config = {
     ...musetricRecommendedRules,
     ...sonarjs.configs.recommended.rules,
     'arrow-body-style': ['error', 'as-needed'],
+    complexity: ['error', 15],
     eqeqeq: ['error', 'always'],
     'func-names': ['error'],
     'import-x/no-cycle': ['error', { ignoreExternal: true }],

--- a/packages/frontend/src/pages/project/buttons/PlaybackControlsButton.tsx
+++ b/packages/frontend/src/pages/project/buttons/PlaybackControlsButton.tsx
@@ -1,11 +1,9 @@
-import MicRoundedIcon from '@mui/icons-material/MicRounded';
-import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
-import StopRoundedIcon from '@mui/icons-material/StopRounded';
-import { Box, IconButton } from '@mui/material';
+import { Box } from '@mui/material';
 import { type FC } from 'react';
-import { useTranslation } from 'react-i18next';
-import { engine } from '../../../engine/engine.js';
 import { useEngineStore } from '../../../engine/useEngineStore.js';
+import { PlaybackPlayButton } from './PlaybackPlayButton.js';
+import { PlaybackRecordButton } from './PlaybackRecordButton.js';
+import { PlaybackStopButton } from './PlaybackStopButton.js';
 
 export type PlaybackControlsButtonProps = {
   projectId: number;
@@ -15,32 +13,10 @@ export const PlaybackControlsButton: FC<PlaybackControlsButtonProps> = (
   props,
 ) => {
   const { projectId } = props;
-  const { t } = useTranslation();
   const frameCount = useEngineStore((state) => state.frameCount);
   const playing = useEngineStore((state) => state.playing);
   const recording = useEngineStore((state) => state.recording);
-  const isSlave = useEngineStore((state) => state.isSlave);
-  const playerCommandPending = useEngineStore(
-    (state) => state.playerCommandPending,
-  );
-  const realtimeFailed = useEngineStore(
-    (state) => state.statuses.realtime === 'error',
-  );
-  const sourceTempoBpm = useEngineStore((state) => state.sourceTempoBpm);
-  const tempoBpm = useEngineStore((state) => state.tempoBpm);
-  const transposeSemitones = useEngineStore(
-    (state) => state.transposeSemitones,
-  );
   const active = playing || recording;
-  const recordingDisabled =
-    !frameCount ||
-    realtimeFailed ||
-    tempoBpm !== sourceTempoBpm ||
-    transposeSemitones !== 0 ||
-    isSlave;
-  const playDisabled =
-    !frameCount || realtimeFailed || playerCommandPending || isSlave;
-  const stopDisabled = !frameCount || realtimeFailed || playerCommandPending;
 
   const getBorderColor = () => {
     if (!frameCount) {
@@ -51,6 +27,7 @@ export const PlaybackControlsButton: FC<PlaybackControlsButtonProps> = (
     }
     return 'text.primary';
   };
+  const borderColor = getBorderColor();
 
   return (
     <Box
@@ -61,72 +38,14 @@ export const PlaybackControlsButton: FC<PlaybackControlsButtonProps> = (
       alignItems='center'
       border='1px solid'
       borderRadius={999}
-      borderColor={getBorderColor()}
+      borderColor={borderColor}
     >
+      {!active && <PlaybackRecordButton projectId={projectId} />}
       {!active && (
-        <IconButton
-          color='error'
-          disabled={recordingDisabled || playerCommandPending}
-          onClick={() => {
-            void engine.player.record(projectId);
-          }}
-          size='small'
-          sx={{
-            alignSelf: 'stretch',
-            borderBottomRightRadius: 0,
-            borderTopRightRadius: 0,
-            flex: 1,
-          }}
-          title={t('pages.project.player.controls.record')}
-        >
-          <MicRoundedIcon />
-        </IconButton>
+        <Box width='1px' height={20} bgcolor={borderColor} flexShrink={0} />
       )}
-      {!active && (
-        <Box
-          width='1px'
-          height={20}
-          bgcolor={getBorderColor()}
-          flexShrink={0}
-        />
-      )}
-      {!active && (
-        <IconButton
-          disabled={playDisabled}
-          onClick={() => {
-            void engine.player.play();
-          }}
-          size='small'
-          sx={{
-            alignSelf: 'stretch',
-            borderBottomLeftRadius: 0,
-            borderTopLeftRadius: 0,
-            flex: 1,
-          }}
-          title={t('pages.project.player.controls.play')}
-        >
-          <PlayArrowRoundedIcon />
-        </IconButton>
-      )}
-      {active && (
-        <IconButton
-          color={recording ? 'error' : undefined}
-          disabled={stopDisabled}
-          onClick={() => {
-            void engine.player.stop();
-          }}
-          size='small'
-          sx={{
-            alignSelf: 'stretch',
-            borderRadius: 999,
-            flex: 1,
-            mx: -0.5,
-          }}
-          title={t('pages.project.player.controls.stop')}
-        >
-          <StopRoundedIcon />
-        </IconButton>
-      )}
+      {!active && <PlaybackPlayButton />}
+      {active && <PlaybackStopButton />}
     </Box>
   );
 };

--- a/packages/frontend/src/pages/project/buttons/PlaybackPlayButton.tsx
+++ b/packages/frontend/src/pages/project/buttons/PlaybackPlayButton.tsx
@@ -1,0 +1,39 @@
+import PlayArrowRoundedIcon from '@mui/icons-material/PlayArrowRounded';
+import { IconButton } from '@mui/material';
+import { type FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { engine } from '../../../engine/engine.js';
+import { useEngineStore } from '../../../engine/useEngineStore.js';
+
+export const PlaybackPlayButton: FC = () => {
+  const { t } = useTranslation();
+  const frameCount = useEngineStore((state) => state.frameCount);
+  const isSlave = useEngineStore((state) => state.isSlave);
+  const playerCommandPending = useEngineStore(
+    (state) => state.playerCommandPending,
+  );
+  const realtimeFailed = useEngineStore(
+    (state) => state.statuses.realtime === 'error',
+  );
+  const disabled =
+    !frameCount || realtimeFailed || playerCommandPending || isSlave;
+
+  return (
+    <IconButton
+      disabled={disabled}
+      onClick={() => {
+        void engine.player.play();
+      }}
+      size='small'
+      sx={{
+        alignSelf: 'stretch',
+        borderBottomLeftRadius: 0,
+        borderTopLeftRadius: 0,
+        flex: 1,
+      }}
+      title={t('pages.project.player.controls.play')}
+    >
+      <PlayArrowRoundedIcon />
+    </IconButton>
+  );
+};

--- a/packages/frontend/src/pages/project/buttons/PlaybackRecordButton.tsx
+++ b/packages/frontend/src/pages/project/buttons/PlaybackRecordButton.tsx
@@ -1,0 +1,55 @@
+import MicRoundedIcon from '@mui/icons-material/MicRounded';
+import { IconButton } from '@mui/material';
+import { type FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { engine } from '../../../engine/engine.js';
+import { useEngineStore } from '../../../engine/useEngineStore.js';
+
+export type PlaybackRecordButtonProps = {
+  projectId: number;
+};
+
+export const PlaybackRecordButton: FC<PlaybackRecordButtonProps> = (props) => {
+  const { projectId } = props;
+  const { t } = useTranslation();
+  const frameCount = useEngineStore((state) => state.frameCount);
+  const isSlave = useEngineStore((state) => state.isSlave);
+  const playerCommandPending = useEngineStore(
+    (state) => state.playerCommandPending,
+  );
+  const realtimeFailed = useEngineStore(
+    (state) => state.statuses.realtime === 'error',
+  );
+  const sourceTempoBpm = useEngineStore((state) => state.sourceTempoBpm);
+  const tempoBpm = useEngineStore((state) => state.tempoBpm);
+  const transposeSemitones = useEngineStore(
+    (state) => state.transposeSemitones,
+  );
+  const disabled =
+    !frameCount ||
+    realtimeFailed ||
+    tempoBpm !== sourceTempoBpm ||
+    transposeSemitones !== 0 ||
+    isSlave ||
+    playerCommandPending;
+
+  return (
+    <IconButton
+      color='error'
+      disabled={disabled}
+      onClick={() => {
+        void engine.player.record(projectId);
+      }}
+      size='small'
+      sx={{
+        alignSelf: 'stretch',
+        borderBottomRightRadius: 0,
+        borderTopRightRadius: 0,
+        flex: 1,
+      }}
+      title={t('pages.project.player.controls.record')}
+    >
+      <MicRoundedIcon />
+    </IconButton>
+  );
+};

--- a/packages/frontend/src/pages/project/buttons/PlaybackStopButton.tsx
+++ b/packages/frontend/src/pages/project/buttons/PlaybackStopButton.tsx
@@ -1,0 +1,39 @@
+import StopRoundedIcon from '@mui/icons-material/StopRounded';
+import { IconButton } from '@mui/material';
+import { type FC } from 'react';
+import { useTranslation } from 'react-i18next';
+import { engine } from '../../../engine/engine.js';
+import { useEngineStore } from '../../../engine/useEngineStore.js';
+
+export const PlaybackStopButton: FC = () => {
+  const { t } = useTranslation();
+  const frameCount = useEngineStore((state) => state.frameCount);
+  const recording = useEngineStore((state) => state.recording);
+  const playerCommandPending = useEngineStore(
+    (state) => state.playerCommandPending,
+  );
+  const realtimeFailed = useEngineStore(
+    (state) => state.statuses.realtime === 'error',
+  );
+  const disabled = !frameCount || realtimeFailed || playerCommandPending;
+
+  return (
+    <IconButton
+      color={recording ? 'error' : undefined}
+      disabled={disabled}
+      onClick={() => {
+        void engine.player.stop();
+      }}
+      size='small'
+      sx={{
+        alignSelf: 'stretch',
+        borderRadius: 999,
+        flex: 1,
+        mx: -0.5,
+      }}
+      title={t('pages.project.player.controls.stop')}
+    >
+      <StopRoundedIcon />
+    </IconButton>
+  );
+};


### PR DESCRIPTION
Turn on the `complexity` ESLint rule (error, max 15) and bring the two functions that broke it under the cap by decomposition, not suppression.

- eslint-config: enable complexity rule at 15.
- engine calibration devices: split the monolithic `apply` (21) into pure helpers `getDeviceAvailability` and `resolveNextDevices` plus the side-effect `resetLostDevices`, leaving `apply` a linear orchestrator.
- frontend PlaybackControlsButton (17): extract the record, play and stop buttons into PlaybackRecordButton, PlaybackPlayButton and PlaybackStopButton, each subscribing to only the state it needs.