### PR TITLE
refactor(dupe): share worker, realtime and visualization helpers

### DIFF
--- a/packages/api/src/routes/project.ts
+++ b/packages/api/src/routes/project.ts
@@ -123,6 +123,35 @@ export namespace realtime {
   export type Params = z.infer<typeof base.paramsSchema>;
   export type Request = z.infer<typeof base.requestSchema>;
   export type Response = z.infer<typeof base.responseSchema>;
+
+  export type Event =
+    | { type: 'recording.started' }
+    | {
+        type: 'recording.peaksChanged';
+        startPeakIndex: number;
+        peaks: number[];
+      }
+    | { type: 'recording.finished' }
+    | { type: 'error'; error: string }
+    | { type: 'player.play' }
+    | { type: 'player.record' }
+    | { type: 'player.stop' }
+    | {
+        type: 'player.frameIndex';
+        frameIndex: number;
+        frozen: boolean;
+        revision: number;
+        source: 'playback' | 'user';
+      }
+    | { type: 'player.revision'; revision: number }
+    | {
+        type: 'player.sync.state';
+        active: boolean;
+        recording: boolean;
+        frozen: boolean;
+        frameIndex: number;
+        revision: number;
+      };
 }
 
 export namespace create {

--- a/packages/backend/src/routers/recording/realtime.ts
+++ b/packages/backend/src/routers/recording/realtime.ts
@@ -1,4 +1,5 @@
 import { type WebSocket } from '@fastify/websocket';
+import { type api } from '@musetric/api';
 
 export type RecordingStartMessage = {
   type: 'recording.start';
@@ -82,38 +83,9 @@ export const isRealtimeMessage = (
 ): message is Record<string, unknown> =>
   typeof message === 'object' && Boolean(message);
 
-export type ProjectRealtimeEvent =
-  | { type: 'recording.started' }
-  | {
-      type: 'recording.peaksChanged';
-      startPeakIndex: number;
-      peaks: number[];
-    }
-  | { type: 'recording.finished' }
-  | { type: 'error'; error: string }
-  | { type: 'player.play' }
-  | { type: 'player.record' }
-  | { type: 'player.stop' }
-  | {
-      type: 'player.frameIndex';
-      frameIndex: number;
-      frozen: boolean;
-      revision: number;
-      source: 'playback' | 'user';
-    }
-  | { type: 'player.revision'; revision: number }
-  | {
-      type: 'player.sync.state';
-      active: boolean;
-      recording: boolean;
-      frozen: boolean;
-      frameIndex: number;
-      revision: number;
-    };
-
 export const sendRealtimeEvent = (
   socket: WebSocket,
-  event: ProjectRealtimeEvent,
+  event: api.project.realtime.Event,
 ): void => {
   if (socket.readyState !== 1) {
     return;

--- a/packages/backend/src/routers/recording/recordingHandlers.ts
+++ b/packages/backend/src/routers/recording/recordingHandlers.ts
@@ -1,8 +1,8 @@
 import { type WebSocket } from '@fastify/websocket';
+import { type api } from '@musetric/api';
 import {
   broadcastRealtime,
   claimPlayerMaster,
-  type ProjectRealtimeEvent,
   type RecordingStartMessage,
   sendRealtimeEvent,
   sendRealtimePacket,
@@ -28,7 +28,7 @@ export type RecordingRealtimeContext = {
   isSocketClosed: () => boolean;
   setIgnoringRecordingStream: (value: boolean) => void;
   isIgnoringRecordingStream: () => boolean;
-  send: (event: ProjectRealtimeEvent) => void;
+  send: (event: api.project.realtime.Event) => void;
   closeWithError: (error: unknown, reason: string) => void;
   enqueueSessionAction: (reason: string, action: () => Promise<void>) => void;
 };

--- a/packages/backend/src/services/processingWorker/analysisWorker.ts
+++ b/packages/backend/src/services/processingWorker/analysisWorker.ts
@@ -1,0 +1,78 @@
+import { type api } from '@musetric/api';
+import {
+  type EventEmitter,
+  type Logger,
+  type MessageHandlers,
+} from '@musetric/utils';
+import {
+  type ProcessingStepKind,
+  type ProcessingWorkerEvent,
+  type ProcessingWorkerProgressEvent,
+} from './processingSummary.js';
+
+export type AnalysisHandlers = MessageHandlers<
+  | { type: 'progress'; progress: number }
+  | ({ type: 'download' } & api.project.Download)
+>;
+
+export type AnalysisWorker<Task> = {
+  run: (task: Task) => Promise<void>;
+  getState: (projectId: number) => ProcessingWorkerProgressEvent | undefined;
+};
+
+export type AnalysisWorkerConfig<Task> = {
+  step: ProcessingStepKind;
+  errorMessage: string;
+  process: (task: Task, handlers: AnalysisHandlers) => Promise<void>;
+};
+
+export const createAnalysisWorker = <Task extends { projectId: number }>(
+  emitter: EventEmitter<ProcessingWorkerEvent>,
+  logger: Logger,
+  config: AnalysisWorkerConfig<Task>,
+): AnalysisWorker<Task> => {
+  const { step, errorMessage, process } = config;
+  let state: ProcessingWorkerProgressEvent | undefined = undefined;
+
+  const handlers: AnalysisHandlers = {
+    progress: (message) => {
+      if (!state) {
+        return;
+      }
+      state = { ...state, progress: message.progress };
+      emitter.emit(state);
+    },
+    download: (message) => {
+      if (!state) {
+        return;
+      }
+      state = { ...state, download: message };
+      emitter.emit(state);
+    },
+  };
+
+  return {
+    run: async (task) => {
+      try {
+        state = {
+          type: 'progress',
+          projectId: task.projectId,
+          step,
+          progress: 0,
+        };
+        emitter.emit(state);
+
+        await process(task, handlers);
+
+        emitter.emit({ type: 'complete', projectId: task.projectId, step });
+        state = undefined;
+      } catch (error) {
+        emitter.emit({ type: 'error', projectId: task.projectId, step });
+        state = undefined;
+        logger.error({ projectId: task.projectId, error }, errorMessage);
+      }
+    },
+    getState: (projectId) =>
+      state && state.projectId === projectId ? state : undefined,
+  };
+};

--- a/packages/backend/src/services/processingWorker/processingChords.ts
+++ b/packages/backend/src/services/processingWorker/processingChords.ts
@@ -2,97 +2,40 @@ import { analyzeChords } from '@musetric/ai/node';
 import { type EventEmitter, type Logger } from '@musetric/utils';
 import { type FastifyInstance } from 'fastify';
 import { envs } from '../../common/envs.js';
-import {
-  type ProcessingWorkerEvent,
-  type ProcessingWorkerProgressEvent,
-} from './processingSummary.js';
+import { type AnalysisWorker, createAnalysisWorker } from './analysisWorker.js';
+import { type ProcessingWorkerEvent } from './processingSummary.js';
 
 export type ChordsTask = {
   projectId: number;
   blobId: string;
 };
 
-export type ChordsWorker = {
-  run: (task: ChordsTask) => Promise<void>;
-  getState: (projectId: number) => ProcessingWorkerProgressEvent | undefined;
-};
+export type ChordsWorker = AnalysisWorker<ChordsTask>;
 
 export const createChordsWorker = (
   app: FastifyInstance,
   emitter: EventEmitter<ProcessingWorkerEvent>,
   logger: Logger,
-): ChordsWorker => {
-  let state: ProcessingWorkerProgressEvent | undefined = undefined;
+): ChordsWorker =>
+  createAnalysisWorker<ChordsTask>(emitter, logger, {
+    step: 'chords',
+    errorMessage: 'Chord detection failed',
+    process: async (task, handlers) => {
+      const sourcePath = app.blobStorage.getPath(task.blobId);
+      const chords = app.blobStorage.createPath();
 
-  return {
-    run: async (task) => {
-      try {
-        state = {
-          type: 'progress',
-          projectId: task.projectId,
-          step: 'chords',
-          progress: 0,
-        };
-        emitter.emit(state);
+      await analyzeChords({
+        gpuHost: app.gpuHost,
+        sourcePath,
+        resultPath: chords.blobPath,
+        handlers,
+        modelsPath: envs.modelsPath,
+        logger,
+      });
 
-        const sourcePath = app.blobStorage.getPath(task.blobId);
-        const chords = app.blobStorage.createPath();
-
-        await analyzeChords({
-          gpuHost: app.gpuHost,
-          sourcePath,
-          resultPath: chords.blobPath,
-          handlers: {
-            progress: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                progress: message.progress,
-              };
-              emitter.emit(state);
-            },
-            download: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                download: message,
-              };
-              emitter.emit(state);
-            },
-          },
-          modelsPath: envs.modelsPath,
-          logger,
-        });
-
-        await app.db.processing.applyChordsResult({
-          projectId: task.projectId,
-          blobId: chords.blobId,
-        });
-
-        emitter.emit({
-          type: 'complete',
-          projectId: task.projectId,
-          step: 'chords',
-        });
-        state = undefined;
-      } catch (error) {
-        emitter.emit({
-          type: 'error',
-          projectId: task.projectId,
-          step: 'chords',
-        });
-        state = undefined;
-        logger.error(
-          { projectId: task.projectId, error },
-          'Chord detection failed',
-        );
-      }
+      await app.db.processing.applyChordsResult({
+        projectId: task.projectId,
+        blobId: chords.blobId,
+      });
     },
-    getState: (projectId) =>
-      state && state.projectId === projectId ? state : undefined,
-  };
-};
+  });

--- a/packages/backend/src/services/processingWorker/processingKey.ts
+++ b/packages/backend/src/services/processingWorker/processingKey.ts
@@ -2,96 +2,39 @@ import { analyzeKey } from '@musetric/ai/node';
 import { type EventEmitter, type Logger } from '@musetric/utils';
 import { type FastifyInstance } from 'fastify';
 import { envs } from '../../common/envs.js';
-import {
-  type ProcessingWorkerEvent,
-  type ProcessingWorkerProgressEvent,
-} from './processingSummary.js';
+import { type AnalysisWorker, createAnalysisWorker } from './analysisWorker.js';
+import { type ProcessingWorkerEvent } from './processingSummary.js';
 
 export type KeyTask = {
   projectId: number;
   blobId: string;
 };
 
-export type KeyWorker = {
-  run: (task: KeyTask) => Promise<void>;
-  getState: (projectId: number) => ProcessingWorkerProgressEvent | undefined;
-};
+export type KeyWorker = AnalysisWorker<KeyTask>;
 
 export const createKeyWorker = (
   app: FastifyInstance,
   emitter: EventEmitter<ProcessingWorkerEvent>,
   logger: Logger,
-): KeyWorker => {
-  let state: ProcessingWorkerProgressEvent | undefined = undefined;
+): KeyWorker =>
+  createAnalysisWorker<KeyTask>(emitter, logger, {
+    step: 'key',
+    errorMessage: 'Key detection failed',
+    process: async (task, handlers) => {
+      const sourcePath = app.blobStorage.getPath(task.blobId);
+      const key = app.blobStorage.createPath();
 
-  return {
-    run: async (task) => {
-      try {
-        state = {
-          type: 'progress',
-          projectId: task.projectId,
-          step: 'key',
-          progress: 0,
-        };
-        emitter.emit(state);
+      await analyzeKey({
+        sourcePath,
+        resultPath: key.blobPath,
+        handlers,
+        modelsPath: envs.modelsPath,
+        logger,
+      });
 
-        const sourcePath = app.blobStorage.getPath(task.blobId);
-        const key = app.blobStorage.createPath();
-
-        await analyzeKey({
-          sourcePath,
-          resultPath: key.blobPath,
-          handlers: {
-            progress: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                progress: message.progress,
-              };
-              emitter.emit(state);
-            },
-            download: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                download: message,
-              };
-              emitter.emit(state);
-            },
-          },
-          modelsPath: envs.modelsPath,
-          logger,
-        });
-
-        await app.db.processing.applyKeyResult({
-          projectId: task.projectId,
-          blobId: key.blobId,
-        });
-
-        emitter.emit({
-          type: 'complete',
-          projectId: task.projectId,
-          step: 'key',
-        });
-        state = undefined;
-      } catch (error) {
-        emitter.emit({
-          type: 'error',
-          projectId: task.projectId,
-          step: 'key',
-        });
-        state = undefined;
-        logger.error(
-          { projectId: task.projectId, error },
-          'Key detection failed',
-        );
-      }
+      await app.db.processing.applyKeyResult({
+        projectId: task.projectId,
+        blobId: key.blobId,
+      });
     },
-    getState: (projectId) =>
-      state && state.projectId === projectId ? state : undefined,
-  };
-};
+  });

