### PR TITLE
refactor(db): initialize a database through one function

### DIFF
--- a/packages/backend-db/src/instance.ts
+++ b/packages/backend-db/src/instance.ts
@@ -25,9 +25,7 @@ export const createDatabase = async (
     enableForeignKeyConstraints: true,
     timeout: 5000,
   });
-  await Promise.resolve(database.exec('PRAGMA foreign_keys = ON;'));
-  await Promise.resolve(database.exec('PRAGMA journal_mode = WAL;'));
-  return database;
+  return await Promise.resolve(database);
 };
 
 export const createInstance = async (databasePath: string) => {

--- a/packages/backend-db/src/migrations/index.ts
+++ b/packages/backend-db/src/migrations/index.ts
@@ -1,4 +1,5 @@
 import { type DatabaseSync } from 'node:sqlite';
+import { createDatabase } from '../instance.js';
 
 const createProject = `
   CREATE TABLE IF NOT EXISTS Project (
@@ -129,8 +130,20 @@ const creationStatements = [
   createRecording,
 ] as const;
 
-export const createTables = async (database: DatabaseSync): Promise<void> => {
+const createTables = async (database: DatabaseSync): Promise<void> => {
   for (const statement of creationStatements) {
     await Promise.resolve(database.exec(statement));
+  }
+};
+
+export const initDatabase = async (databasePath: string): Promise<void> => {
+  const database = await createDatabase(databasePath);
+  try {
+    database.exec('PRAGMA journal_mode = WAL;');
+    await createTables(database);
+  } finally {
+    if (database.isOpen) {
+      database.close();
+    }
   }
 };

--- a/packages/backend/scripts/init.ts
+++ b/packages/backend/scripts/init.ts
@@ -1,17 +1,5 @@
-import { DB } from '@musetric/backend-db';
-import { createTables } from '@musetric/backend-db/migrations';
+import { initDatabase } from '@musetric/backend-db/migrations';
 import { envs } from '../src/common/envs.js';
 
-const initDB = async () => {
-  const database = await DB.createDatabase(envs.databasePath);
-  try {
-    await createTables(database);
-    console.log('Database schema initialized');
-  } finally {
-    if (database.isOpen) {
-      database.close();
-    }
-  }
-};
-
-await initDB();
+await initDatabase(envs.databasePath);
+console.log('Database schema initialized');

--- a/packages/desktop/src/backend.ts
+++ b/packages/desktop/src/backend.ts
@@ -1,8 +1,7 @@
 import { join } from 'node:path';
 import { type GpuPageHostFactory } from '@musetric/ai/node';
 import { type AppConfig } from '@musetric/backend-core/config';
-import { DB } from '@musetric/backend-db';
-import { createTables } from '@musetric/backend-db/migrations';
+import { initDatabase } from '@musetric/backend-db/migrations';
 import { createStoragePaths } from '@musetric/utils/node';
 import { app } from 'electron';
 
@@ -21,17 +20,6 @@ const createDesktopConfig = (): AppConfig => {
   };
 };
 
-const initDatabase = async (config: AppConfig): Promise<void> => {
-  const database = await DB.createDatabase(config.databasePath);
-  try {
-    await createTables(database);
-  } finally {
-    if (database.isOpen) {
-      database.close();
-    }
-  }
-};
-
 export type DesktopBackend = {
   url: string;
   close: () => Promise<void>;
@@ -45,7 +33,7 @@ export const startBackend = async (
   options: StartBackendOptions,
 ): Promise<DesktopBackend> => {
   const config = createDesktopConfig();
-  await initDatabase(config);
+  await initDatabase(config.databasePath);
   const { createServerApp } = await import('@musetric/backend-core');
   const backend = await createServerApp(config, {
     gpuPageHostFactory: options.gpuPageHostFactory,


### PR DESCRIPTION
Both hosts opened the database, created the schema and closed the connection themselves. initDatabase takes the path and does all of it, and createTables is no longer exported.

The journal mode moved there too: it is stored in the database file and only ever needs setting on a new one, so re-applying it on every connection open was pointless. PRAGMA foreign_keys is dropped, since opening the database already asks for enableForeignKeyConstraints.