### PR TITLE
refactor(fft): share radix factorization and power-of-two check

### DIFF
--- a/packages/fft/src/fourier/factorization.es.ts
+++ b/packages/fft/src/fourier/factorization.es.ts
@@ -1,3 +1,41 @@
+export const isPowerOfTwo = (value: number): boolean =>
+  value > 0 && (value & (value - 1)) === 0;
+
+export type Radix8PreferredStageCounts = {
+  radix8StageCount: number;
+  radix4StageCount: number;
+  radix2StageCount: number;
+  radix3StageCount: number;
+  radix5StageCount: number;
+};
+
+export const createRadix8PreferredCounts = (
+  size: number,
+): Radix8PreferredStageCounts | undefined => {
+  let remaining = size;
+  const counts: Radix8PreferredStageCounts = {
+    radix8StageCount: 0,
+    radix4StageCount: 0,
+    radix2StageCount: 0,
+    radix3StageCount: 0,
+    radix5StageCount: 0,
+  };
+  const factors = [
+    [8, 'radix8StageCount'],
+    [4, 'radix4StageCount'],
+    [2, 'radix2StageCount'],
+    [3, 'radix3StageCount'],
+    [5, 'radix5StageCount'],
+  ] as const;
+  for (const [factor, key] of factors) {
+    while (remaining % factor === 0) {
+      counts[key]++;
+      remaining /= factor;
+    }
+  }
+  return remaining === 1 ? counts : undefined;
+};
+
 export type RadixStageCounts = {
   radix4StageCount: number;
   radix2StageCount: number;

--- a/packages/fft/src/fourier/fftPackedStockham/c2r/pipeline.ts
+++ b/packages/fft/src/fourier/fftPackedStockham/c2r/pipeline.ts
@@ -1,3 +1,8 @@
+import {
+  createRadix8PreferredCounts,
+  isPowerOfTwo,
+  type Radix8PreferredStageCounts,
+} from '../../factorization.es.js';
 import { multiPassPairStageShader } from './multiPassPairStage.wgsl.js';
 import { multiPassStageShader } from './multiPassStage.wgsl.js';
 import {
@@ -7,64 +12,34 @@ import {
 import { transformShader } from './transform.wgsl.js';
 import { transformInPlaceMixedShader } from './transformInPlaceMixed.wgsl.js';
 
-type TransformStageCounts = {
-  radix8StageCount: number;
-  radix4StageCount: number;
-  radix2StageCount: number;
-  radix3StageCount: number;
-  radix5StageCount: number;
-};
-
-const stageCount = (counts: TransformStageCounts): number =>
+const stageCount = (counts: Radix8PreferredStageCounts): number =>
   counts.radix8StageCount +
   counts.radix4StageCount +
   counts.radix2StageCount +
   counts.radix3StageCount +
   counts.radix5StageCount;
 
-const isPowerOfTwo = (value: number): boolean => (value & (value - 1)) === 0;
-
-const createRadix8PreferredCounts = (
-  packedWindowSize: number,
-): TransformStageCounts => {
-  let remaining = packedWindowSize;
-  const counts: TransformStageCounts = {
-    radix8StageCount: 0,
-    radix4StageCount: 0,
-    radix2StageCount: 0,
-    radix3StageCount: 0,
-    radix5StageCount: 0,
-  };
-  const factors = [
-    [8, 'radix8StageCount'],
-    [4, 'radix4StageCount'],
-    [2, 'radix2StageCount'],
-    [3, 'radix3StageCount'],
-    [5, 'radix5StageCount'],
-  ] as const;
-  for (const [factor, key] of factors) {
-    while (remaining % factor === 0) {
-      counts[key]++;
-      remaining /= factor;
-    }
-  }
-  return counts;
-};
-
 const selectTransformStageCounts = (
   variant: Extract<
     PackedStockhamC2rVariant,
     { kind: 'singlePass' | 'inPlaceMixed' }
   >,
-): TransformStageCounts =>
-  createRadix8PreferredCounts(variant.packedWindowSize);
+): Radix8PreferredStageCounts => {
+  const counts = createRadix8PreferredCounts(variant.packedWindowSize);
+  if (counts === undefined) {
+    throw new Error(
+      `Packed window size ${variant.packedWindowSize} is not radix-8 factorable`,
+    );
+  }
+  return counts;
+};
 
 const selectTransformThreadCount = (
   variant: Extract<
     PackedStockhamC2rVariant,
     { kind: 'singlePass' | 'inPlaceMixed' }
   >,
-  counts: TransformStageCounts,
+  counts: Radix8PreferredStageCounts,
 ): number => {
   if (variant.kind === 'inPlaceMixed') {
     if (isPowerOfTwo(variant.packedWindowSize)) {

--- a/packages/fft/src/fourier/fftPackedStockham/r2c/pipeline.ts
+++ b/packages/fft/src/fourier/fftPackedStockham/r2c/pipeline.ts
@@ -1,3 +1,4 @@
+import { isPowerOfTwo } from '../../factorization.es.js';
 import { multiPassPairStageShader } from './multiPassPairStage.wgsl.js';
 import { multiPassStageShader } from './multiPassStage.wgsl.js';
 import {
@@ -18,8 +19,6 @@ const selectStockhamThreadCount = (packedWindowSize: number): number => {
   }
   return 256;
 };
-
-const isPowerOfTwo = (value: number): boolean => (value & (value - 1)) === 0;
 
 const createRadix8StageCounts = (
   packedWindowSize: number,

--- a/packages/fft/src/fourier/fftPackedStockham/r2c/support.ts
+++ b/packages/fft/src/fourier/fftPackedStockham/r2c/support.ts
@@ -1,51 +1,16 @@
 import { type FourierConfig } from '../../config.es.js';
 import {
+  createRadix8PreferredCounts,
   createRadixStages,
   expandRadix8PreferredStages,
+  isPowerOfTwo,
   type MultiPassRadixStage,
+  type Radix8PreferredStageCounts,
   type RadixStageCounts,
 } from '../../factorization.es.js';
 
 const minPackedWindowSize = 2;
 const pairThreadsPerGroup = 8;
-
-const isPowerOfTwo = (value: number): boolean =>
-  Number.isInteger(Math.log2(value));
-
-export type InPlaceMixedStageCounts = {
-  radix8StageCount: number;
-  radix4StageCount: number;
-  radix2StageCount: number;
-  radix3StageCount: number;
-  radix5StageCount: number;
-};
-
-const createRadix8PreferredCounts = (
-  packedWindowSize: number,
-): InPlaceMixedStageCounts | undefined => {
-  let remaining = packedWindowSize;
-  const counts = {
-    radix8StageCount: 0,
-    radix4StageCount: 0,
-    radix2StageCount: 0,
-    radix3StageCount: 0,
-    radix5StageCount: 0,
-  };
-  const factors = [
-    [8, 'radix8StageCount'],
-    [4, 'radix4StageCount'],
-    [2, 'radix2StageCount'],
-    [3, 'radix3StageCount'],
-    [5, 'radix5StageCount'],
-  ] as const;
-  for (const [factor, key] of factors) {
-    while (remaining % factor === 0) {
-      counts[key]++;
-      remaining /= factor;
-    }
-  }
-  return remaining === 1 ? counts : undefined;
-};
 
 const maxPairGroupSize = 64;
 
@@ -158,7 +123,7 @@ export type PackedStockhamR2cVariant =
     })
   | (PackedStockhamR2cBaseVariant & {
       kind: 'inPlaceMixed';
-      inPlaceStageCounts: InPlaceMixedStageCounts;
+      inPlaceStageCounts: Radix8PreferredStageCounts;
     })
   | (PackedStockhamR2cBaseVariant & {
       kind: 'multiPass';

--- a/packages/fft/src/fourier/fftPackedTiledR2c/support.ts
+++ b/packages/fft/src/fourier/fftPackedTiledR2c/support.ts
@@ -1,6 +1,7 @@
 import { type FourierConfig } from '../config.es.js';
 import {
   createRadixStages,
+  isPowerOfTwo,
   type RadixStageCounts,
 } from '../factorization.es.js';
 import { selectBalancedTileShape } from '../tileShape.js';
@@ -10,9 +11,6 @@ const maxTileSize = 256;
 const maxWindowSize = 65536;
 const minPackedWindowSize = 4;
 const maxPackedWindowSize = maxWindowSize / 2;
-
-const isPowerOfTwo = (value: number): boolean =>
-  Number.isInteger(Math.log2(value));
 
 const maxPaddedSecondPassTileSize = 248;
 const secondPassPadColumns = 8;


### PR DESCRIPTION
Move the duplicated radix-8 preferred stage counter and the two divergent isPowerOfTwo implementations into factorization.es.ts so every caller runs the identical check. The c2r pipeline now rejects non-factorable sizes explicitly instead of silently returning truncated counts.