--- a/packages/backend/src/services/processingWorker/processingRhythm.ts
+++ b/packages/backend/src/services/processingWorker/processingRhythm.ts
@@ -2,97 +2,40 @@ import { analyzeRhythm } from '@musetric/ai/node';
 import { type EventEmitter, type Logger } from '@musetric/utils';
 import { type FastifyInstance } from 'fastify';
 import { envs } from '../../common/envs.js';
-import {
-  type ProcessingWorkerEvent,
-  type ProcessingWorkerProgressEvent,
-} from './processingSummary.js';
+import { type AnalysisWorker, createAnalysisWorker } from './analysisWorker.js';
+import { type ProcessingWorkerEvent } from './processingSummary.js';
 
 export type RhythmTask = {
   projectId: number;
   blobId: string;
 };
 
-export type RhythmWorker = {
-  run: (task: RhythmTask) => Promise<void>;
-  getState: (projectId: number) => ProcessingWorkerProgressEvent | undefined;
-};
+export type RhythmWorker = AnalysisWorker<RhythmTask>;
 
 export const createRhythmWorker = (
   app: FastifyInstance,
   emitter: EventEmitter<ProcessingWorkerEvent>,
   logger: Logger,
-): RhythmWorker => {
-  let state: ProcessingWorkerProgressEvent | undefined = undefined;
+): RhythmWorker =>
+  createAnalysisWorker<RhythmTask>(emitter, logger, {
+    step: 'rhythm',
+    errorMessage: 'Rhythm analysis failed',
+    process: async (task, handlers) => {
+      const sourcePath = app.blobStorage.getPath(task.blobId);
+      const rhythm = app.blobStorage.createPath();
 
-  return {
-    run: async (task) => {
-      try {
-        state = {
-          type: 'progress',
-          projectId: task.projectId,
-          step: 'rhythm',
-          progress: 0,
-        };
-        emitter.emit(state);
+      await analyzeRhythm({
+        gpuHost: app.gpuHost,
+        sourcePath,
+        resultPath: rhythm.blobPath,
+        handlers,
+        modelsPath: envs.modelsPath,
+        logger,
+      });
 
-        const sourcePath = app.blobStorage.getPath(task.blobId);
-        const rhythm = app.blobStorage.createPath();
-
-        await analyzeRhythm({
-          gpuHost: app.gpuHost,
-          sourcePath,
-          resultPath: rhythm.blobPath,
-          handlers: {
-            progress: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                progress: message.progress,
-              };
-              emitter.emit(state);
-            },
-            download: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                download: message,
-              };
-              emitter.emit(state);
-            },
-          },
-          modelsPath: envs.modelsPath,
-          logger,
-        });
-
-        await app.db.processing.applyRhythmResult({
-          projectId: task.projectId,
-          blobId: rhythm.blobId,
-        });
-
-        emitter.emit({
-          type: 'complete',
-          projectId: task.projectId,
-          step: 'rhythm',
-        });
-        state = undefined;
-      } catch (error) {
-        emitter.emit({
-          type: 'error',
-          projectId: task.projectId,
-          step: 'rhythm',
-        });
-        state = undefined;
-        logger.error(
-          { projectId: task.projectId, error },
-          'Rhythm analysis failed',
-        );
-      }
+      await app.db.processing.applyRhythmResult({
+        projectId: task.projectId,
+        blobId: rhythm.blobId,
+      });
     },
