### PR TITLE
refactor(spectrogram): share compute bind-group buffer entries

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -1,5 +1,5 @@
 {
-  "threshold": 1.2,
+  "threshold": 0,
   "reporters": ["console"],
   "minLines": 10,
   "minTokens": 80,

--- a/packages/spectrogram/src/common/computeBufferEntries.ts
+++ b/packages/spectrogram/src/common/computeBufferEntries.ts
@@ -1,0 +1,20 @@
+export type ComputeBufferKind =
+  | 'read-only-storage'
+  | 'storage'
+  | 'dynamic-uniform';
+
+const bufferByKind: Record<ComputeBufferKind, GPUBufferBindingLayout> = {
+  'read-only-storage': { type: 'read-only-storage' },
+  storage: { type: 'storage' },
+  'dynamic-uniform': { type: 'uniform', hasDynamicOffset: true },
+};
+
+export const computeBufferEntries = (
+  kinds: ComputeBufferKind[],
+  baseBinding = 0,
+): GPUBindGroupLayoutEntry[] =>
+  kinds.map((kind, index) => ({
+    binding: baseBinding + index,
+    visibility: GPUShaderStage.COMPUTE,
+    buffer: bufferByKind[kind],
+  }));

--- a/packages/spectrogram/src/comparison/index.ts
+++ b/packages/spectrogram/src/comparison/index.ts
@@ -1,4 +1,5 @@
 import { createResourceCell, type ResourceCell } from '@musetric/utils';
+import { computeBufferEntries } from '../common/computeBufferEntries.js';
 import { createDynamicUniformParams } from '../common/dynamicUniform.js';
 import {
   type ExtSpectrogramConfig,
@@ -51,28 +52,12 @@ export const createSpectrogramComparisonColorCell = (
   });
   const bindGroupLayout = device.createBindGroupLayout({
     label: 'comparison-color-bind-group-layout',
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 1,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-      {
-        binding: 3,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform', hasDynamicOffset: true },
-      },
-    ],
+    entries: computeBufferEntries([
+      'read-only-storage',
+      'read-only-storage',
+      'storage',
+      'dynamic-uniform',
+    ]),
   });
   const pipeline = device.createComputePipeline({
     label: 'comparison-color-pipeline',

--- a/packages/spectrogram/src/decibelify/pipeline.ts
+++ b/packages/spectrogram/src/decibelify/pipeline.ts
@@ -1,3 +1,4 @@
+import { computeBufferEntries } from '../common/computeBufferEntries.js';
 import { energyShader } from './energy.wgsl.js';
 import { runShader } from './run.wgsl.js';
 
@@ -10,28 +11,12 @@ export type Pipelines = {
 export const createPipelines = (device: GPUDevice): Pipelines => {
   const layout = device.createBindGroupLayout({
     label: 'decibelify-bind-group-layout',
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 1,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform', hasDynamicOffset: true },
-      },
-      {
-        binding: 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-      {
-        binding: 3,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-    ],
+    entries: computeBufferEntries([
+      'read-only-storage',
+      'dynamic-uniform',
+      'storage',
+      'storage',
+    ]),
   });
   const pipelineLayout = device.createPipelineLayout({
     label: 'decibelify-pipeline-layout',

--- a/packages/spectrogram/src/fundamentalFrequency/pipeline.ts
+++ b/packages/spectrogram/src/fundamentalFrequency/pipeline.ts
@@ -1,3 +1,4 @@
+import { computeBufferEntries } from '../common/computeBufferEntries.js';
 import { autocorrelationShader } from './autocorrelation.wgsl.js';
 import { shader } from './fundamentalFrequency.wgsl.js';
 import { trackShader } from './track.wgsl.js';
@@ -13,68 +14,28 @@ export const createPipelines = (
 ): FundamentalFrequencyPipelines => {
   const autocorrLayout = device.createBindGroupLayout({
     label: 'fundamental-frequency-autocorr-bind-group-layout',
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 1,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-      {
-        binding: 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform', hasDynamicOffset: true },
-      },
-    ],
+    entries: computeBufferEntries([
+      'read-only-storage',
+      'storage',
+      'dynamic-uniform',
+    ]),
   });
   const observeLayout = device.createBindGroupLayout({
     label: 'fundamental-frequency-observe-bind-group-layout',
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 1,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-      {
-        binding: 3,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform', hasDynamicOffset: true },
-      },
-    ],
+    entries: computeBufferEntries([
+      'read-only-storage',
+      'read-only-storage',
+      'storage',
+      'dynamic-uniform',
+    ]),
   });
   const trackLayout = device.createBindGroupLayout({
     label: 'fundamental-frequency-track-bind-group-layout',
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 1,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-      {
-        binding: 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform', hasDynamicOffset: true },
-      },
-    ],
+    entries: computeBufferEntries([
+      'read-only-storage',
+      'storage',
+      'dynamic-uniform',
+    ]),
   });
   const autocorrPipelineLayout = device.createPipelineLayout({
     label: 'fundamental-frequency-autocorr-pipeline-layout',

--- a/packages/spectrogram/src/magnitudify/pipeline.ts
+++ b/packages/spectrogram/src/magnitudify/pipeline.ts
@@ -1,3 +1,4 @@
+import { computeBufferEntries } from '../common/computeBufferEntries.js';
 import { runShader } from './run.wgsl.js';
 
 export type Pipelines = {
@@ -8,23 +9,7 @@ export type Pipelines = {
 export const createPipelines = (device: GPUDevice): Pipelines => {
   const layout = device.createBindGroupLayout({
     label: 'magnitudify-bind-group-layout',
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-      {
-        binding: 1,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-      {
-        binding: 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform', hasDynamicOffset: true },
-      },
-    ],
+    entries: computeBufferEntries(['storage', 'storage', 'dynamic-uniform']),
   });
   const pipelineLayout = device.createPipelineLayout({
     label: 'magnitudify-pipeline-layout',

--- a/packages/spectrogram/src/remap/pipeline.ts
+++ b/packages/spectrogram/src/remap/pipeline.ts
@@ -1,19 +1,13 @@
+import { computeBufferEntries } from '../common/computeBufferEntries.js';
 import { createShader } from './remap.wgsl.js';
 
 export const createPipeline = (device: GPUDevice, spectrumCount: number) => {
   const spectrumEntries = Array.from({ length: spectrumCount }).flatMap(
-    (_, index): GPUBindGroupLayoutEntry[] => [
-      {
-        binding: 2 + index * 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 3 + index * 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-    ],
+    (_, index) =>
+      computeBufferEntries(
+        ['read-only-storage', 'read-only-storage'],
+        2 + index * 2,
+      ),
   );
   const bindGroupLayout = device.createBindGroupLayout({
     label: 'remap-bind-group-layout',

--- a/packages/spectrogram/src/sliceSamples/pipeline.ts
+++ b/packages/spectrogram/src/sliceSamples/pipeline.ts
@@ -1,30 +1,15 @@
+import { computeBufferEntries } from '../common/computeBufferEntries.js';
 import { shader } from './sliceSamples.wgsl.js';
 
 export const createPipeline = (device: GPUDevice) => {
   const layout = device.createBindGroupLayout({
     label: 'slice-samples-bind-group-layout',
-    entries: [
-      {
-        binding: 0,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-      {
-        binding: 1,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'storage' },
-      },
-      {
-        binding: 2,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'uniform', hasDynamicOffset: true },
-      },
-      {
-        binding: 3,
-        visibility: GPUShaderStage.COMPUTE,
-        buffer: { type: 'read-only-storage' },
-      },
-    ],
+    entries: computeBufferEntries([
+      'read-only-storage',
+      'storage',
+      'dynamic-uniform',
+      'read-only-storage',
+    ]),
   });
   const pipelineLayout = device.createPipelineLayout({
     label: 'slice-samples-pipeline-layout',


### PR DESCRIPTION
Extract computeBufferEntries helper mapping a list of buffer kinds (read-only-storage / storage / dynamic-uniform) to compute GPUBindGroupLayoutEntry list with sequential bindings, collapsing the repeated entry boilerplate across the pipeline builders.

Also set jscpd threshold to 0 so any new clone fails check:dupe.