### PR TITLE
fix(ai): decode collapsed whisper windows without timestamps

### DIFF
--- a/packages/ai/src/runtime/whisper/whisperDecoder.ts
+++ b/packages/ai/src/runtime/whisper/whisperDecoder.ts
@@ -1,4 +1,8 @@
-import { splitBySegments, type WordChunk } from './whisperSegments.js';
+import {
+  spanText,
+  splitBySegments,
+  type WordChunk,
+} from './whisperSegments.js';
 
 const sampleRate = 16000;
 
@@ -64,6 +68,11 @@ export type WhisperDecoder = {
     audio: Float32Array,
     language: string,
     guard: DecodeGuard | undefined,
+  ) => Promise<DecodeResult>;
+
+  decodeAligned: (
+    audio: Float32Array,
+    language: string,
   ) => Promise<DecodeResult>;
 };
 
@@ -140,5 +149,47 @@ export const createWhisperDecoder = (
     };
   };
 
-  return { decodeTimestamped };
+  const decodeAligned = async (
+    audio: Float32Array,
+    language: string,
+  ): Promise<DecodeResult> => {
+    const inputs = await internals.processor(audio);
+    const output = await internals.model.generate({
+      inputs: inputs.input_features,
+      return_token_timestamps: true,
+      return_timestamps: false,
+      ...generateArgs(audio, language, undefined),
+    });
+
+    const [ids] = output.sequences.tolist();
+    const [times] = output.token_timestamps.tolist();
+
+    const chunks: WordChunk[] = [];
+    for (const [index, id] of ids.entries()) {
+      const piece = internals.tokenizer.decode([id], {
+        skip_special_tokens: true,
+      });
+      if (!piece) {
+        continue;
+      }
+      const startsWord = piece.startsWith(' ') || chunks.length === 0;
+      const time = times[index] ?? 0;
+      if (startsWord) {
+        chunks.push({ text: piece, timestamp: [time, time] });
+        continue;
+      }
+      const last = chunks[chunks.length - 1];
+      last.text += piece;
+      last.timestamp[1] = time;
+    }
+    for (const chunk of chunks) {
+      if ((chunk.timestamp[1] ?? 0) <= chunk.timestamp[0]) {
+        chunk.timestamp[1] = chunk.timestamp[0];
+      }
+    }
+
+    return { text: spanText(chunks), chunks, segments: [chunks] };
+  };
+
+  return { decodeTimestamped, decodeAligned };
 };

--- a/packages/ai/src/runtime/whisper/whisperRuntime.ts
+++ b/packages/ai/src/runtime/whisper/whisperRuntime.ts
@@ -13,7 +13,12 @@ import {
   type DecodeResult,
   type WhisperPipelineInternals,
 } from './whisperDecoder.js';
-import { extractWords, isLooped, spanText } from './whisperSegments.js';
+import {
+  countWords,
+  extractWords,
+  isLooped,
+  spanText,
+} from './whisperSegments.js';
 
 const sampleRate = 16000;
 
@@ -21,6 +26,10 @@ const guardLadder: DecodeGuard[] = [
   { no_repeat_ngram_size: 3 },
   { no_repeat_ngram_size: 3, repetition_penalty: 1.15 },
 ];
+
+const collapsedWordsPerSecond = 0.25;
+const collapsedMinSeconds = 12;
+const alignedWordsPerSecond = 0.8;
 
 type LoadProgress = {
   status?: string;
@@ -42,6 +51,11 @@ export type WhisperRuntime = {
     audios: Float32Array[],
     language: string,
   ) => Promise<TranscriptionWord[][]>;
+
+  transcribeAligned: (
+    audio: Float32Array,
+    language: string,
+  ) => Promise<TranscriptionWord[]>;
   release: () => Promise<void>;
 };
 
