### PR TITLE
fix(desktop): relaunch when started during shutdown

### DIFF
--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -15,6 +15,7 @@ const main = (): void => {
   let backend: DesktopBackend | undefined = undefined;
   let stopBackendPromise: Promise<void> | undefined = undefined;
   let isQuitting = false;
+  let isRelaunchRequested = false;
   const mainWindows = new Set<BrowserWindow>();
 
   const isMac = process.platform === 'darwin';
@@ -77,6 +78,14 @@ const main = (): void => {
     void createWindow(backend.url);
   };
 
+  const requestRelaunch = (): void => {
+    if (isRelaunchRequested) {
+      return;
+    }
+    isRelaunchRequested = true;
+    app.relaunch();
+  };
+
   const start = async (): Promise<void> => {
     const activeBackend = await startBackend({
       gpuPageHostFactory: createElectronGpuHost(),
@@ -102,7 +111,13 @@ const main = (): void => {
     });
 
   app.on('second-instance', () => {
-    void startPromise.then(openMainWindow);
+    void startPromise.then(() => {
+      if (isQuitting) {
+        requestRelaunch();
+        return;
+      }
+      openMainWindow();
+    });
   });
 
   app.on('activate', () => {


### PR DESCRIPTION
A closing process holds the single instance lock until it exits, so a launch at that moment exited on its own and the second-instance handler skipped the window. Ask Electron to start a fresh process instead.