### PR TITLE
refactor(ai): share STFT inference runtime for vocals and lead/backing

### DIFF
--- a/packages/ai/src/runtime/leadBacking/leadBackingRuntime.ts
+++ b/packages/ai/src/runtime/leadBacking/leadBackingRuntime.ts
@@ -1,24 +1,19 @@
-import {
-  createFftPackedStockhamR2c,
-  createIfftPackedStockhamC2r,
-} from '@musetric/fft/gpu';
-import * as ort from 'onnxruntime-web/webgpu';
 import { leadBackingModel } from '../../models/leadBackingModel.js';
 import {
   createBindGroup,
   createBindGroupLayout,
   createComputePipeline,
-  createReadbackBuffer,
   createStorageBuffer,
-  dispatch1d,
-  dispatch2d,
 } from '../helpers.js';
+import {
+  createStftInferenceRuntime,
+  type StftInferenceCore,
+  type StftInferenceRuntime,
+} from '../stftInference.js';
 import { leadBackingFrameShader } from './frame.wgsl.js';
 import { leadBackingOverlapAddShader } from './overlapAdd.wgsl.js';
 import { leadBackingPackShader } from './pack.wgsl.js';
 import { leadBackingUnpackShader } from './unpack.wgsl.js';
-
-ort.env.logLevel = 'error';
 
 export type LeadBackingGpuRuntime = {
   processChunk: (
@@ -34,196 +29,72 @@ export type LeadBackingGpuRuntimeOptions = {
 export const createLeadBackingGpuRuntime = async (
   options: LeadBackingGpuRuntimeOptions,
 ): Promise<LeadBackingGpuRuntime> => {
-  const { nFft, hop, dimF, dimT, channels, chunkSamples } = leadBackingModel;
-  const pad = nFft / 2;
-  const freqs = nFft / 2 + 1;
+  const { nFft, dimF, dimT, channels } = leadBackingModel;
   const frames = dimT;
   const windowCount = channels * frames;
-  const chunkFloats = channels * chunkSamples;
-  const chunkBytes = chunkFloats * Float32Array.BYTES_PER_ELEMENT;
-  const spectrumBytes =
-    windowCount * (nFft + 2) * Float32Array.BYTES_PER_ELEMENT;
+  const freqs = nFft / 2 + 1;
   const modelBytes = 4 * dimF * dimT * Float32Array.BYTES_PER_ELEMENT;
 
-  const session = await ort.InferenceSession.create(options.modelUrl, {
-    executionProviders: ['webgpu'],
-    graphOptimizationLevel: 'all',
-    preferredOutputLocation: { [leadBackingModel.outputName]: 'gpu-buffer' },
-  });
-  const device = await ort.env.webgpu.device;
+  const runtime: StftInferenceRuntime = await createStftInferenceRuntime({
+    label: 'Lead/backing',
+    model: { ...leadBackingModel, frames },
+    modelUrl: options.modelUrl,
+    frameShader: leadBackingFrameShader,
+    overlapAddShader: leadBackingOverlapAddShader,
+    createCore: (buffers): StftInferenceCore => {
+      const { device, wave, spectrum } = buffers;
+      const modelInput = createStorageBuffer(device, modelBytes);
+      const modelOutput = createStorageBuffer(device, modelBytes);
 
-  const frameLayout = createBindGroupLayout(device, [
-    'read-only-storage',
-    'storage',
-  ]);
-  const framePipeline = createComputePipeline({
-    device,
-    layout: frameLayout,
-    code: leadBackingFrameShader,
-    constants: { nFft, hop, pad, frames, windowCount, samples: chunkSamples },
-  });
-  const packLayout = createBindGroupLayout(device, [
-    'read-only-storage',
-    'storage',
-  ]);
-  const packPipeline = createComputePipeline({
-    device,
-    layout: packLayout,
-    code: leadBackingPackShader,
-    constants: { nFft, frames, windowCount, dimF, dimT },
-  });
-  const unpackLayout = createBindGroupLayout(device, [
-    'read-only-storage',
-    'storage',
-  ]);
-  const unpackPipeline = createComputePipeline({
-    device,
-    layout: unpackLayout,
-    code: leadBackingUnpackShader,
-    constants: { nFft, frames, windowCount, dimF, dimT, freqs },
-  });
-  const overlapAddLayout = createBindGroupLayout(device, [
-    'read-only-storage',
-    'storage',
-  ]);
-  const overlapAddPipeline = createComputePipeline({
-    device,
-    layout: overlapAddLayout,
-    code: leadBackingOverlapAddShader,
-    constants: { nFft, hop, pad, frames, channels, samples: chunkSamples },
-  });
+      const packLayout = createBindGroupLayout(device, [
+        'read-only-storage',
+        'storage',
+      ]);
+      const packPipeline = createComputePipeline({
+        device,
+        layout: packLayout,
+        code: leadBackingPackShader,
+        constants: { nFft, frames, windowCount, dimF, dimT },
+      });
+      const unpackLayout = createBindGroupLayout(device, [
+        'read-only-storage',
+        'storage',
+      ]);
+      const unpackPipeline = createComputePipeline({
+        device,
+        layout: unpackLayout,
+        code: leadBackingUnpackShader,
+        constants: { nFft, frames, windowCount, dimF, dimT, freqs },
+      });
 
-  const fftCell = createFftPackedStockhamR2c(device);
-  const ifftCell = createIfftPackedStockhamC2r(device);
-  const rawAudio = createStorageBuffer(device, chunkBytes);
-  const wave = createStorageBuffer(device, spectrumBytes);
-  const modelInput = createStorageBuffer(device, modelBytes);
-  const modelOutput = createStorageBuffer(device, modelBytes);
-  const spectrum = createStorageBuffer(device, spectrumBytes);
-  const frameTime = createStorageBuffer(
-    device,
-    windowCount * nFft * Float32Array.BYTES_PER_ELEMENT,
-  );
-  const outputAudio = createStorageBuffer(device, chunkBytes);
-  const readback = createReadbackBuffer(device, chunkBytes);
-
-  const frameBindGroup = createBindGroup(device, frameLayout, [rawAudio, wave]);
-  const packBindGroup = createBindGroup(device, packLayout, [wave, modelInput]);
-  const unpackBindGroup = createBindGroup(device, unpackLayout, [
-    modelOutput,
-    spectrum,
-  ]);
-  const overlapAddBindGroup = createBindGroup(device, overlapAddLayout, [
-    frameTime,
-    outputAudio,
-  ]);
-  const fft = fftCell.get({
-    wave,
-    spectrum: wave,
-    config: { windowSize: nFft, windowCount },
-  });
-  const ifft = ifftCell.get({
-    wave: frameTime,
-    spectrum,
-    config: { windowSize: nFft, windowCount },
-  });
-  const outputTensor = ort.Tensor.fromGpuBuffer(modelOutput, {
-    dataType: 'float32',
-    dims: [...leadBackingModel.outputShape],
+      return {
+        modelInput,
+        modelOutput,
+        analysis: {
+          pipeline: packPipeline,
+          bindGroup: createBindGroup(device, packLayout, [wave, modelInput]),
+          x: dimF,
+          y: windowCount,
+        },
+        synthesis: {
+          pipeline: unpackPipeline,
+          bindGroup: createBindGroup(device, unpackLayout, [
+            modelOutput,
+            spectrum,
+          ]),
+          x: freqs,
+          y: windowCount,
+        },
+        release: () => {
+          modelInput.destroy();
+          modelOutput.destroy();
+        },
+      };
+    },
   });
 
-  const processChunk = async (
-    input: Float32Array<ArrayBuffer>,
-  ): Promise<Float32Array<ArrayBuffer>> => {
-    if (input.length !== chunkFloats) {
-      throw new Error(`Lead/backing chunk must contain ${chunkFloats} floats`);
-    }
-
-    device.queue.writeBuffer(rawAudio, 0, input);
-    const stftEncoder = device.createCommandEncoder();
-    const framePass = stftEncoder.beginComputePass();
-    dispatch2d({
-      pass: framePass,
-      pipeline: framePipeline,
-      bindGroup: frameBindGroup,
-      x: nFft,
-      y: windowCount,
-    });
-    framePass.end();
-    fft.run(stftEncoder);
-    const packPass = stftEncoder.beginComputePass();
-    dispatch2d({
-      pass: packPass,
-      pipeline: packPipeline,
-      bindGroup: packBindGroup,
-      x: dimF,
-      y: windowCount,
-    });
-    packPass.end();
-    device.queue.submit([stftEncoder.finish()]);
-
-    const inputTensor = ort.Tensor.fromGpuBuffer(modelInput, {
-      dataType: 'float32',
-      dims: [...leadBackingModel.inputShape],
-    });
-    const result = await session.run(
-      { [leadBackingModel.inputName]: inputTensor },
-      { [leadBackingModel.outputName]: outputTensor },
-    );
-    const output = result[leadBackingModel.outputName];
-    if (output.gpuBuffer !== modelOutput) {
-      output.dispose();
-      throw new Error(
-        'Lead/backing model output did not reuse the preallocated GPU buffer',
-      );
-    }
-
-    const istftEncoder = device.createCommandEncoder();
-    const unpackPass = istftEncoder.beginComputePass();
-    dispatch2d({
-      pass: unpackPass,
-      pipeline: unpackPipeline,
-      bindGroup: unpackBindGroup,
-      x: freqs,
-      y: windowCount,
-    });
-    unpackPass.end();
-    ifft.run(istftEncoder);
-    const overlapAddPass = istftEncoder.beginComputePass();
-    dispatch1d(
-      overlapAddPass,
-      overlapAddPipeline,
-      overlapAddBindGroup,
-      chunkFloats,
-    );
-    overlapAddPass.end();
-    istftEncoder.copyBufferToBuffer(outputAudio, 0, readback, 0, chunkBytes);
-    device.queue.submit([istftEncoder.finish()]);
-    await readback.mapAsync(GPUMapMode.READ);
-    const mapped = new Float32Array(readback.getMappedRange());
-    const audio = new Float32Array(mapped.length);
-    audio.set(mapped);
-    readback.unmap();
-    return audio;
+  return {
+    processChunk: runtime.processChunk,
+    release: runtime.release,
   };
-
-  const release = async (): Promise<void> => {
-    fftCell.dispose();
-    ifftCell.dispose();
-    for (const buffer of [
-      rawAudio,
-      wave,
-      modelInput,
-      modelOutput,
-      spectrum,
-      frameTime,
-      outputAudio,
-      readback,
-    ]) {
-      buffer.destroy();
-    }
-    await session.release();
-  };
-
-  return { processChunk, release };
 };

--- a/packages/ai/src/runtime/stftInference.ts
+++ b/packages/ai/src/runtime/stftInference.ts
@@ -1,0 +1,227 @@
+import {
+  createFftPackedStockhamR2c,
+  createIfftPackedStockhamC2r,
+} from '@musetric/fft/gpu';
+import * as ort from 'onnxruntime-web/webgpu';
+import {
+  createBindGroup,
+  createBindGroupLayout,
+  createComputePipeline,
+  createReadbackBuffer,
+  createStorageBuffer,
+  dispatch1d,
+  dispatch2d,
+  type Dispatch2dOptions,
+} from './helpers.js';
+
+ort.env.logLevel = 'error';
+
+export type StftStage = Omit<Dispatch2dOptions, 'pass'>;
+
+const runStage = (encoder: GPUCommandEncoder, stage: StftStage): void => {
+  const pass = encoder.beginComputePass();
+  dispatch2d({ pass, ...stage });
+  pass.end();
+};
+
+export type StftInferenceRuntime = {
+  processChunk: (
+    input: Float32Array<ArrayBuffer>,
+    output?: Float32Array<ArrayBuffer>,
+  ) => Promise<Float32Array<ArrayBuffer>>;
+  release: () => Promise<void>;
+};
+
+export type StftInferenceModel = {
+  nFft: number;
+  hop: number;
+  channels: number;
+  chunkSamples: number;
+  frames: number;
+  inputName: string;
+  outputName: string;
+  inputShape: readonly number[];
+  outputShape: readonly number[];
+};
+
+export type StftInferenceBuffers = {
+  device: GPUDevice;
+  wave: GPUBuffer;
+  spectrum: GPUBuffer;
+};
+
+export type StftInferenceCore = {
+  modelInput: GPUBuffer;
+  modelOutput: GPUBuffer;
+  analysis: StftStage;
+  synthesis: StftStage;
+  release: () => void;
+};
+
+export type StftInferenceOptions = {
+  label: string;
+  model: StftInferenceModel;
+  modelUrl: string;
+  externalData?: NonNullable<
+    ort.InferenceSession.SessionOptions['externalData']
+  >;
+  frameShader: string;
+  overlapAddShader: string;
+  createCore: (buffers: StftInferenceBuffers) => StftInferenceCore;
+};
+
+export const createStftInferenceRuntime = async (
+  options: StftInferenceOptions,
+): Promise<StftInferenceRuntime> => {
+  const { label, model, frameShader, overlapAddShader, createCore } = options;
+  const { nFft, hop, channels, chunkSamples, frames } = model;
+  const pad = nFft / 2;
+  const windowCount = channels * frames;
+  const chunkFloats = channels * chunkSamples;
+  const chunkBytes = chunkFloats * Float32Array.BYTES_PER_ELEMENT;
+  const spectrumBytes =
+    windowCount * (nFft + 2) * Float32Array.BYTES_PER_ELEMENT;
+
+  const session = await ort.InferenceSession.create(options.modelUrl, {
+    executionProviders: ['webgpu'],
+    graphOptimizationLevel: 'all',
+    preferredOutputLocation: { [model.outputName]: 'gpu-buffer' },
+    ...(options.externalData ? { externalData: options.externalData } : {}),
+  });
+  const device = await ort.env.webgpu.device;
+
+  const frameLayout = createBindGroupLayout(device, [
+    'read-only-storage',
+    'storage',
+  ]);
+  const framePipeline = createComputePipeline({
+    device,
+    layout: frameLayout,
+    code: frameShader,
+    constants: { nFft, hop, pad, frames, windowCount, samples: chunkSamples },
+  });
+  const overlapAddLayout = createBindGroupLayout(device, [
+    'read-only-storage',
+    'storage',
+  ]);
+  const overlapAddPipeline = createComputePipeline({
+    device,
+    layout: overlapAddLayout,
+    code: overlapAddShader,
+    constants: { nFft, hop, pad, frames, channels, samples: chunkSamples },
+  });
+
+  const fftCell = createFftPackedStockhamR2c(device);
+  const ifftCell = createIfftPackedStockhamC2r(device);
+  const rawAudio = createStorageBuffer(device, chunkBytes);
+  const wave = createStorageBuffer(device, spectrumBytes);
+  const spectrum = createStorageBuffer(device, spectrumBytes);
+  const frameTime = createStorageBuffer(
+    device,
+    windowCount * nFft * Float32Array.BYTES_PER_ELEMENT,
+  );
+  const outputAudio = createStorageBuffer(device, chunkBytes);
+  const readback = createReadbackBuffer(device, chunkBytes);
+
+  const core = createCore({ device, wave, spectrum });
+
+  const frameStage: StftStage = {
+    pipeline: framePipeline,
+    bindGroup: createBindGroup(device, frameLayout, [rawAudio, wave]),
+    x: nFft,
+    y: windowCount,
+  };
+  const overlapAddBindGroup = createBindGroup(device, overlapAddLayout, [
+    frameTime,
+    outputAudio,
+  ]);
+  const fft = fftCell.get({
+    wave,
+    spectrum: wave,
+    config: { windowSize: nFft, windowCount },
+  });
+  const ifft = ifftCell.get({
+    wave: frameTime,
+    spectrum,
+    config: { windowSize: nFft, windowCount },
+  });
+  const inputTensor = ort.Tensor.fromGpuBuffer(core.modelInput, {
+    dataType: 'float32',
+    dims: [...model.inputShape],
+  });
+  const outputTensor = ort.Tensor.fromGpuBuffer(core.modelOutput, {
+    dataType: 'float32',
+    dims: [...model.outputShape],
+  });
+
+  const processChunk = async (
+    input: Float32Array<ArrayBuffer>,
+    output?: Float32Array<ArrayBuffer>,
+  ): Promise<Float32Array<ArrayBuffer>> => {
+    if (
+      input.length !== chunkFloats ||
+      (output && output.length !== chunkFloats)
+    ) {
+      throw new Error(`${label} chunk must contain ${chunkFloats} floats`);
+    }
+    device.queue.writeBuffer(rawAudio, 0, input);
+
+    const stftEncoder = device.createCommandEncoder();
+    runStage(stftEncoder, frameStage);
+    fft.run(stftEncoder);
+    runStage(stftEncoder, core.analysis);
+    device.queue.submit([stftEncoder.finish()]);
+
+    const result = await session.run(
+      { [model.inputName]: inputTensor },
+      { [model.outputName]: outputTensor },
+    );
+    const modelResult = result[model.outputName];
+    if (modelResult.gpuBuffer !== core.modelOutput) {
+      modelResult.dispose();
+      throw new Error(
+        `${label} model output did not reuse the preallocated GPU buffer`,
+      );
+    }
+
+    const istftEncoder = device.createCommandEncoder();
+    runStage(istftEncoder, core.synthesis);
+    ifft.run(istftEncoder);
+    const overlapAddPass = istftEncoder.beginComputePass();
+    dispatch1d(
+      overlapAddPass,
+      overlapAddPipeline,
+      overlapAddBindGroup,
+      chunkFloats,
+    );
+    overlapAddPass.end();
+    istftEncoder.copyBufferToBuffer(outputAudio, 0, readback, 0, chunkBytes);
+    device.queue.submit([istftEncoder.finish()]);
+
+    await readback.mapAsync(GPUMapMode.READ);
+    const mapped = new Float32Array(readback.getMappedRange());
+    const audio = output ?? new Float32Array(mapped.length);
+    audio.set(mapped);
+    readback.unmap();
+    return audio;
+  };
+
+  const release = async (): Promise<void> => {
+    fftCell.dispose();
+    ifftCell.dispose();
+    for (const buffer of [
+      rawAudio,
+      wave,
+      spectrum,
+      frameTime,
+      outputAudio,
+      readback,
+    ]) {
+      buffer.destroy();
+    }
+    core.release();
+    await session.release();
+  };
+
+  return { processChunk, release };
+};

--- a/packages/ai/src/runtime/vocals/vocalsRuntime.ts
+++ b/packages/ai/src/runtime/vocals/vocalsRuntime.ts
@@ -1,24 +1,19 @@
-import {
-  createFftPackedStockhamR2c,
-  createIfftPackedStockhamC2r,
-} from '@musetric/fft/gpu';
-import * as ort from 'onnxruntime-web/webgpu';
 import { vocalsModel } from '../../models/vocalsModel.js';
 import {
   createBindGroup,
   createBindGroupLayout,
   createComputePipeline,
-  createReadbackBuffer,
   createStorageBuffer,
-  dispatch1d,
-  dispatch2d,
 } from '../helpers.js';
+import {
+  createStftInferenceRuntime,
+  type StftInferenceCore,
+  type StftInferenceRuntime,
+} from '../stftInference.js';
 import { vocalsApplyMasksShader } from './applyMasks.wgsl.js';
 import { vocalsFrameShader } from './frame.wgsl.js';
 import { vocalsOverlapAddShader } from './overlapAdd.wgsl.js';
 import { vocalsPackShader } from './pack.wgsl.js';
-
-ort.env.logLevel = 'error';
 
 export type VocalsProcessChunkOptions = {
   input: Float32Array<ArrayBuffer>;
@@ -39,196 +34,76 @@ export type VocalsGpuRuntimeOptions = {
 export const createVocalsGpuRuntime = async (
   options: VocalsGpuRuntimeOptions,
 ): Promise<VocalsGpuRuntime> => {
-  const { nFft, hop, frames, channels, chunkSamples } = vocalsModel;
-  const pad = nFft / 2;
+  const { nFft, frames } = vocalsModel;
   const packedBins = (nFft / 2 + 1) * 2;
-  const windowCount = channels * frames;
-  const chunkFloats = channels * chunkSamples;
-  const chunkBytes = chunkFloats * Float32Array.BYTES_PER_ELEMENT;
-  const spectrumBytes =
-    windowCount * (nFft + 2) * Float32Array.BYTES_PER_ELEMENT;
   const modelBytes = packedBins * frames * 2 * Float32Array.BYTES_PER_ELEMENT;
 
-  const session = await ort.InferenceSession.create(options.modelUrl, {
-    executionProviders: ['webgpu'],
-    graphOptimizationLevel: 'all',
-    preferredOutputLocation: { [vocalsModel.outputName]: 'gpu-buffer' },
+  const runtime: StftInferenceRuntime = await createStftInferenceRuntime({
+    label: 'Vocals',
+    model: vocalsModel,
+    modelUrl: options.modelUrl,
     externalData: [{ path: options.modelDataPath, data: options.modelDataUrl }],
-  });
-  const device = await ort.env.webgpu.device;
+    frameShader: vocalsFrameShader,
+    overlapAddShader: vocalsOverlapAddShader,
+    createCore: (buffers): StftInferenceCore => {
+      const { device, wave, spectrum } = buffers;
+      const stft = createStorageBuffer(device, modelBytes);
+      const masks = createStorageBuffer(device, modelBytes);
 
-  const frameLayout = createBindGroupLayout(device, [
-    'read-only-storage',
-    'storage',
-  ]);
-  const framePipeline = createComputePipeline({
-    device,
-    layout: frameLayout,
-    code: vocalsFrameShader,
-    constants: { nFft, hop, pad, frames, windowCount, samples: chunkSamples },
-  });
-  const packLayout = createBindGroupLayout(device, [
-    'read-only-storage',
-    'storage',
-  ]);
-  const packPipeline = createComputePipeline({
-    device,
-    layout: packLayout,
-    code: vocalsPackShader,
-    constants: { nFft, frames, packedBins },
-  });
-  const applyMasksLayout = createBindGroupLayout(device, [
-    'read-only-storage',
-    'read-only-storage',
-    'storage',
-  ]);
-  const applyMasksPipeline = createComputePipeline({
-    device,
-    layout: applyMasksLayout,
-    code: vocalsApplyMasksShader,
-    constants: { nFft, frames, packedBins },
-  });
-  const overlapAddLayout = createBindGroupLayout(device, [
-    'read-only-storage',
-    'storage',
-  ]);
-  const overlapAddPipeline = createComputePipeline({
-    device,
-    layout: overlapAddLayout,
-    code: vocalsOverlapAddShader,
-    constants: { nFft, hop, pad, frames, channels, samples: chunkSamples },
-  });
+      const packLayout = createBindGroupLayout(device, [
+        'read-only-storage',
+        'storage',
+      ]);
+      const packPipeline = createComputePipeline({
+        device,
+        layout: packLayout,
+        code: vocalsPackShader,
+        constants: { nFft, frames, packedBins },
+      });
+      const applyMasksLayout = createBindGroupLayout(device, [
+        'read-only-storage',
+        'read-only-storage',
+        'storage',
+      ]);
+      const applyMasksPipeline = createComputePipeline({
+        device,
+        layout: applyMasksLayout,
+        code: vocalsApplyMasksShader,
+        constants: { nFft, frames, packedBins },
+      });
 
-  const fftCell = createFftPackedStockhamR2c(device);
-  const ifftCell = createIfftPackedStockhamC2r(device);
-  const rawAudio = createStorageBuffer(device, chunkBytes);
-  const wave = createStorageBuffer(device, spectrumBytes);
-  const stft = createStorageBuffer(device, modelBytes);
-  const masks = createStorageBuffer(device, modelBytes);
-  const spectrum = createStorageBuffer(device, spectrumBytes);
-  const frameTime = createStorageBuffer(
-    device,
-    windowCount * nFft * Float32Array.BYTES_PER_ELEMENT,
-  );
-  const outputAudio = createStorageBuffer(device, chunkBytes);
-  const readback = createReadbackBuffer(device, chunkBytes);
-
-  const frameBindGroup = createBindGroup(device, frameLayout, [rawAudio, wave]);
-  const packBindGroup = createBindGroup(device, packLayout, [wave, stft]);
-  const applyMasksBindGroup = createBindGroup(device, applyMasksLayout, [
-    stft,
-    masks,
-    spectrum,
-  ]);
-  const overlapAddBindGroup = createBindGroup(device, overlapAddLayout, [
-    frameTime,
-    outputAudio,
-  ]);
-  const fft = fftCell.get({
-    wave,
-    spectrum: wave,
-    config: { windowSize: nFft, windowCount },
-  });
-  const ifft = ifftCell.get({
-    wave: frameTime,
-    spectrum,
-    config: { windowSize: nFft, windowCount },
-  });
-  const masksOutput = ort.Tensor.fromGpuBuffer(masks, {
-    dataType: 'float32',
-    dims: [...vocalsModel.outputShape],
+      return {
+        modelInput: stft,
+        modelOutput: masks,
+        analysis: {
+          pipeline: packPipeline,
+          bindGroup: createBindGroup(device, packLayout, [wave, stft]),
+          x: packedBins,
+          y: frames,
+        },
+        synthesis: {
+          pipeline: applyMasksPipeline,
+          bindGroup: createBindGroup(device, applyMasksLayout, [
+            stft,
+            masks,
+            spectrum,
+          ]),
+          x: packedBins,
+          y: frames,
+        },
+        release: () => {
+          stft.destroy();
+          masks.destroy();
+        },
+      };
+    },
   });
 
   const processChunk = async (
     chunkOptions: VocalsProcessChunkOptions,
   ): Promise<void> => {
-    const { input, output } = chunkOptions;
-    if (input.length !== chunkFloats || output.length !== chunkFloats) {
-      throw new Error(`Vocals chunk must contain ${chunkFloats} floats`);
-    }
-
-    device.queue.writeBuffer(rawAudio, 0, input);
-    const stftEncoder = device.createCommandEncoder();
-    const framePass = stftEncoder.beginComputePass();
-    dispatch2d({
-      pass: framePass,
-      pipeline: framePipeline,
-      bindGroup: frameBindGroup,
-      x: nFft,
-      y: windowCount,
-    });
-    framePass.end();
-    fft.run(stftEncoder);
-    const packPass = stftEncoder.beginComputePass();
-    dispatch2d({
-      pass: packPass,
-      pipeline: packPipeline,
-      bindGroup: packBindGroup,
-      x: packedBins,
-      y: frames,
-    });
-    packPass.end();
-    device.queue.submit([stftEncoder.finish()]);
-
-    const inputTensor = ort.Tensor.fromGpuBuffer(stft, {
-      dataType: 'float32',
-      dims: [...vocalsModel.inputShape],
-    });
-    const result = await session.run(
-      { [vocalsModel.inputName]: inputTensor },
-      { [vocalsModel.outputName]: masksOutput },
-    );
-    const masksTensor = result[vocalsModel.outputName];
-    if (masksTensor.gpuBuffer !== masks) {
-      masksTensor.dispose();
-      throw new Error(
-        'Vocals model output did not reuse the preallocated GPU buffer',
-      );
-    }
-
-    const istftEncoder = device.createCommandEncoder();
-    const applyMasksPass = istftEncoder.beginComputePass();
-    dispatch2d({
-      pass: applyMasksPass,
-      pipeline: applyMasksPipeline,
-      bindGroup: applyMasksBindGroup,
-      x: packedBins,
-      y: frames,
-    });
-    applyMasksPass.end();
-    ifft.run(istftEncoder);
-    const overlapAddPass = istftEncoder.beginComputePass();
-    dispatch1d(
-      overlapAddPass,
-      overlapAddPipeline,
-      overlapAddBindGroup,
-      chunkFloats,
-    );
-    overlapAddPass.end();
-    istftEncoder.copyBufferToBuffer(outputAudio, 0, readback, 0, chunkBytes);
-    device.queue.submit([istftEncoder.finish()]);
-    await readback.mapAsync(GPUMapMode.READ);
-    output.set(new Float32Array(readback.getMappedRange()));
-    readback.unmap();
+    await runtime.processChunk(chunkOptions.input, chunkOptions.output);
   };
 
-  const release = async (): Promise<void> => {
-    fftCell.dispose();
-    ifftCell.dispose();
-    for (const buffer of [
-      rawAudio,
-      wave,
-      stft,
-      masks,
-      spectrum,
-      frameTime,
-      outputAudio,
-      readback,
-    ]) {
-      buffer.destroy();
-    }
-    await session.release();
-  };
-
-  return { processChunk, release };
+  return { processChunk, release: runtime.release };
 };


### PR DESCRIPTION
Extract the common STFT -> ONNX -> iSTFT skeleton into createStftInferenceRuntime. The vocals and lead/backing runtimes were ~90% duplicated; they now provide only a model-specific core (buffers, pack/unpack vs pack/apply-masks pipelines) via dispatchAnalysis and dispatchSynthesis hooks, while the skeleton owns the session, shared buffers, FFT/iFFT cells, compute-pass lifecycle and readback.

Also create the input tensor once instead of per chunk and fold the two chunk-length guards into one.