### PR TITLE
feat(ffmpeg): bundle pinned FFmpeg binaries

### DIFF
--- a/.github/prTitle.config.yml
+++ b/.github/prTitle.config.yml
@@ -48,7 +48,7 @@ scopes:
   - engine # packages/engine audio engine: playback/decode/visualization orchestration
   - fft # FFT signal-processing core behind visualizations
   - spectrogram # frequency spectrogram visualization
-  - ffmpeg # packages/ffmpeg ffmpeg-based audio codec/processing tasks
+  - ffmpeg # packages/ffmpeg vendored ffmpeg binary + audio codec/processing tasks
   - utils # packages/utils low-level shared utilities
   # App
   - backend # packages/backend Fastify server & orchestration

--- a/.github/workflows/desktopBuild.yml
+++ b/.github/workflows/desktopBuild.yml
@@ -24,7 +24,9 @@ jobs:
           path: ~/.yarn/berry/cache
           key: yarn-${{ runner.os }}-${{ hashFiles('yarn.lock') }}
           restore-keys: yarn-${{ runner.os }}-
-      - run: yarn --immutable --mode=skip-build
+      - run: yarn --immutable
+        env:
+          MUSETRIC_SKIP_PLAYWRIGHT_INSTALL: true
       - run: yarn build:desktop
       - run: yarn workspace @musetric/desktop pack:installer
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ build/
 tmp/
 **/backend/storage/
 packages/desktop/assets/
+packages/ffmpeg/resources/
 .eslintrc.local.json
 yarn-error.log
 .eslintcache

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@
 - `packages/api`: shared API contracts and client/server integration helpers.
 - `packages/backend-db`: backend data access, entities, and schema-related code.
 - `packages/utils`: low-level shared utilities used across packages.
-- `packages/ffmpeg`: the ffmpeg-based audio codec and processing tasks (decode/encode, loudness, wave peaks, format conversion).
+- `packages/ffmpeg`: vendored ffmpeg/ffprobe binary plus the audio codec and processing tasks (decode/encode, loudness, wave peaks, format conversion) built on it.
 - `packages/spa-router`: shared SPA routing utilities.
 - `packages/eslint-config`: the repository ESLint rules.
 - `packages/performance`: performance-focused playground and measurement app for audio work.

