### PR TITLE
fix(desktop): name the data folder after the product

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@musetric/desktop",
+  "productName": "Musetric",
   "version": "0.1.0",
   "description": "Musetric — audio separation, transcription and analysis desktop app",
   "author": "Musetric <musetric@gmail.com>",


### PR DESCRIPTION
Electron reads the app name from the package.json inside the asar and falls back to the package name, so the npm scope became a vendor folder in the user profile: @musetric/desktop. The productName in the builder config never reaches the runtime.