### PR TITLE
fix(ai): drop only the caption segment from a whisper window

### DIFF
--- a/packages/ai/src/runtime/whisper/whisperDecoder.ts
+++ b/packages/ai/src/runtime/whisper/whisperDecoder.ts
@@ -1,0 +1,140 @@
+import { splitBySegments, type WordChunk } from './whisperSegments.js';
+
+const sampleRate = 16000;
+
+const melHopSamples = 160;
+
+const timePrecision = 0.02;
+
+const maxDecodeTokens = 400;
+const tokensPerSecond = 12;
+const minDecodeTokens = 32;
+
+export type DecodeGuard = Record<string, unknown>;
+
+type TokenId = number | bigint;
+
+type GenerateOutput = {
+  sequences: { tolist: () => TokenId[][] };
+  token_timestamps: { tolist: () => number[][] };
+};
+
+export type WhisperModelInternals = {
+  generation_config: {
+    lang_to_id?: Record<string, number>;
+    decoder_start_token_id?: number;
+  };
+  generate: (args: Record<string, unknown>) => Promise<GenerateOutput>;
+} & ((args: Record<string, unknown>) => Promise<{
+  logits: { data: Float32Array };
+}>);
+
+type AsrChunk = {
+  tokens: TokenId[];
+  token_timestamps: number[];
+  stride: [number, number, number];
+};
+
+type AsrWords = { chunks?: WordChunk[] };
+
+export type WhisperTokenizer = {
+  decode: (ids: TokenId[], options?: Record<string, unknown>) => string;
+  timestamp_begin: number;
+  _decode_asr: (
+    chunks: AsrChunk[],
+    options: Record<string, unknown>,
+  ) => [string, AsrWords];
+};
+
+export type WhisperPipelineInternals = {
+  model: WhisperModelInternals;
+  tokenizer: WhisperTokenizer;
+  processor: (audio: Float32Array) => Promise<{ input_features: unknown }>;
+};
+
+export type DecodeResult = {
+  text?: string;
+  chunks?: WordChunk[];
+  segments?: WordChunk[][];
+};
+
+export type WhisperDecoder = {
+  decodeTimestamped: (
+    audio: Float32Array,
+    language: string,
+    guard: DecodeGuard | undefined,
+  ) => Promise<DecodeResult>;
+};
+
+export const createWhisperDecoder = (
+  internals: WhisperPipelineInternals,
+): WhisperDecoder => {
+  const generateArgs = (
+    audio: Float32Array,
+    language: string,
+    guard: DecodeGuard | undefined,
+  ): Record<string, unknown> => ({
+    num_frames: Math.floor(audio.length / melHopSamples),
+    language,
+    task: 'transcribe',
+    max_new_tokens: Math.min(
+      maxDecodeTokens,
+      Math.max(
+        minDecodeTokens,
+        Math.round((audio.length / sampleRate) * tokensPerSecond) +
+          minDecodeTokens,
+      ),
+    ),
+
+    ...guard,
+  });
+
+  const decodeTimestamped = async (
+    audio: Float32Array,
+    language: string,
+    guard: DecodeGuard | undefined,
+  ): Promise<DecodeResult> => {
+    const inputs = await internals.processor(audio);
+    const output = await internals.model.generate({
+      inputs: inputs.input_features,
+      return_timestamps: true,
+      return_token_timestamps: true,
+      ...generateArgs(audio, language, guard),
+    });
+
+    const [rawTokens] = output.sequences.tolist();
+    const [rawTimes] = output.token_timestamps.tolist();
+    const { timestamp_begin: timestampBegin } = internals.tokenizer;
+    const prefix = Math.max(
+      rawTokens.findIndex((token) => Number(token) >= timestampBegin),
+      0,
+    );
+    const tokens = rawTokens.slice(prefix);
+    const chunk: AsrChunk = {
+      tokens,
+      token_timestamps: rawTimes
+        .slice(prefix)
+        .map((time) => Math.round(time * 100) / 100),
+      stride: [audio.length / sampleRate, 0, 0],
+    };
+    const [text, words] = internals.tokenizer._decode_asr([chunk], {
+      time_precision: timePrecision,
+      return_timestamps: 'word',
+      force_full_sequences: false,
+    });
+
+    const chunks = words.chunks ?? [];
+    return {
+      text,
+      chunks,
+      segments: splitBySegments({
+        tokens: tokens.map(Number),
+        words: chunks,
+        timestampBegin,
+        timePrecision,
+      }),
+    };
+  };
+
+  return { decodeTimestamped };
+};

--- a/packages/ai/src/runtime/whisper/whisperRuntime.ts
+++ b/packages/ai/src/runtime/whisper/whisperRuntime.ts
@@ -5,58 +5,28 @@ import {
   Tensor,
 } from '@huggingface/transformers';
 import { whisperModel } from '../../models/whisperModel.js';
+import { isHallucination } from '../../transcription/hallucinationFilter.js';
 import { type TranscriptionWord } from '../../transcription/types.js';