-    getState: (projectId) =>
-      state && state.projectId === projectId ? state : undefined,
-  };
-};
+  });

--- a/packages/backend/src/services/processingWorker/processingSeparation.ts
+++ b/packages/backend/src/services/processingWorker/processingSeparation.ts
@@ -12,10 +12,8 @@ import {
 } from '@musetric/utils';
 import { type FastifyInstance } from 'fastify';
 import { envs } from '../../common/envs.js';
-import {
-  type ProcessingWorkerEvent,
-  type ProcessingWorkerProgressEvent,
-} from './processingSummary.js';
+import { type AnalysisWorker, createAnalysisWorker } from './analysisWorker.js';
+import { type ProcessingWorkerEvent } from './processingSummary.js';
 
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(max, Math.max(min, value));
@@ -64,178 +62,126 @@ export type SeparationTask = {
   blobId: string;
 };
 
-export type SeparationWorker = {
-  run: (task: SeparationTask) => Promise<void>;
-  getState: (projectId: number) => ProcessingWorkerProgressEvent | undefined;
-};
+export type SeparationWorker = AnalysisWorker<SeparationTask>;
 
 export const createSeparationWorker = (
   app: FastifyInstance,
   emitter: EventEmitter<ProcessingWorkerEvent>,
   logger: Logger,
-): SeparationWorker => {
-  let state: ProcessingWorkerProgressEvent | undefined = undefined;
-
-  return {
-    run: async (task) => {
-      try {
-        state = {
-          type: 'progress',
-          projectId: task.projectId,
-          step: 'separation',
-          progress: 0,
-        };
-        emitter.emit(state);
-
-        const project = await app.db.project.get(task.projectId);
-        if (!project) {
-          throw new Error(`Project with id ${task.projectId} not found`);
-        }
-
-        const masterSourcePath = app.blobStorage.getPath(task.blobId);
-        const sourceAnalysisPromise = analyzeLoudness({
-          fromPath: masterSourcePath,
-          logger,
-        });
-        const masterLead = app.blobStorage.createPath();
-        const masterBacking = app.blobStorage.createPath();
-        const masterInstrumental = app.blobStorage.createPath();
-
-        await separateAudio({
-          gpuHost: app.gpuHost,
-          sourcePath: masterSourcePath,
-          leadPath: masterLead.blobPath,
-          backingPath: masterBacking.blobPath,
-          instrumentalPath: masterInstrumental.blobPath,
-          sampleRate: project.sampleRate,
-          handlers: {
-            progress: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                progress: message.progress,
-              };
-              emitter.emit(state);
-            },
-            download: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                download: message,
-              };
-              emitter.emit(state);
-            },
-          },
-          modelsPath: envs.modelsPath,
-          logger,
-        });
-
-        const deliveryLead = app.blobStorage.createPath();
-        const deliveryBacking = app.blobStorage.createPath();
-        const deliveryInstrumental = app.blobStorage.createPath();
-        await Promise.all([
-          convertToFmp4({
-            fromPath: masterLead.blobPath,
-            toPath: deliveryLead.blobPath,
-            sampleRate: project.sampleRate,
-            logger,
-          }),
-          convertToFmp4({
-            fromPath: masterBacking.blobPath,
-            toPath: deliveryBacking.blobPath,
-            sampleRate: project.sampleRate,
-            logger,
-          }),
-          convertToFmp4({
-            fromPath: masterInstrumental.blobPath,
-            toPath: deliveryInstrumental.blobPath,
-            sampleRate: project.sampleRate,
-            logger,
-          }),
-        ]);
-
-        const wavePeaksLead = app.blobStorage.createPath();
-        const wavePeaksBacking = app.blobStorage.createPath();
-        const wavePeaksInstrumental = app.blobStorage.createPath();
-        await Promise.all([
-          generateWavePeaks({
-            fromPath: masterLead.blobPath,
-            toPath: wavePeaksLead.blobPath,
-            sampleRate: project.sampleRate,
-            logger,
-          }),
-          generateWavePeaks({
-            fromPath: masterBacking.blobPath,
-            toPath: wavePeaksBacking.blobPath,
-            sampleRate: project.sampleRate,
-            logger,
-          }),
-          generateWavePeaks({
-            fromPath: masterInstrumental.blobPath,
-            toPath: wavePeaksInstrumental.blobPath,
-            sampleRate: project.sampleRate,
-            logger,
-          }),
-        ]);
-
-        const [sourceAnalysis, leadAnalysis] = await Promise.all([
-          sourceAnalysisPromise,
-          analyzeLeadVisualLoudness({
-            fromPath: masterLead.blobPath,
-            sampleRate: project.sampleRate,
-            logger,
-          }),
-        ]);
-
-        await app.db.processing.applySeparationResult({
-          projectId: task.projectId,
-          audioAnalysis: {
-            sourceIntegratedLoudnessDb: sourceAnalysis.integratedLoudnessDb,
-            sourceTruePeakDb: sourceAnalysis.truePeakDb,
-            sourceGainDb: calculateSourceGainDb(sourceAnalysis),
-            leadIntegratedLoudnessDb: leadAnalysis.integratedLoudnessDb,
-            leadTruePeakDb: leadAnalysis.truePeakDb,
-            leadP95RmsDb: leadAnalysis.p95RmsDb,
-            leadSpectrogramGainDb: calculateLeadSpectrogramGainDb(leadAnalysis),
-          },
-          master: {
-            leadId: masterLead.blobId,
-            backingId: masterBacking.blobId,
-            instrumentalId: masterInstrumental.blobId,
-          },
-          delivery: {
-            leadId: deliveryLead.blobId,
-            backingId: deliveryBacking.blobId,
-            instrumentalId: deliveryInstrumental.blobId,
-          },
-          wavePeaks: {
-            leadId: wavePeaksLead.blobId,
-            backingId: wavePeaksBacking.blobId,
-            instrumentalId: wavePeaksInstrumental.blobId,
-          },
-        });
-
-        state = undefined;
-        emitter.emit({
-          type: 'complete',
-          projectId: task.projectId,
-          step: 'separation',
-        });
-      } catch (error) {
-        emitter.emit({
-          type: 'error',
-          projectId: task.projectId,
-          step: 'separation',
-        });
-        state = undefined;
-        logger.error({ projectId: task.projectId, error }, 'Separation failed');
+): SeparationWorker =>
+  createAnalysisWorker<SeparationTask>(emitter, logger, {
+    step: 'separation',
+    errorMessage: 'Separation failed',
+    process: async (task, handlers) => {
+      const project = await app.db.project.get(task.projectId);
+      if (!project) {
+        throw new Error(`Project with id ${task.projectId} not found`);
       }
+
+      const masterSourcePath = app.blobStorage.getPath(task.blobId);
+      const sourceAnalysisPromise = analyzeLoudness({
+        fromPath: masterSourcePath,
+        logger,
+      });
+      const masterLead = app.blobStorage.createPath();
+      const masterBacking = app.blobStorage.createPath();
+      const masterInstrumental = app.blobStorage.createPath();
+
+      await separateAudio({
+        gpuHost: app.gpuHost,
+        sourcePath: masterSourcePath,
+        leadPath: masterLead.blobPath,
+        backingPath: masterBacking.blobPath,
+        instrumentalPath: masterInstrumental.blobPath,
+        sampleRate: project.sampleRate,
+        handlers,
+        modelsPath: envs.modelsPath,
+        logger,
+      });
+
+      const deliveryLead = app.blobStorage.createPath();
+      const deliveryBacking = app.blobStorage.createPath();
+      const deliveryInstrumental = app.blobStorage.createPath();
+      await Promise.all([
+        convertToFmp4({
+          fromPath: masterLead.blobPath,
+          toPath: deliveryLead.blobPath,
+          sampleRate: project.sampleRate,
+          logger,
+        }),
+        convertToFmp4({
+          fromPath: masterBacking.blobPath,
+          toPath: deliveryBacking.blobPath,
+          sampleRate: project.sampleRate,
+          logger,
+        }),
+        convertToFmp4({
+          fromPath: masterInstrumental.blobPath,
+          toPath: deliveryInstrumental.blobPath,
+          sampleRate: project.sampleRate,
+          logger,
+        }),
+      ]);
+
+      const wavePeaksLead = app.blobStorage.createPath();
+      const wavePeaksBacking = app.blobStorage.createPath();
+      const wavePeaksInstrumental = app.blobStorage.createPath();
+      await Promise.all([
+        generateWavePeaks({
+          fromPath: masterLead.blobPath,
+          toPath: wavePeaksLead.blobPath,
+          sampleRate: project.sampleRate,
+          logger,
+        }),
+        generateWavePeaks({
+          fromPath: masterBacking.blobPath,
+          toPath: wavePeaksBacking.blobPath,
+          sampleRate: project.sampleRate,
+          logger,
+        }),
+        generateWavePeaks({
+          fromPath: masterInstrumental.blobPath,
+          toPath: wavePeaksInstrumental.blobPath,
+          sampleRate: project.sampleRate,
+          logger,
+        }),
+      ]);
+
+      const [sourceAnalysis, leadAnalysis] = await Promise.all([
+        sourceAnalysisPromise,
+        analyzeLeadVisualLoudness({
+          fromPath: masterLead.blobPath,
+          sampleRate: project.sampleRate,
+          logger,
+        }),
+      ]);
+
+      await app.db.processing.applySeparationResult({
+        projectId: task.projectId,
+        audioAnalysis: {
+          sourceIntegratedLoudnessDb: sourceAnalysis.integratedLoudnessDb,
+          sourceTruePeakDb: sourceAnalysis.truePeakDb,
+          sourceGainDb: calculateSourceGainDb(sourceAnalysis),
+          leadIntegratedLoudnessDb: leadAnalysis.integratedLoudnessDb,
+          leadTruePeakDb: leadAnalysis.truePeakDb,
+          leadP95RmsDb: leadAnalysis.p95RmsDb,
+          leadSpectrogramGainDb: calculateLeadSpectrogramGainDb(leadAnalysis),
+        },
+        master: {
+          leadId: masterLead.blobId,
+          backingId: masterBacking.blobId,
+          instrumentalId: masterInstrumental.blobId,
+        },
+        delivery: {
+          leadId: deliveryLead.blobId,
+          backingId: deliveryBacking.blobId,
+          instrumentalId: deliveryInstrumental.blobId,
+        },
+        wavePeaks: {
+          leadId: wavePeaksLead.blobId,
+          backingId: wavePeaksBacking.blobId,
+          instrumentalId: wavePeaksInstrumental.blobId,
+        },
+      });
     },
-    getState: (projectId) =>
-      state && state.projectId === projectId ? state : undefined,
-  };
-};
+  });

