### PR TITLE
fix(desktop): prevent concurrent storage access

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -13,6 +13,7 @@ const startServer = async () => {
     databasePath: envs.databasePath,
     modelsPath: envs.modelsPath,
     browserBundlePath: envs.browserBundlePath,
+    lockPath: envs.lockPath,
     https: await getHttps(),
   };
   const app = await createServerApp(config);

--- a/packages/desktop/src/backend.ts
+++ b/packages/desktop/src/backend.ts
@@ -4,6 +4,7 @@ import { type AppConfig } from '@musetric/backend-core/config';
 import { initDatabase } from '@musetric/backend-db/migrations';
 import { createStoragePaths } from '@musetric/utils/node';
 import { app } from 'electron';
+import { acquireStorageLock } from './storageLock.js';
 
 const requestedPort = Number(process.env.MUSETRIC_DESKTOP_PORT ?? 0);
 
@@ -31,25 +32,38 @@ export type StartBackendOptions = {
 
 export const startBackend = async (
   options: StartBackendOptions,
-): Promise<DesktopBackend> => {
+): Promise<DesktopBackend | undefined> => {
   const config = createDesktopConfig();
-  await initDatabase(config.databasePath);
-  const { createServerApp } = await import('@musetric/backend-core');
-  const backend = await createServerApp(config, {
-    gpuPageHostFactory: options.gpuPageHostFactory,
-  });
-  await backend.listen({
-    port: requestedPort,
-    host: '127.0.0.1',
-  });
-  const address = backend.server.address();
-  if (!address || typeof address === 'string') {
-    throw new Error('desktop backend failed to bind a local HTTP port');
+  const storageLock = acquireStorageLock(config.lockPath);
+  if (!storageLock) {
+    return undefined;
   }
-  return {
-    url: `http://127.0.0.1:${address.port}`,
-    close: async () => {
-      await backend.close();
-    },
-  };
+  try {
+    await initDatabase(config.databasePath);
+    const { createServerApp } = await import('@musetric/backend-core');
+    const backend = await createServerApp(config, {
+      gpuPageHostFactory: options.gpuPageHostFactory,
+    });
+    await backend.listen({
+      port: requestedPort,
+      host: '127.0.0.1',
+    });
+    const address = backend.server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('desktop backend failed to bind a local HTTP port');
+    }
+    return {
+      url: `http://127.0.0.1:${address.port}`,
+      close: async () => {
+        try {
+          await backend.close();
+        } finally {
+          storageLock.release();
+        }
+      },
+    };
+  } catch (error) {
+    storageLock.release();
+    throw error;
+  }
 };

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,16 +1,21 @@
-import { app, BrowserWindow } from 'electron';
+import { app, BrowserWindow, dialog } from 'electron';
 import { type DesktopBackend, startBackend } from './backend.js';
 import { createElectronGpuHost } from './electronGpuHost.js';
 
 const main = (): void => {
+  if (!app.requestSingleInstanceLock()) {
+    app.exit(0);
+    return;
+  }
+
   app.commandLine.appendSwitch('enable-unsafe-webgpu');
   app.commandLine.appendSwitch('disable-webgpu-blocklist');
   app.commandLine.appendSwitch('ignore-gpu-blocklist');
 
   let backend: DesktopBackend | undefined = undefined;
   let stopBackendPromise: Promise<void> | undefined = undefined;
-  let mainWindow: BrowserWindow | undefined = undefined;
   let isQuitting = false;
+  const mainWindows = new Set<BrowserWindow>();
 
   const isMac = process.platform === 'darwin';
 
@@ -55,36 +60,56 @@ const main = (): void => {
         nodeIntegration: false,
       },
     });
-    mainWindow = window;
+    mainWindows.add(window);
     window.on('closed', () => {
-      mainWindow = undefined;
-      if (!isMac) {
+      mainWindows.delete(window);
+      if (!isMac && mainWindows.size === 0) {
         void shutdown();
       }
     });
     await window.loadURL(url);
   };
 
+  const openMainWindow = (): void => {
+    if (isQuitting || backend === undefined) {
+      return;
+    }
+    void createWindow(backend.url);
+  };
+
   const start = async (): Promise<void> => {
     const activeBackend = await startBackend({
       gpuPageHostFactory: createElectronGpuHost(),
     });
+    if (activeBackend === undefined) {
+      dialog.showErrorBox(
+        'Musetric is already running',
+        'Another Musetric process is using the same data folder. Close it and try again.',
+      );
+      await shutdown();
+      return;
+    }
     backend = activeBackend;
     await createWindow(activeBackend.url);
-    app.on('activate', () => {
-      if (mainWindow === undefined) {
-        void createWindow(activeBackend.url);
-      }
-    });
   };
 
-  void app
+  const startPromise = app
     .whenReady()
     .then(start)
     .catch((error: unknown) => {
       console.error(error);
       void shutdown();
     });
+
+  app.on('second-instance', () => {
+    void startPromise.then(openMainWindow);
+  });
+
+  app.on('activate', () => {
+    if (mainWindows.size === 0) {
+      openMainWindow();
+    }
+  });
 
   app.on('window-all-closed', () => {
     if (!isMac) {

--- a/packages/desktop/src/storageLock.ts
+++ b/packages/desktop/src/storageLock.ts
@@ -1,0 +1,35 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+const sqliteBusyErrorCode = 5;
+
+const isBusyError = (error: unknown): boolean =>
+  error instanceof Error &&
+  'errcode' in error &&
+  error.errcode === sqliteBusyErrorCode;
+
+export type StorageLock = {
+  release: () => void;
+};
+
+export const acquireStorageLock = (
+  lockPath: string,
+): StorageLock | undefined => {
+  mkdirSync(dirname(lockPath), { recursive: true });
+  const database = new DatabaseSync(lockPath, { timeout: 0 });
+  try {
+    database.exec('BEGIN EXCLUSIVE');
+  } catch (error) {
+    database.close();
+    if (isBusyError(error)) {
+      return undefined;
+    }
+    throw error;
+  }
+  return {
+    release: () => {
+      database.close();
+    },
+  };
+};

--- a/packages/utils/src/storagePaths.node.ts
+++ b/packages/utils/src/storagePaths.node.ts
@@ -6,6 +6,7 @@ export type StoragePaths = {
   databasePath: string;
   modelsPath: string;
   browserBundlePath: string;
+  lockPath: string;
 };
 
 export const createStoragePaths = (rootPath: string): StoragePaths => ({
@@ -14,4 +15,5 @@ export const createStoragePaths = (rootPath: string): StoragePaths => ({
   databasePath: join(rootPath, 'storage/db/app.db'),
   modelsPath: join(rootPath, 'storage/models'),
   browserBundlePath: join(rootPath, 'dist-browser'),
+  lockPath: join(rootPath, 'storage/backend.lock'),
 });


### PR DESCRIPTION
Ensure the desktop app runs only once per user data directory.

Use an SQLite exclusive lock around backend startup and database initialization, release it after shutdown or a failed startup, and route secondary Electron launches to the primary process.