### PR TITLE
refactor(desktop): own the storage lock path

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -13,7 +13,6 @@ const startServer = async () => {
     databasePath: envs.databasePath,
     modelsPath: envs.modelsPath,
     browserBundlePath: envs.browserBundlePath,
-    lockPath: envs.lockPath,
     https: await getHttps(),
   };
   const app = await createServerApp(config);

--- a/packages/desktop/src/backend.ts
+++ b/packages/desktop/src/backend.ts
@@ -8,6 +8,9 @@ import { acquireStorageLock } from './storageLock.js';
 
 const requestedPort = Number(process.env.MUSETRIC_DESKTOP_PORT ?? 0);
 
+const createLockPath = (): string =>
+  join(app.getPath('userData'), 'storage/backend.lock');
+
 const createDesktopConfig = (): AppConfig => {
   const resourcePaths = createStoragePaths(
     join(app.getAppPath(), '../backend'),
@@ -34,7 +37,7 @@ export const startBackend = async (
   options: StartBackendOptions,
 ): Promise<DesktopBackend | undefined> => {
   const config = createDesktopConfig();
-  const storageLock = acquireStorageLock(config.lockPath);
+  const storageLock = acquireStorageLock(createLockPath());
   if (!storageLock) {
     return undefined;
   }

--- a/packages/utils/src/storagePaths.node.ts
+++ b/packages/utils/src/storagePaths.node.ts
@@ -6,7 +6,6 @@ export type StoragePaths = {
   databasePath: string;
   modelsPath: string;
   browserBundlePath: string;
-  lockPath: string;
 };
 
 export const createStoragePaths = (rootPath: string): StoragePaths => ({
@@ -15,5 +14,4 @@ export const createStoragePaths = (rootPath: string): StoragePaths => ({
   databasePath: join(rootPath, 'storage/db/app.db'),
   modelsPath: join(rootPath, 'storage/models'),
   browserBundlePath: join(rootPath, 'dist-browser'),
-  lockPath: join(rootPath, 'storage/backend.lock'),
 });


### PR DESCRIPTION
Only the desktop shell acquires the lock, but lockPath sat in the shared StoragePaths, so the server passed a field nobody read and the config looked like backend-core enforced single access. Build the path where it is used instead.