--- a/packages/backend/src/services/processingWorker/processingTranscription.ts
+++ b/packages/backend/src/services/processingWorker/processingTranscription.ts
@@ -2,97 +2,40 @@ import { transcribeAudio } from '@musetric/ai/node';
 import { type EventEmitter, type Logger } from '@musetric/utils';
 import { type FastifyInstance } from 'fastify';
 import { envs } from '../../common/envs.js';
-import {
-  type ProcessingWorkerEvent,
-  type ProcessingWorkerProgressEvent,
-} from './processingSummary.js';
+import { type AnalysisWorker, createAnalysisWorker } from './analysisWorker.js';
+import { type ProcessingWorkerEvent } from './processingSummary.js';
 
 export type TranscriptionTask = {
   projectId: number;
   blobId: string;
 };
 
-export type TranscriptionWorker = {
-  run: (task: TranscriptionTask) => Promise<void>;
-  getState: (projectId: number) => ProcessingWorkerProgressEvent | undefined;
-};
+export type TranscriptionWorker = AnalysisWorker<TranscriptionTask>;
 
 export const createTranscriptionWorker = (
   app: FastifyInstance,
   emitter: EventEmitter<ProcessingWorkerEvent>,
   logger: Logger,
-): TranscriptionWorker => {
-  let state: ProcessingWorkerProgressEvent | undefined = undefined;
+): TranscriptionWorker =>
+  createAnalysisWorker<TranscriptionTask>(emitter, logger, {
+    step: 'transcription',
+    errorMessage: 'Transcription failed',
+    process: async (task, handlers) => {
+      const sourcePath = app.blobStorage.getPath(task.blobId);
+      const transcription = app.blobStorage.createPath();
 
-  return {
-    run: async (task) => {
-      try {
-        state = {
-          type: 'progress',
-          projectId: task.projectId,
-          step: 'transcription',
-          progress: 0,
-        };
-        emitter.emit(state);
+      await transcribeAudio({
+        gpuHost: app.gpuHost,
+        sourcePath,
+        resultPath: transcription.blobPath,
+        handlers,
+        modelsPath: envs.modelsPath,
+        logger,
+      });
 
-        const sourcePath = app.blobStorage.getPath(task.blobId);
-        const transcription = app.blobStorage.createPath();
-
-        await transcribeAudio({
-          gpuHost: app.gpuHost,
-          sourcePath,
-          resultPath: transcription.blobPath,
-          handlers: {
-            progress: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                progress: message.progress,
-              };
-              emitter.emit(state);
-            },
-            download: (message) => {
-              if (!state) {
-                return;
-              }
-              state = {
-                ...state,
-                download: message,
-              };
-              emitter.emit(state);
-            },
-          },
-          modelsPath: envs.modelsPath,
-          logger,
-        });
-
-        await app.db.processing.applyTranscriptionResult({
-          projectId: task.projectId,
-          blobId: transcription.blobId,
-        });
-
-        emitter.emit({
-          type: 'complete',
-          projectId: task.projectId,
-          step: 'transcription',
-        });
-        state = undefined;
-      } catch (error) {
-        emitter.emit({
-          type: 'error',
-          projectId: task.projectId,
-          step: 'transcription',
-        });
-        state = undefined;
-        logger.error(
-          { projectId: task.projectId, error },
-          'Transcription failed',
-        );
-      }
+      await app.db.processing.applyTranscriptionResult({
+        projectId: task.projectId,
+        blobId: transcription.blobId,
+      });
     },
-    getState: (projectId) =>
-      state && state.projectId === projectId ? state : undefined,
-  };
-};
+  });

