### PR TITLE
fix(desktop): give the dev build its own data folder

### DIFF
--- a/packages/desktop/src/appPaths.ts
+++ b/packages/desktop/src/appPaths.ts
@@ -12,6 +12,12 @@ const createDataRootPath = (): string => {
   return app.getPath('appData');
 };
 
+const createDataDirectoryName = (): string =>
+  app.isPackaged ? app.getName() : `${app.getName()} Dev`;
+
 export const applyAppPaths = (): void => {
-  app.setPath('userData', join(createDataRootPath(), app.getName()));
+  app.setPath(
+    'userData',
+    join(createDataRootPath(), createDataDirectoryName()),
+  );
 };


### PR DESCRIPTION
Both builds resolved the same folder, so a running dev instance held the single instance lock and the storage lock of the installed app: starting the installed app then did nothing at all, without a window or an error.

The dev build now works in a folder of its own and downloads its own copy of the models.