### PR TITLE
fix(ai): guard whisper decoder loops per segment

### DIFF
--- a/packages/ai/src/runtime/whisper/whisperDecoder.ts
+++ b/packages/ai/src/runtime/whisper/whisperDecoder.ts
@@ -11,7 +11,7 @@ const maxDecodeTokens = 400;
 const tokensPerSecond = 12;
 const minDecodeTokens = 32;
 
-export type DecodeGuard = Record<string, unknown>;
+export type DecodeGuard = Record<string, number>;
 
 type TokenId = number | bigint;
 

--- a/packages/ai/src/runtime/whisper/whisperRuntime.ts
+++ b/packages/ai/src/runtime/whisper/whisperRuntime.ts
@@ -17,12 +17,10 @@ import { extractWords, isLooped, spanText } from './whisperSegments.js';
 
 const sampleRate = 16000;
 
-const fallbackTemperatures = [0, 0.2, 0.4, 0.6, 0.8, 1.0];
-
-const ladderGuard = (temperature: number): DecodeGuard => ({
-  no_repeat_ngram_size: 3,
-  ...(temperature > 0 ? { do_sample: true, temperature } : {}),
-});
+const guardLadder: DecodeGuard[] = [
+  { no_repeat_ngram_size: 3 },
+  { no_repeat_ngram_size: 3, repetition_penalty: 1.15 },
+];
 
 type LoadProgress = {
   status?: string;
@@ -160,34 +158,52 @@ export const createWhisperRuntime = async (
       return { text: spanText(chunks), chunks, segments: clean };
     };
 
-    let looped: number[] = [];
+    const hasLoopedSegment = async (result: DecodeResult): Promise<boolean> => {
+      const segments = result.segments ?? [];
+      if (segments.length === 0) {
+        return isLooped(result.text ?? '');
+      }
+      for (const segment of segments) {
+        if (await isLooped(spanText(segment))) {
+          return true;
+        }
+      }
+      return false;
+    };
+
+    const runLadder = async (looped: number[]): Promise<void> => {
+      let bad = looped;
+      for (const guard of guardLadder) {
+        if (bad.length === 0) {
+          return;
+        }
+        const retried = await decodePass(
+          bad.map((index) => audios[index]),
+          language,
+          guard,
+        );
+        const stillBad: number[] = [];
+        for (const [retryIndex, index] of bad.entries()) {
+          if (await hasLoopedSegment(retried[retryIndex])) {
+            stillBad.push(index);
+          } else {
+            outputs[index] = retried[retryIndex];
+          }
+        }
+        console.log(
+          `whisper ladder ${JSON.stringify(guard)}: rescued ${bad.length - stillBad.length}/${bad.length} chunk(s)`,
+        );
+        bad = stillBad;
+      }
+    };
+
+    const looped: number[] = [];
     for (const [index, result] of outputs.entries()) {
-      if (await isLooped(result.text ?? '')) {
+      if (await hasLoopedSegment(result)) {
         looped.push(index);
       }
     }
-    for (const temperature of fallbackTemperatures) {
-      if (looped.length === 0) {
-        break;
-      }
-      const retried = await decodePass(
-        looped.map((index) => audios[index]),
-        language,
-        ladderGuard(temperature),
-      );
-      const stillLooped: number[] = [];
-      for (const [retryIndex, index] of looped.entries()) {
-        outputs[index] = retried[retryIndex];
-        if (await isLooped(retried[retryIndex].text ?? '')) {
-          stillLooped.push(index);
-        }
-      }
-      const label = temperature > 0 ? `temp=${temperature}` : 'greedy+guard';
-      console.log(
-        `whisper ladder ${label}: rescued ${looped.length - stillLooped.length}/${looped.length} chunk(s)`,
-      );
-      looped = stillLooped;
-    }
+    await runLadder(looped);
 
     for (const [index, result] of outputs.entries()) {
       outputs[index] = dropCaptionSegments(result);

--- a/packages/ai/src/runtime/whisper/whisperSegments.ts
+++ b/packages/ai/src/runtime/whisper/whisperSegments.ts
@@ -1,3 +1,4 @@
+import { uniqueRatio } from '../../transcription/collapseRepair.js';
 import { type TranscriptionWord } from '../../transcription/types.js';
 
 export type WordChunk = { text: string; timestamp: [number, number | null] };
@@ -35,10 +36,12 @@ const compressionRatio = async (text: string): Promise<number> => {
   return bytes.length / compressed.byteLength;
 };
 
-const loopCompressionRatio = 2.4;
+const loopCompressionRatio = 3.5;
+const loopUniqueRatio = 0.35;
 
 export const isLooped = async (text: string): Promise<boolean> =>
-  (await compressionRatio(text)) > loopCompressionRatio;
+  (await compressionRatio(text)) > loopCompressionRatio &&
+  uniqueRatio(text) < loopUniqueRatio;
 
 type SegmentBounds = [number, number][];
 

--- a/packages/ai/src/transcription/collapseRepair.ts
+++ b/packages/ai/src/transcription/collapseRepair.ts
@@ -40,7 +40,7 @@ const normalizeTokens = (text: string): string[] =>
     .split(/\s+/)
     .filter(Boolean);
 
-const uniqueRatio = (text: string): number => {
+export const uniqueRatio = (text: string): number => {
   const tokens = normalizeTokens(text);
   if (tokens.length === 0) {
     return 1.0;


### PR DESCRIPTION
The guard measured compression over the text of a whole window, so a single stuck line hid behind the rest of it while dense singing tripped the threshold, and the retry sampled at rising temperature and kept its result whether or not it helped.

Measure per decoded segment with a threshold that also requires a low unique token ratio, retry greedily with a repetition guard, and keep the retry only when the loop is gone.