@@ -81,7 +95,7 @@ export const createWhisperRuntime = async (
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
   const internals = transcriber as unknown as WhisperPipelineInternals;
-  const { decodeTimestamped } = createWhisperDecoder(internals);
+  const { decodeTimestamped, decodeAligned } = createWhisperDecoder(internals);
   const generationConfig = internals.model.generation_config;
   const langToId = generationConfig.lang_to_id ?? {};
   const startToken = generationConfig.decoder_start_token_id ?? 50258;
@@ -137,6 +151,32 @@ export const createWhisperRuntime = async (
     const maxDuration = Math.max(...audios.map((a) => a.length / sampleRate));
 
     const outputs = await decodePass(audios, language, undefined);
+
+    const preferAligned = async (
+      result: DecodeResult,
+      audio: Float32Array,
+    ): Promise<DecodeResult> => {
+      const duration = audio.length / sampleRate;
+      const words = countWords(result.text);
+      const collapsed =
+        duration >= collapsedMinSeconds &&
+        words / duration < collapsedWordsPerSecond;
+      if (!collapsed && !isHallucination(result.text ?? '')) {
+        return result;
+      }
+      const aligned = await decodeAligned(audio, language);
+      const alignedWords = countWords(aligned.text);
+      const better =
+        alignedWords > words &&
+        alignedWords / duration >= alignedWordsPerSecond &&
+        !isHallucination(aligned.text ?? '') &&
+        !(await isLooped(aligned.text ?? ''));
+      console.log(
+        `whisper aligned decode: ${words}w -> ${alignedWords}w, ` +
+          `${better ? 'taken' : 'kept timestamped'}`,
+      );
+      return better ? aligned : result;
+    };
 
     const dropCaptionSegments = (result: DecodeResult): DecodeResult => {
       const segments = result.segments ?? [];
@@ -206,7 +246,9 @@ export const createWhisperRuntime = async (
     await runLadder(looped);
 
     for (const [index, result] of outputs.entries()) {
-      outputs[index] = dropCaptionSegments(result);
+      outputs[index] = dropCaptionSegments(
+        await preferAligned(result, audios[index]),
+      );
     }
 
     console.log(
@@ -215,9 +257,17 @@ export const createWhisperRuntime = async (
     return outputs.map((result) => extractWords(result.chunks ?? []));
   };
 
+  const transcribeAligned = async (
+    audio: Float32Array,
+    language: string,
+  ): Promise<TranscriptionWord[]> => {
+    const aligned = await decodeAligned(audio, language);
+    return extractWords(aligned.chunks ?? []);
+  };
+
   const release = async (): Promise<void> => {
     await transcriber.dispose();
   };
 
-  return { detectLanguage, transcribeBatch, release };
+  return { detectLanguage, transcribeBatch, transcribeAligned, release };
 };

--- a/packages/ai/src/runtime/whisper/whisperSegments.ts
+++ b/packages/ai/src/runtime/whisper/whisperSegments.ts
@@ -24,6 +24,9 @@ export const spanText = (chunks: WordChunk[]): string =>
     .join('')
     .trim();
 
+export const countWords = (text: string | undefined): number =>
+  (text ?? '').trim().split(/\s+/).filter(Boolean).length;
+
 const compressionRatio = async (text: string): Promise<number> => {
   const bytes = new TextEncoder().encode(text);
   if (bytes.length < 48) {

--- a/packages/ai/src/service/browserTranscribe.ts
+++ b/packages/ai/src/service/browserTranscribe.ts
@@ -38,6 +38,7 @@ export const registerTranscribeApi = (): void => {
           language: request.language,
           detectLanguage: runtime.detectLanguage,
           transcribeBatch: runtime.transcribeBatch,
+          transcribeAligned: runtime.transcribeAligned,
 
           onProgress: async (fraction) => reportProgress(0.4 + fraction * 0.6),
         });

--- a/packages/ai/src/transcription/transcribePipeline.ts
+++ b/packages/ai/src/transcription/transcribePipeline.ts
@@ -88,9 +88,16 @@ export type TranscribeBatch = (
   language: string,
 ) => Promise<TranscriptionWord[][]>;
 
+export type TranscribeAligned = (
+  audio: Float32Array,
+  language: string,
+) => Promise<TranscriptionWord[]>;
+
 export type RunTranscriptionOptions = {
   audio: Float32Array;
   transcribeBatch: TranscribeBatch;
+
+  transcribeAligned?: TranscribeAligned;
 
   language?: string;
   detectLanguage?: DetectLanguage;
@@ -151,7 +158,9 @@ export const runTranscription = async (
     wordsPerChunk,
     mapping,
     transcribeSlice: async (slice) =>
-      (await transcribeBatch([slice], language))[0] ?? [],
+      options.transcribeAligned
+        ? await options.transcribeAligned(slice, language)
+        : ((await transcribeBatch([slice], language))[0] ?? []),
   });
   const words = repaired.flat().sort((a, b) => a.start - b.start);
 


### PR DESCRIPTION
Asking for word timestamps inside generation derails the decoder on hard windows: it emits a caption or a couple of words where the same buffer decodes into a full line without them. The same mechanism made window repair reject both halves it re-decoded.

Re-decode such a window with timestamps off, aligning words from token times, and take the result only when it is denser and neither a caption nor a loop; let the pipeline use that decode for repair halves too.