### PR TITLE
fix(desktop): store data in the platform data directory

### DIFF
--- a/packages/desktop/src/appPaths.ts
+++ b/packages/desktop/src/appPaths.ts
@@ -1,0 +1,17 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { app } from 'electron';
+
+const createDataRootPath = (): string => {
+  if (process.platform === 'win32') {
+    return process.env.LOCALAPPDATA ?? join(homedir(), 'AppData', 'Local');
+  }
+  if (process.platform === 'linux') {
+    return process.env.XDG_DATA_HOME ?? join(homedir(), '.local', 'share');
+  }
+  return app.getPath('appData');
+};
+
+export const applyAppPaths = (): void => {
+  app.setPath('userData', join(createDataRootPath(), app.getName()));
+};

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,8 +1,11 @@
 import { app, BrowserWindow, dialog } from 'electron';
+import { applyAppPaths } from './appPaths.js';
 import { type DesktopBackend, startBackend } from './backend.js';
 import { createElectronGpuHost } from './electronGpuHost.js';
 
 const main = (): void => {
+  applyAppPaths();
+
   if (!app.requestSingleInstanceLock()) {
     app.exit(0);
     return;


### PR DESCRIPTION
The database, the blobs and two gigabytes of models were written to APPDATA, which roams with the user profile in a domain and puts sqlite on a network share. On Linux the Electron default is the config directory, which is not where gigabytes belong either.

Each platform now picks its own data root: LOCALAPPDATA on Windows, the XDG data directory on Linux, Application Support on macOS. The paths are applied before the single instance lock so that the lock follows the folder it protects.