--- a/packages/engine/src/decoder/realtime.worker.ts
+++ b/packages/engine/src/decoder/realtime.worker.ts
@@ -33,39 +33,10 @@ const closeSocket = (realtime: InternalRealtime) => {
   realtime.socket.close();
 };
 
-export type ProjectRealtimeEvent =
-  | {
-      type: 'recording.peaksChanged';
-      startPeakIndex: number;
-      peaks: number[];
-    }
-  | { type: 'recording.finished' }
-  | { type: 'recording.started' }
-  | { type: 'error'; error: string }
-  | { type: 'player.play' }
-  | { type: 'player.record' }
-  | { type: 'player.stop' }
-  | {
-      type: 'player.frameIndex';
-      frameIndex: number;
-      frozen: boolean;
-      revision: number;
-      source: 'playback' | 'user';
-    }
-  | { type: 'player.revision'; revision: number }
-  | {
-      type: 'player.sync.state';
-      active: boolean;
-      recording: boolean;
-      frozen: boolean;
-      frameIndex: number;
-      revision: number;
-    };
-
 export type ProjectRealtimeOptions = {
   isRecordingReady: () => boolean;
   onOpen: () => void;
-  onEvent: (event: ProjectRealtimeEvent) => void;
+  onEvent: (event: api.project.realtime.Event) => void;
   onPacket: (data: ArrayBuffer) => void;
   onClose: (error: Error) => void;
 };