+import {
+  createWhisperDecoder,
+  type DecodeGuard,
+  type DecodeResult,
+  type WhisperPipelineInternals,
+} from './whisperDecoder.js';
+import { extractWords, isLooped, spanText } from './whisperSegments.js';
 
-type WordChunk = { text: string; timestamp: [number, number | null] };
-
-const extractWords = (chunks: WordChunk[]): TranscriptionWord[] => {
-  const words: TranscriptionWord[] = [];
-  for (const chunk of chunks) {
-    const text = chunk.text.trim();
-    if (!text) {
-      continue;
-    }
-
-    const [start, rawEnd] = chunk.timestamp;
-    const end = rawEnd ?? start;
-    words.push({ text, start, end });
-  }
-  return words;
-};
-
-const loopCompressionRatio = 2.4;
+const sampleRate = 16000;
 
 const fallbackTemperatures = [0, 0.2, 0.4, 0.6, 0.8, 1.0];
 
-const compressionRatio = async (text: string): Promise<number> => {
-  const bytes = new TextEncoder().encode(text);
-  if (bytes.length < 48) {
-    return 0;
-  }
-  const compressedStream = new Blob([bytes])
-    .stream()
-    .pipeThrough(new CompressionStream('gzip'));
-  const compressed = await new Response(compressedStream).arrayBuffer();
-  return bytes.length / compressed.byteLength;
-};
+const ladderGuard = (temperature: number): DecodeGuard => ({
+  no_repeat_ngram_size: 3,
+  ...(temperature > 0 ? { do_sample: true, temperature } : {}),
+});
 
 type LoadProgress = {
   status?: string;
   progress?: number;
-};
-
-type WhisperModelInternals = {
-  generation_config: {
-    lang_to_id?: Record<string, number>;
-    decoder_start_token_id?: number;
-  };
-} & ((args: Record<string, unknown>) => Promise<{
-  logits: { data: Float32Array };
-}>);
-
-type WhisperPipelineInternals = {
-  model: WhisperModelInternals;
-  processor: (audio: Float32Array) => Promise<{ input_features: unknown }>;
 };
 
 export type WhisperRuntimeOptions = {
@@ -113,6 +83,7 @@ export const createWhisperRuntime = async (
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const internals = transcriber as unknown as WhisperPipelineInternals;
+  const { decodeTimestamped } = createWhisperDecoder(internals);
   const generationConfig = internals.model.generation_config;
   const langToId = generationConfig.lang_to_id ?? {};
   const startToken = generationConfig.decoder_start_token_id ?? 50258;
@@ -140,48 +111,21 @@ export const createWhisperRuntime = async (
     return best.slice(2, -2);
   };
 
-  type DecodeResult = { text?: string; chunks?: WordChunk[] };
-
   const decodePass = async (
     audios: Float32Array[],
     language: string,
-    guard: boolean,
-    temperature = 0,
+    guard: DecodeGuard | undefined,
   ): Promise<DecodeResult[]> => {
-    const maxDuration = Math.max(...audios.map((a) => a.length / 16000));
-    const maxNewTokens = Math.min(
-      400,
-      Math.max(32, Math.round(maxDuration * 12) + 32),
-    );
-    try {
-      const output = await transcriber(audios, {
-        return_timestamps: 'word',
-        chunk_length_s: 0,
-        language,
-        task: 'transcribe',
-        max_new_tokens: maxNewTokens,
-
-        ...(temperature > 0 ? { do_sample: true, temperature } : {}),
-        ...(guard ? { no_repeat_ngram_size: 3 } : {}),
-      });
-      return Array.isArray(output) ? output : [output];
-    } catch (error) {
-      if (!(error instanceof Error) || !/non-empty array/.test(error.message)) {
-        throw error;
-      }
-
-      if (audios.length === 1) {
+    const results: DecodeResult[] = [];
+    for (const audio of audios) {
+      if (audio.length === 0) {
         console.log('whisper decode: empty chunk skipped');
-        return [{}];
+        results.push({});
+        continue;
       }
-      const results: DecodeResult[] = [];
-      for (const audio of audios) {
-        results.push(
-          (await decodePass([audio], language, guard, temperature))[0],
-        );
-      }
-      return results;
+      results.push(await decodeTimestamped(audio, language, guard));
     }
+    return results;
   };
 
   const transcribeBatch = async (
@@ -192,15 +136,33 @@ export const createWhisperRuntime = async (
       return [];
     }
     const decodeStart = performance.now();
-    const maxDuration = Math.max(...audios.map((a) => a.length / 16000));
+    const maxDuration = Math.max(...audios.map((a) => a.length / sampleRate));
 
-    const outputs = await decodePass(audios, language, false);
+    const outputs = await decodePass(audios, language, undefined);
 
-    const isLooped = async (result: DecodeResult): Promise<boolean> =>
-      (await compressionRatio(result.text ?? '')) > loopCompressionRatio;
+    const dropCaptionSegments = (result: DecodeResult): DecodeResult => {
+      const segments = result.segments ?? [];
+      if (segments.length === 0) {
+        return isHallucination(result.text ?? '') ? { text: '' } : result;
+      }
+      const clean = segments.filter(
+        (segment) => !isHallucination(spanText(segment)),
+      );
+      if (clean.length === segments.length) {
+        return result;
+      }
+      for (const segment of segments) {
+        if (!clean.includes(segment)) {
+          console.log(`whisper caption dropped: ${spanText(segment)}`);
+        }
+      }
+      const chunks = clean.flat();
+      return { text: spanText(chunks), chunks, segments: clean };
+    };
+
     let looped: number[] = [];
     for (const [index, result] of outputs.entries()) {
-      if (await isLooped(result)) {
+      if (await isLooped(result.text ?? '')) {
         looped.push(index);
       }
     }
@@ -211,13 +173,12 @@ export const createWhisperRuntime = async (
       const retried = await decodePass(
         looped.map((index) => audios[index]),
         language,
-        true,
-        temperature,
+        ladderGuard(temperature),
       );
       const stillLooped: number[] = [];
       for (const [retryIndex, index] of looped.entries()) {
         outputs[index] = retried[retryIndex];
-        if (await isLooped(retried[retryIndex])) {
+        if (await isLooped(retried[retryIndex].text ?? '')) {
           stillLooped.push(index);
         }
       }
@@ -226,6 +187,10 @@ export const createWhisperRuntime = async (
         `whisper ladder ${label}: rescued ${looped.length - stillLooped.length}/${looped.length} chunk(s)`,
       );
       looped = stillLooped;
+    }
+
+    for (const [index, result] of outputs.entries()) {
+      outputs[index] = dropCaptionSegments(result);
     }
 
     console.log(

--- a/packages/ai/src/runtime/whisper/whisperSegments.ts
+++ b/packages/ai/src/runtime/whisper/whisperSegments.ts
@@ -1,0 +1,93 @@
+import { type TranscriptionWord } from '../../transcription/types.js';
+
+export type WordChunk = { text: string; timestamp: [number, number | null] };
+
+export const extractWords = (chunks: WordChunk[]): TranscriptionWord[] => {
+  const words: TranscriptionWord[] = [];
+  for (const chunk of chunks) {
+    const text = chunk.text.trim();
+    if (!text) {
+      continue;
+    }
+
+    const [start, rawEnd] = chunk.timestamp;
+    const end = rawEnd ?? start;
+    words.push({ text, start, end });
+  }
+  return words;
+};
+
+export const spanText = (chunks: WordChunk[]): string =>
+  chunks
+    .map((chunk) => chunk.text)
+    .join('')
+    .trim();
+
+const compressionRatio = async (text: string): Promise<number> => {
+  const bytes = new TextEncoder().encode(text);
+  if (bytes.length < 48) {
+    return 0;
+  }
+  const compressedStream = new Blob([bytes])
+    .stream()
+    .pipeThrough(new CompressionStream('gzip'));
+  const compressed = await new Response(compressedStream).arrayBuffer();
+  return bytes.length / compressed.byteLength;
+};
+
+const loopCompressionRatio = 2.4;
+
+export const isLooped = async (text: string): Promise<boolean> =>
+  (await compressionRatio(text)) > loopCompressionRatio;
+
+type SegmentBounds = [number, number][];
+
+const readBounds = (
+  tokens: number[],
+  timestampBegin: number,
+  timePrecision: number,
+): SegmentBounds => {
+  const bounds: SegmentBounds = [];
+  let open: number | undefined = undefined;
+  for (const token of tokens) {
+    if (token < timestampBegin) {
+      continue;
+    }
+    const time = (token - timestampBegin) * timePrecision;
+    if (open === undefined) {
+      open = time;
+      continue;
+    }
+    bounds.push([open, time]);
+    open = undefined;
+  }
+  return bounds;
+};
+
+export type SplitOptions = {
+  tokens: number[];
+  words: WordChunk[];
+  timestampBegin: number;
+  timePrecision: number;
+};
+
+export const splitBySegments = (options: SplitOptions): WordChunk[][] => {
+  const { tokens, words, timestampBegin, timePrecision } = options;
+  const bounds = readBounds(tokens, timestampBegin, timePrecision);
+  if (bounds.length === 0) {
+    return words.length > 0 ? [words] : [];
+  }
+
+  const segments: WordChunk[][] = bounds.map(() => []);
+  for (const word of words) {
+    let index = bounds.length - 1;
+    for (const [candidate, [, end]] of bounds.entries()) {
+      if (word.timestamp[0] <= end) {
+        index = candidate;
+        break;
+      }
+    }
+    segments[index].push(word);
+  }
+  return segments.filter((segment) => segment.length > 0);
+};


### PR DESCRIPTION
Caption boilerplate was filtered after words from every window had been regrouped by a one-second gap, so a caption could end up in the same group as lyrics from the neighbouring window and take them down with it.

The boundaries needed to filter it precisely never reached the caller: the speech-recognition pipeline consumes the timestamp tokens the decoder emits and returns text and words only. Call generate directly to keep them, split words into the decoder's own segments, and drop only the segment that is a caption.