### PR TITLE
fix(ai): collapse degenerate repeats in whisper words

### DIFF
--- a/packages/ai/src/runtime/whisper/whisperSegments.ts
+++ b/packages/ai/src/runtime/whisper/whisperSegments.ts
@@ -1,12 +1,17 @@
 import { uniqueRatio } from '../../transcription/collapseRepair.js';
 import { type TranscriptionWord } from '../../transcription/types.js';
 
+const degenerateRepeat = /(.{1,3}?)\1{3,}/gu;
+
+const collapseRepeats = (text: string): string =>
+  text.replace(degenerateRepeat, '$1$1');
+
 export type WordChunk = { text: string; timestamp: [number, number | null] };
 
 export const extractWords = (chunks: WordChunk[]): TranscriptionWord[] => {
   const words: TranscriptionWord[] = [];
   for (const chunk of chunks) {
-    const text = chunk.text.trim();
+    const text = collapseRepeats(chunk.text.trim());
     if (!text) {
       continue;
     }


### PR DESCRIPTION
A stuck decoder can emit a single token run with no spaces inside it, which the loop guard does not see: the text compresses hard but its unique token ratio stays high because it is one word. Collapse such runs to two repetitions when words are built.