--- a/knip.ts
+++ b/knip.ts
@@ -5,8 +5,9 @@ const config: KnipConfig = {
   ignoreExportsUsedInFile: true,
   ignoreIssues: {
     'packages/engine/src/engine.ts': ['exports'],
+    'packages/desktop/scripts/beforePack.ts': ['exports'],
   },
-  ignoreBinaries: ['ffmpeg', 'ps'],
+  ignoreBinaries: ['ps'],
   ignoreUnresolved: ['vite/client', '^tsx$'],
   ignoreDependencies: ['@vitest/browser'],
   ignoreFiles: ['**/i18next.config.ts', '**/vitest.bench.config.ts'],
@@ -22,6 +23,9 @@ const config: KnipConfig = {
     },
     'packages/cqt': {
       entry: ['src/**/*.bench.ts'],
+    },
+    'packages/desktop': {
+      entry: ['scripts/**/*.ts'],
     },
     'packages/script': {
       entry: ['src/**/*.ts'],

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -10,7 +10,7 @@
     "dev": "yarn project:init && yarn build:browser && node --import tsx --watch src/index.ts",
     "build:project": "tsc --build && vite build",
     "build:browser": "vite build",
-    "project:init": "node --import tsx ./scripts/init.js",
+    "project:init": "node --import tsx ./scripts/init.ts",
     "project:start": "node dist/index.js",
     "check:ts": "tsc --build",
     "check:lint": "eslint . --cache --cache-strategy content",

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -5,10 +5,14 @@ electronVersion: 43.1.1
 directories:
   output: build
   buildResources: assets
+beforePack: ./scripts/beforePack.ts
 win:
   icon: assets/icon.png
   target:
-    - nsis
+    - target: nsis
+      arch:
+        - x64
+        - arm64
 nsis:
   oneClick: false
   perMachine: false
@@ -16,13 +20,20 @@ nsis:
   createDesktopShortcut: true
   createStartMenuShortcut: true
   shortcutName: Musetric
+  license: license.txt
 mac:
   target:
-    - dmg
+    - target: dmg
+      arch:
+        - x64
+        - arm64
   category: public.app-category.music
 linux:
   target:
-    - AppImage
+    - target: AppImage
+      arch:
+        - x64
+        - arm64
   category: Audio
 files:
   - dist/**/*
@@ -39,5 +50,10 @@ extraResources:
     to: backend/storage/public
   - from: ../backend/dist-browser
     to: backend/dist-browser
+  - from: ../../license.md
+    to: license.md
+  - from: ../../thirdPartyNotices.md
+    to: thirdPartyNotices.md
 asarUnpack:
   - node_modules/**/*.node
+  - node_modules/@musetric/ffmpeg/resources/**

--- a/packages/desktop/license.txt
+++ b/packages/desktop/license.txt
@@ -1,0 +1,42 @@
+Musetric
+
+MIT License
+
+Copyright (c) 2020-2026 Vladlen Popelenkov
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+
+Bundled FFmpeg
+
+This application bundles the FFmpeg command line tools (ffmpeg, ffprobe) in
+their LGPL configuration and runs them as separate executables. FFmpeg is
+licensed under the GNU Lesser General Public License version 2.1 or later.
+
+The full LGPL text ships next to the binaries, inside the installed
+application under
+
+  resources/app.asar.unpacked/node_modules/@musetric/ffmpeg/resources/
+
+together with a source.txt naming the exact build and where its sources and
+build scripts are published: https://github.com/musetric/ffmpeg-builds
+
+Every other third-party work this application bundles or downloads, including
+the AI models, is listed in resources/thirdPartyNotices.md inside the
+installed application.

--- a/packages/desktop/scripts/beforePack.ts
+++ b/packages/desktop/scripts/beforePack.ts
@@ -1,0 +1,26 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Arch } from 'electron-builder';
+
+const hookDir = dirname(fileURLToPath(import.meta.url));
+const fetchScript = join(
+  hookDir,
+  '..',
+  '..',
+  'ffmpeg',
+  'scripts',
+  'fetchFfmpeg.ts',
+);
+
+type PackContext = {
+  electronPlatformName: string;
+  arch: Arch;
+};
+
+export const beforePack = (context: PackContext): void => {
+  const key = `${context.electronPlatformName}-${Arch[context.arch]}`;
+  execFileSync(process.execPath, [fetchScript, key, '--prune'], {
+    stdio: 'inherit',
+  });
+};

--- a/packages/ffmpeg/package.json
+++ b/packages/ffmpeg/package.json
@@ -14,6 +14,7 @@
     }
   },
   "scripts": {
+    "postinstall": "node ./scripts/fetchFfmpeg.ts",
     "build:project": "tsc --build",
     "check:ts": "tsc --build",
     "check:lint": "eslint . --cache --cache-strategy content",

--- a/packages/ffmpeg/scripts/fetchFfmpeg.ts
+++ b/packages/ffmpeg/scripts/fetchFfmpeg.ts
@@ -1,0 +1,314 @@
+import { execFile } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { createWriteStream, existsSync } from 'node:fs';
+import {
+  chmod,
+  copyFile,
+  mkdir,
+  mkdtemp,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+const tarBin =
+  process.platform === 'win32'
+    ? join(process.env.SystemRoot ?? 'C:\\Windows', 'System32', 'tar.exe')
+    : 'tar';
+
+const releaseRepo = 'https://github.com/musetric/ffmpeg-builds';
+const releaseTag = 'ffmpeg-n8.1.2';
+const releaseBase = `${releaseRepo}/releases/download/${releaseTag}`;
+
+type FfmpegBuild = {
+  url: string;
+  sha256: string;
+  exe: '' | '.exe';
+  ffmpegSha256: string;
+  ffprobeSha256: string;
+};
+
+type FfmpegHashes = {
+  archive: string;
+  ffmpeg: string;
+  ffprobe: string;
+};
+
+const musetric = (
+  os: 'windows' | 'linux' | 'macos',
+  arch: 'x64' | 'arm64',
+  hashes: FfmpegHashes,
+): FfmpegBuild => ({
+  url: `${releaseBase}/ffmpeg-lgpl-${os}-${arch}.tar.gz`,
+  sha256: hashes.archive,
+  exe: os === 'windows' ? '.exe' : '',
+  ffmpegSha256: hashes.ffmpeg,
+  ffprobeSha256: hashes.ffprobe,
+});
+
+const builds = new Map<string, FfmpegBuild>([
+  [
+    'win32-x64',
+    musetric('windows', 'x64', {
+      archive:
+        '655229847a3f2c2f51d360ddf82c06cf759de861431e6aca2776deacc20928ed',
+      ffmpeg:
+        '22c517bb3a005ee56139d290631a4199ddd223dd230c05427177ac7fbba177c6',
+      ffprobe:
+        '60a9266b623675a268a66d6f3ece89958222b8a6bfebbd94396bef1a582f4b5c',
+    }),
+  ],
+  [
+    'win32-arm64',
+    musetric('windows', 'arm64', {
+      archive:
+        '11c870008366aa7ae0c26e148873c1563faefe7af949a7962d4cef790449873c',
+      ffmpeg:
+        '5a8ece55b2b8521e07c57d131ce6db1301c13c5380105dc1873271fdfea8eb01',
+      ffprobe:
+        'ce5f9bd84be07ea6a17dc2472bf15d247e592c11c615a6a90a7487aa51914222',
+    }),
+  ],
+  [
+    'linux-x64',
+    musetric('linux', 'x64', {
+      archive:
+        'ac2c24beae8ba279f59a6161aa9786b52f23c8bb092955b4b522b39e337a4a07',
+      ffmpeg:
+        '73dd2b464b68fae0bda391a9295c23b60a00f7e71a5355d767ccc025980423a1',
+      ffprobe:
+        'c3e6281b0e2b8fdbbdd9c672f5a44392bcc179b2b2dba2df0988c1ebb64bbf8d',
+    }),
+  ],
+  [
+    'linux-arm64',
+    musetric('linux', 'arm64', {
+      archive:
+        'dac20991bca0b5bf5fcaceb95bbcf7b70db97b6585717a88f3bd0ce55c44e42c',
+      ffmpeg:
+        '5de68cea92a24ef39da5fec2f6a5eb4936e9529118c8f26cff469c57f46dbbab',
+      ffprobe:
+        'b175675b7e0339cad38e5fbfed0ab8598c24575310d819c19df08efa913e8141',
+    }),
+  ],
+  [
+    'darwin-arm64',
+    musetric('macos', 'arm64', {
+      archive:
+        'e25393de3bedc64367f20acf792d484d6ccb747b07b9510be4fa834d613289a6',
+      ffmpeg:
+        'b4527d8e038abb7539a71d89dc9e7e56015713f5ac4b16afd289bc7470cf8956',
+      ffprobe:
+        'e4150e4079e1195b008bd21d498af1cc0aea07836e47f6f76f8b7d6e1879d613',
+    }),
+  ],
+  [
+    'darwin-x64',
+    musetric('macos', 'x64', {
+      archive:
+        '3d44ecbae9fb6e8e8f4e563be62336cfc42d328364e8db54dedff737b85bc9d7',
+      ffmpeg:
+        '0bdf967aad6086c534bcc4a4f1e208a5c9160fbf8fcb27141ce4e05ecc59cd3b',
+      ffprobe:
+        '8676b805a461adaeeb73b721862dfcde7e7aaa27c30343c92bf91f8b965c79cd',
+    }),
+  ],
+]);
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const resourcesDir = join(packageDir, 'resources');
+
+const cacheHome =
+  process.platform === 'win32'
+    ? (process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local'))
+    : (process.env.XDG_CACHE_HOME ?? join(homedir(), '.cache'));
+const storeRoot = join(cacheHome, 'musetric', 'ffmpeg', releaseTag);
+
+const args = process.argv.slice(2);
+const force = args.includes('--force');
+const prune = args.includes('--prune');
+const explicitKeys = args.filter((arg) => !arg.startsWith('--'));
+const hostKey = `${process.platform}-${process.arch}`;
+
+const licenseName = 'LICENSE.txt';
+const sourceName = 'source.txt';
+const licenseSha256 =
+  '246041b6ecf9bc32d718a62c57877c78b5eb397b6467e74ed7ae2626ab189c30';
+const downloadTimeoutMs = 5 * 60 * 1000;
+
+const members = (build: FfmpegBuild): string[] => [
+  `ffmpeg${build.exe}`,
+  `ffprobe${build.exe}`,
+  licenseName,
+];
+
+const sourceNote = (build: FfmpegBuild): string =>
+  [
+    `release: ${releaseRepo}/releases/tag/${releaseTag}`,
+    `archive: ${build.url}`,
+    `sha256: ${build.sha256}`,
+    `source: ${releaseRepo} holds the ffmpeg sources and build scripts for ${releaseTag}`,
+    '',
+  ].join('\n');
+
+const sha256Of = async (path: string): Promise<string> =>
+  createHash('sha256')
+    .update(await readFile(path))
+    .digest('hex');
+
+const memberSha256 = (build: FfmpegBuild, member: string): string => {
+  if (member === `ffmpeg${build.exe}`) {
+    return build.ffmpegSha256;
+  }
+  if (member === `ffprobe${build.exe}`) {
+    return build.ffprobeSha256;
+  }
+  return licenseSha256;
+};
+
+const hasExpectedMembers = async (
+  targetDir: string,
+  build: FfmpegBuild,
+): Promise<boolean> => {
+  try {
+    const actualHashes = await Promise.all(
+      members(build).map(async (member) => sha256Of(join(targetDir, member))),
+    );
+    return actualHashes.every(
+      (actual, index) => actual === memberSha256(build, members(build)[index]),
+    );
+  } catch {
+    return false;
+  }
+};
+
+const download = async (
+  build: FfmpegBuild,
+  destPath: string,
+): Promise<void> => {
+  console.log(`Downloading ${build.url}`);
+  const response = await fetch(build.url, {
+    signal: AbortSignal.timeout(downloadTimeoutMs),
+  });
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed (${response.status}): ${build.url}`);
+  }
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(destPath));
+  const actual = await sha256Of(destPath);
+  if (actual !== build.sha256) {
+    throw new Error(
+      `Checksum mismatch for ${build.url}: expected ${build.sha256}, got ${actual}`,
+    );
+  }
+};
+
+const ensureStore = async (
+  key: string,
+  build: FfmpegBuild,
+): Promise<string> => {
+  const storeDir = join(storeRoot, key);
+  if (await hasExpectedMembers(storeDir, build)) {
+    return storeDir;
+  }
+  const downloadDir = await mkdtemp(join(tmpdir(), 'musetric-ffmpeg-'));
+  const stageDir = `${storeDir}.stage`;
+  try {
+    const archivePath = join(downloadDir, `${key}.tar.gz`);
+    await download(build, archivePath);
+    await rm(stageDir, { recursive: true, force: true });
+    await mkdir(stageDir, { recursive: true });
+    await execFileAsync(tarBin, [
+      '-xf',
+      archivePath,
+      '-C',
+      stageDir,
+      ...members(build),
+    ]);
+    await rm(storeDir, { recursive: true, force: true });
+    await rename(stageDir, storeDir);
+  } finally {
+    await rm(downloadDir, { recursive: true, force: true });
+    await rm(stageDir, { recursive: true, force: true });
+  }
+  return storeDir;
+};
+
+const isVendored = async (
+  targetDir: string,
+  build: FfmpegBuild,
+): Promise<boolean> => {
+  const sourcePath = join(targetDir, sourceName);
+  if (!existsSync(sourcePath)) {
+    return false;
+  }
+  if ((await readFile(sourcePath, 'utf8')) !== sourceNote(build)) {
+    return false;
+  }
+  return hasExpectedMembers(targetDir, build);
+};
+
+const vendorKey = async (key: string): Promise<void> => {
+  const build = builds.get(key);
+  if (build === undefined) {
+    throw new Error(
+      `No pinned ffmpeg build for ${key}. ` +
+        `Supported: ${[...builds.keys()].join(', ')}.`,
+    );
+  }
+  const targetDir = join(resourcesDir, key);
+  if (!force && (await isVendored(targetDir, build))) {
+    console.log(`ffmpeg/ffprobe already vendored for ${key}, skipping.`);
+    return;
+  }
+  const storeDir = await ensureStore(key, build);
+  await mkdir(targetDir, { recursive: true });
+  for (const member of members(build)) {
+    const destPath = join(targetDir, member);
+    await copyFile(join(storeDir, member), destPath);
+    if (build.exe === '' && member !== licenseName) {
+      await chmod(destPath, 0o755);
+    }
+  }
+  await writeFile(join(targetDir, sourceName), sourceNote(build));
+  console.log(`Vendored ffmpeg/ffprobe for ${key}.`);
+};
+
+const pruneKeys = async (keys: string[]): Promise<void> => {
+  const entries = await readdir(resourcesDir, { withFileTypes: true });
+  for (const entry of entries) {
+    if (!entry.isDirectory() || keys.includes(entry.name)) {
+      continue;
+    }
+    await rm(join(resourcesDir, entry.name), { recursive: true, force: true });
+    console.log(`Pruned vendored ffmpeg for ${entry.name}.`);
+  }
+};
+
+const resolveKeys = (): string[] =>
+  explicitKeys.length > 0 ? explicitKeys : [hostKey];
+
+const main = async (): Promise<void> => {
+  if (process.env.MUSETRIC_SKIP_FFMPEG_FETCH !== undefined) {
+    console.log('Skipping ffmpeg/ffprobe fetch.');
+    return;
+  }
+  const keys = resolveKeys();
+  for (const key of keys) {
+    await vendorKey(key);
+  }
+  if (prune) {
+    await pruneKeys(keys);
+  }
+};
+
+await main();

--- a/packages/ffmpeg/src/analyzeLoudness.ts
+++ b/packages/ffmpeg/src/analyzeLoudness.ts
@@ -1,5 +1,6 @@
 import { type Logger } from '@musetric/utils';
 import { spawnScript } from '@musetric/utils/node';
+import { ffmpegPath } from './paths.js';
 
 const parseNumber = (value: unknown, label: string): number => {
   const rawNumber = typeof value === 'number' ? value : Number(value);
@@ -50,7 +51,7 @@ export const analyzeLoudness = async (
   const stderrLines: string[] = [];
 
   await spawnScript({
-    command: 'ffmpeg',
+    command: ffmpegPath(),
     flatArgs: [
       '-hide_banner',
       '-nostats',

--- a/packages/ffmpeg/src/codec.ts
+++ b/packages/ffmpeg/src/codec.ts
@@ -1,6 +1,7 @@
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { type Logger } from '@musetric/utils';
+import { ffmpegPath, ffprobePath } from './paths.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -18,7 +19,9 @@ const runFfmpeg = async (options: RunFfmpegOptions): Promise<Buffer> => {
   let lastStderr = '';
 
   return new Promise<Buffer>((resolve, reject) => {
-    const child = spawn('ffmpeg', args, { stdio: ['pipe', 'pipe', 'pipe'] });
+    const child = spawn(ffmpegPath(), args, {
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
 
     child.stdout.on('data', (chunk: Buffer) => {
       if (captureStdout) {
@@ -94,7 +97,7 @@ export const decodeInterleavedPcm = async (
 };
 
 const probeChannelCount = async (sourcePath: string): Promise<number> => {
-  const { stdout } = await execFileAsync('ffprobe', [
+  const { stdout } = await execFileAsync(ffprobePath(), [
     '-v',
     'error',
     '-select_streams',

--- a/packages/ffmpeg/src/convertToFlac.ts
+++ b/packages/ffmpeg/src/convertToFlac.ts
@@ -2,6 +2,7 @@ import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { type Logger } from '@musetric/utils';
 import { spawnScript } from '@musetric/utils/node';
+import { ffmpegPath } from './paths.js';
 
 export const flacAudioOutput = {
   format: 'flac',
@@ -22,7 +23,7 @@ export const convertToFlac = async (
   await mkdir(dirname(toPath), { recursive: true });
 
   await spawnScript({
-    command: 'ffmpeg',
+    command: ffmpegPath(),
     flatArgs: [
       '-y',
       '-hide_banner',

--- a/packages/ffmpeg/src/convertToFmp4.ts
+++ b/packages/ffmpeg/src/convertToFmp4.ts
@@ -2,6 +2,7 @@ import { mkdir } from 'node:fs/promises';
 import { dirname } from 'node:path';
 import { type Logger } from '@musetric/utils';
 import { spawnScript } from '@musetric/utils/node';
+import { ffmpegPath } from './paths.js';
 
 const fragmentDurationSeconds = 2;
 
@@ -25,7 +26,7 @@ export const convertToFmp4 = async (
   await mkdir(dirname(toPath), { recursive: true });
 
   await spawnScript({
-    command: 'ffmpeg',
+    command: ffmpegPath(),
     flatArgs: [
       '-y',
       '-hide_banner',

--- a/packages/ffmpeg/src/generateWavePeaks/readPcm.ts
+++ b/packages/ffmpeg/src/generateWavePeaks/readPcm.ts
@@ -1,5 +1,6 @@
 import { type Logger } from '@musetric/utils';
 import { spawnScript } from '@musetric/utils/node';
+import { ffmpegPath } from '../paths.js';
 
 export type ReadPcmOptions = {
   fromPath: string;
@@ -16,7 +17,7 @@ export const readPcm = async (options: ReadPcmOptions): Promise<void> => {
   let sampleIndex = 0;
 
   await spawnScript({
-    command: 'ffmpeg',
+    command: ffmpegPath(),
     flatArgs: [
       '-hide_banner',
       '-loglevel',

--- a/packages/ffmpeg/src/getAudioFrameCount.ts
+++ b/packages/ffmpeg/src/getAudioFrameCount.ts
@@ -1,5 +1,6 @@
 import { type Logger } from '@musetric/utils';
 import { spawnScript } from '@musetric/utils/node';
+import { ffprobePath } from './paths.js';
 
 export const getAudioFrameCount = async (
   fromPath: string,
@@ -10,7 +11,7 @@ export const getAudioFrameCount = async (
   let durationSeconds = undefined as number | undefined;
 
   await spawnScript({
-    command: 'ffprobe',
+    command: ffprobePath(),
     flatArgs: [
       '-v',
       'error',

--- a/packages/ffmpeg/src/index.ts
+++ b/packages/ffmpeg/src/index.ts
@@ -5,3 +5,4 @@ export * from './convertToFlac.js';
 export * from './convertToFmp4.js';
 export * from './generateWavePeaks/index.js';
 export * from './getAudioFrameCount.js';
+export * from './paths.js';

--- a/packages/ffmpeg/src/paths.ts
+++ b/packages/ffmpeg/src/paths.ts
@@ -1,0 +1,28 @@
+import { existsSync } from 'node:fs';
+import { dirname, join, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const asarMarker = `${sep}app.asar${sep}`;
+const unpackedMarker = `${sep}app.asar.unpacked${sep}`;
+
+const fromUnpackedAsar = (path: string): string =>
+  path.includes(asarMarker) ? path.replace(asarMarker, unpackedMarker) : path;
+
+const platformKey = `${process.platform}-${process.arch}`;
+const exeSuffix = process.platform === 'win32' ? '.exe' : '';
+
+const bundledDir = fromUnpackedAsar(join(packageDir, 'resources', platformKey));
+
+const bundledBinary = (name: 'ffmpeg' | 'ffprobe'): string => {
+  const path = join(bundledDir, `${name}${exeSuffix}`);
+  if (!existsSync(path)) {
+    throw new Error(`Bundled ${name} is missing at ${path}.`);
+  }
+  return path;
+};
+
+export const ffmpegPath = (): string => bundledBinary('ffmpeg');
+
+export const ffprobePath = (): string => bundledBinary('ffprobe');

--- a/packages/fft/scripts/setup.ts
+++ b/packages/fft/scripts/setup.ts
@@ -1,8 +1,13 @@
 import { execSync } from 'child_process';
 
-if (process.platform !== 'linux') {
+const skipPlaywrightInstall =
+  process.env.MUSETRIC_SKIP_PLAYWRIGHT_INSTALL !== undefined;
+
+if (process.platform !== 'linux' && !skipPlaywrightInstall) {
   console.log('Installing Playwright browsers...');
   execSync('npx playwright install', { stdio: 'inherit' });
+} else if (skipPlaywrightInstall) {
+  console.log('Skipping Playwright install.');
 } else {
   console.log('Skipping Playwright install on Linux');
 }

--- a/thirdPartyNotices.md
+++ b/thirdPartyNotices.md
@@ -195,3 +195,12 @@ SOFTWARE.
 - Local files: `packages/ai/src/models/beatThisModel.ts`, `packages/ai/src/service/beatThisModelCache.node.ts`.
 - License: MIT, inherited from the upstream Beat This! weights; conversion to ONNX does not change the weight license.
 - License source: Hugging Face model card metadata.
+
+## FFmpeg
+
+- Source: https://github.com/FFmpeg/FFmpeg, built and published as https://github.com/musetric/ffmpeg-builds (release `ffmpeg-n8.1.2`).
+- Usage: the unmodified `ffmpeg` and `ffprobe` command line tools, built in their LGPL configuration. They are vendored into `packages/ffmpeg/resources/<platform>-<arch>/` and shipped inside the desktop app, where this project runs them as separate processes; nothing is linked against the FFmpeg libraries.
+- Local files: `packages/ffmpeg/scripts/fetchFfmpeg.ts`, `packages/ffmpeg/src/paths.ts`, `packages/ffmpeg/src/codec.ts`, `packages/ffmpeg/src/analyzeLoudness.ts`, `packages/ffmpeg/src/convertToFlac.ts`, `packages/ffmpeg/src/convertToFmp4.ts`, `packages/ffmpeg/src/generateWavePeaks/readPcm.ts`, `packages/ffmpeg/src/getAudioFrameCount.ts`.
+- License: LGPL-2.1-or-later. Full text: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+- License source: the `LICENSE.txt` shipped inside each downloaded archive, which is copied next to the binaries and travels with every installer.
+- Source availability: the sources and build scripts for the exact binaries are published in the release above. Each vendored directory also carries a `source.txt` naming the release, the archive URL and its SHA-256, so a shipped binary can be traced back to the sources it was built from.


### PR DESCRIPTION
Bundle pinned LGPL FFmpeg and FFprobe binaries in @musetric/ffmpeg so audio processing never resolves executables from the system PATH.

- Fetch the host binary at install with SHA-256 verification and a versioned user cache; MUSETRIC_SKIP_FFMPEG_FETCH explicitly skips the fetch.
- Route every FFmpeg task through bundled paths, including the ASAR-unpacked path in desktop builds.
- Fetch the exact target binary in beforePack and prune non-target resources so each installer ships only its platform and architecture.
- Include the LGPL notice and source metadata in desktop distributions.
- Run normal lifecycle scripts in the desktop CI workflow while skipping only Playwright browser setup.
- Correct the backend project:init TypeScript entrypoint.