--- a/packages/frontend/src/pages/project/visualization/VisualizationCursor.tsx
+++ b/packages/frontend/src/pages/project/visualization/VisualizationCursor.tsx
@@ -1,16 +1,12 @@
 import { Box } from '@mui/material';
-import { subscribeResizeObserver } from '@musetric/utils/dom';
 import { type FC, useEffect, useRef } from 'react';
 import { engine } from '../../../engine/engine.js';
 import { useSettingsStore } from '../settings/store.js';
 import { useProjectStore } from '../store.js';
-
-const engineRenderKeys = ['frameCount', 'frameIndex'] as const;
-const projectRenderKeys = ['visualizationMode'] as const;
-const settingsRenderKeys = ['playheadRatio'] as const;
-
-const alignPixel = (value: number, pixelRatio: number) =>
-  Math.round(value * pixelRatio) / pixelRatio;
+import {
+  alignPixel,
+  subscribeVisualizationRender,
+} from './visualizationRender.js';
 
 export const VisualizationCursor: FC = () => {
   const ref = useRef<HTMLDivElement>(null);
@@ -52,24 +48,14 @@ export const VisualizationCursor: FC = () => {
 
     render();
 
-    const unsubscribes = [
-      subscribeResizeObserver(parentElement, resize),
-      ...engineRenderKeys.map((key) =>
-        engine.store.subscribe((state) => state[key], render),
-      ),
-      ...projectRenderKeys.map((key) =>
-        useProjectStore.subscribe((state) => state[key], render),
-      ),
-      ...settingsRenderKeys.map((key) =>
-        useSettingsStore.subscribe((state) => state[key], render),
-      ),
-    ];
-
-    return () => {
-      for (const unsubscribe of unsubscribes) {
-        unsubscribe();
-      }
-    };
+    return subscribeVisualizationRender({
+      resizeTarget: parentElement,
+      onResize: resize,
+      render,
+      engineKeys: ['frameCount', 'frameIndex'],
+      projectKeys: ['visualizationMode'],
+      settingsKeys: ['playheadRatio'],
+    });
   }, []);
 
   return (

--- a/packages/frontend/src/pages/project/visualization/VisualizationTimeline.tsx
+++ b/packages/frontend/src/pages/project/visualization/VisualizationTimeline.tsx
@@ -1,14 +1,14 @@
 import { Box } from '@mui/material';
 import { useTheme } from '@mui/material/styles';
 import { createTimelineProcessor } from '@musetric/audio/timeline';
-import { subscribeResizeObserver } from '@musetric/utils/dom';
 import { type FC, useEffect, useRef } from 'react';
 import { engine } from '../../../engine/engine.js';
 import { useSettingsStore } from '../settings/store.js';
 import { useProjectStore } from '../store.js';
-
-const alignPixel = (value: number, pixelRatio: number) =>
-  Math.round(value * pixelRatio) / pixelRatio;
+import {
+  alignPixel,
+  subscribeVisualizationRender,
+} from './visualizationRender.js';
 
 export const VisualizationTimeline: FC = () => {
   const theme = useTheme();
@@ -22,10 +22,6 @@ export const VisualizationTimeline: FC = () => {
     if (!canvas || !handle) {
       return;
     }
-
-    const engineRenderKeys = ['duration', 'frameCount', 'frameIndex'] as const;
-    const projectRenderKeys = ['visualizationMode'] as const;
-    const settingsRenderKeys = ['visibleTime', 'playheadRatio'] as const;
 
     const processor = createTimelineProcessor({
       config: {
@@ -73,23 +69,17 @@ export const VisualizationTimeline: FC = () => {
 
     render();
 
-    const unsubscribes = [
-      subscribeResizeObserver(canvas, resize),
-      ...engineRenderKeys.map((key) =>
-        engine.store.subscribe((state) => state[key], render),
-      ),
-      ...projectRenderKeys.map((key) =>
-        useProjectStore.subscribe((state) => state[key], render),
-      ),
-      ...settingsRenderKeys.map((key) =>
-        useSettingsStore.subscribe((state) => state[key], render),
-      ),
-    ];
+    const unsubscribe = subscribeVisualizationRender({
+      resizeTarget: canvas,
+      onResize: resize,
+      render,
+      engineKeys: ['duration', 'frameCount', 'frameIndex'],
+      projectKeys: ['visualizationMode'],
+      settingsKeys: ['visibleTime', 'playheadRatio'],
+    });
 
     return () => {
-      for (const unsubscribe of unsubscribes) {
-        unsubscribe();
-      }
+      unsubscribe();
       processor.dispose();
     };
   }, [theme]);

--- a/packages/frontend/src/pages/project/visualization/visualizationRender.ts
+++ b/packages/frontend/src/pages/project/visualization/visualizationRender.ts
@@ -1,0 +1,52 @@
+import { subscribeResizeObserver } from '@musetric/utils/dom';
+import { engine } from '../../../engine/engine.js';
+import { useSettingsStore } from '../settings/store.js';
+import { useProjectStore } from '../store.js';
+
+export const alignPixel = (value: number, pixelRatio: number): number =>
+  Math.round(value * pixelRatio) / pixelRatio;
+
+type EngineKey = keyof ReturnType<typeof engine.store.get>;
+type ProjectKey = keyof ReturnType<typeof useProjectStore.getState>;
+type SettingsKey = keyof ReturnType<typeof useSettingsStore.getState>;
+
+export type VisualizationRenderOptions = {
+  resizeTarget: Element;
+  onResize: () => void;
+  render: () => void;
+  engineKeys: readonly EngineKey[];
+  projectKeys: readonly ProjectKey[];
+  settingsKeys: readonly SettingsKey[];
+};
+
+export const subscribeVisualizationRender = (
+  options: VisualizationRenderOptions,
+): (() => void) => {
+  const {
+    resizeTarget,
+    onResize,
+    render,
+    engineKeys,
+    projectKeys,
+    settingsKeys,
+  } = options;
+
+  const unsubscribes = [
+    subscribeResizeObserver(resizeTarget, onResize),
+    ...engineKeys.map((key) =>
+      engine.store.subscribe((state) => state[key], render),
+    ),
+    ...projectKeys.map((key) =>
+      useProjectStore.subscribe((state) => state[key], render),
+    ),
+    ...settingsKeys.map((key) =>
+      useSettingsStore.subscribe((state) => state[key], render),
+    ),
+  ];
+
+  return () => {
+    for (const unsubscribe of unsubscribes) {
+      unsubscribe();
+    }
+  };
+};


### PR DESCRIPTION
Collapse the near-identical processing workers (chords, key, rhythm, transcription, separation) onto a single createAnalysisWorker factory that owns the progress state machine and progress/download handlers.

Move the duplicated ProjectRealtimeEvent union into api.project.realtime.Event so backend and engine share one contract.

Extract alignPixel and the store-subscription wiring shared by VisualizationCursor and VisualizationTimeline into visualizationRender.