### PR TITLE
perf(ai): enable simple cache for audio separation

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -64,7 +64,7 @@ catalog:
   'jscpd': '5.0.12'
   'knip': '6.27.0'
   'koffi': '3.0.2'
-  'onnxruntime-web': '1.26.0'
+  'onnxruntime-web': '1.29.0-dev.20260724-ed98916356'
   'openapi-types': '12.1.3'
   'pino': '10.3.1'
   'pino-pretty': '13.1.3'

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@fastify/static": "10.1.2",
     "adm-zip": "^0.6.0",
     "filelist": "2.0.2",
-    "onnxruntime-web": "1.26.0",
+    "onnxruntime-web": "1.29.0-dev.20260724-ed98916356",
     "sharp": "^0.35.3"
   }
 }

--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -28,7 +28,7 @@
     "@musetric/ffmpeg": "workspace:*",
     "@musetric/fft": "workspace:*",
     "@musetric/utils": "workspace:*",
-    "onnxruntime-web": "1.26.0"
+    "onnxruntime-web": "1.29.0-dev.20260724-ed98916356"
   },
   "devDependencies": {
     "@musetric/cqt": "workspace:*",

--- a/packages/ai/src/runtime/ortWebGpu.ts
+++ b/packages/ai/src/runtime/ortWebGpu.ts
@@ -1,0 +1,7 @@
+import { type InferenceSession } from 'onnxruntime-web/webgpu';
+
+export const webGpuExecutionProvider: InferenceSession.WebGpuExecutionProviderOption =
+  {
+    name: 'webgpu',
+    storageBufferCacheMode: 'simple',
+  };

--- a/packages/ai/src/runtime/stftInference.ts
+++ b/packages/ai/src/runtime/stftInference.ts
@@ -13,6 +13,7 @@ import {
   dispatch2d,
   type Dispatch2dOptions,
 } from './helpers.js';
+import { webGpuExecutionProvider } from './ortWebGpu.js';
 
 ort.env.logLevel = 'error';
 
@@ -83,7 +84,7 @@ export const createStftInferenceRuntime = async (
     windowCount * (nFft + 2) * Float32Array.BYTES_PER_ELEMENT;
 
   const session = await ort.InferenceSession.create(options.modelUrl, {
-    executionProviders: ['webgpu'],
+    executionProviders: [webGpuExecutionProvider],
     graphOptimizationLevel: 'all',
     preferredOutputLocation: { [model.outputName]: 'gpu-buffer' },
     ...(options.externalData ? { externalData: options.externalData } : {}),

--- a/packages/ai/src/runtime/whisper/whisperRuntime.ts
+++ b/packages/ai/src/runtime/whisper/whisperRuntime.ts
@@ -96,12 +96,7 @@ export const createWhisperRuntime = async (
       dtype: { ...whisperModel.dtype },
 
       session_options: {
-        executionProviders: [
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          { name: 'webgpu', storageBufferCacheMode: 'bucket' } as {
-            name: 'webgpu';
-          },
-        ],
+        executionProviders: ['webgpu'],
       },
       progress_callback: (data: LoadProgress) => {
         if (data.status === 'progress' && typeof data.progress === 'number') {

--- a/packages/backend-core/package.json
+++ b/packages/backend-core/package.json
@@ -41,7 +41,7 @@
     "fastify": "5.10.0",
     "fastify-sse-v2": "4.2.2",
     "fastify-type-provider-zod": "6.1.0",
-    "onnxruntime-web": "1.26.0",
+    "onnxruntime-web": "1.29.0-dev.20260724-ed98916356",
     "openapi-types": "12.1.3",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2020,7 +2020,7 @@ __metadata:
     "@musetric/ffmpeg": "workspace:*"
     "@musetric/fft": "workspace:*"
     "@musetric/utils": "workspace:*"
-    onnxruntime-web: 1.26.0
+    onnxruntime-web: 1.29.0-dev.20260724-ed98916356
   languageName: unknown
   linkType: soft
 
@@ -2111,7 +2111,7 @@ __metadata:
     fastify: 5.10.0
     fastify-sse-v2: 4.2.2
     fastify-type-provider-zod: 6.1.0
-    onnxruntime-web: 1.26.0
+    onnxruntime-web: 1.29.0-dev.20260724-ed98916356
     openapi-types: 12.1.3
     pino: 10.3.1
     pino-pretty: 13.1.3
@@ -8194,10 +8194,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onnxruntime-common@npm:1.26.0":
-  version: 1.26.0
-  resolution: "onnxruntime-common@npm:1.26.0"
-  checksum: 10c0/220679e2b0129fcc8efd710e1502f792ee5583173d261840369c2dd07bbfdcb9dbbeb027002131094f05e0d287354f7cf66605084b6eb0d90d9543fe485c8c6f
+"onnxruntime-common@npm:1.29.0-dev.20260723-1b1e1db7bc":
+  version: 1.29.0-dev.20260723-1b1e1db7bc
+  resolution: "onnxruntime-common@npm:1.29.0-dev.20260723-1b1e1db7bc"
+  checksum: 10c0/bde02b0d7ec5b565e75a29f9cc82d797194a66cdbd7544b2ae261e76e774558153e5b575ee3593a0ac0955bd7036167a5783c0edb6c21609a5abc8a0eb84f840
   languageName: node
   linkType: hard
 
@@ -8213,17 +8213,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"onnxruntime-web@npm:1.26.0":
-  version: 1.26.0
-  resolution: "onnxruntime-web@npm:1.26.0"
+"onnxruntime-web@npm:1.29.0-dev.20260724-ed98916356":
+  version: 1.29.0-dev.20260724-ed98916356
+  resolution: "onnxruntime-web@npm:1.29.0-dev.20260724-ed98916356"
   dependencies:
     flatbuffers: "npm:^25.1.24"
     guid-typescript: "npm:^1.0.9"
     long: "npm:^5.2.3"
-    onnxruntime-common: "npm:1.26.0"
+    onnxruntime-common: "npm:1.29.0-dev.20260723-1b1e1db7bc"
     platform: "npm:^1.3.6"
     protobufjs: "npm:^7.2.4"
-  checksum: 10c0/6e63265dd2810c22897843c140b5c6b5912f285274f5f743af83ebdfeded863e5dea9f92e5f246cf72a0eb8ae4f38e64990869f6cd7472a0f20940b19b362c83
+  checksum: 10c0/737dbfdde6d11f0509d4307fe8f05218342b46c6c17c4f484e80d43e62746a61e59833e2e6164c5e42fcd83e2201adf200028808f816ab83bcb6a620f355b3be
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Upgrade onnxruntime-web to the upstream dev build that exposes storageBufferCacheMode. Configure simple only in the shared STFT runtime used by vocals and lead/backing separation, while every other runtime keeps the default WebGPU cache mode. The new public type also removes the obsolete Whisper workaround.