### PR TITLE
refactor(desktop): keep the chromium profile in a subfolder

### DIFF
--- a/packages/desktop/src/appPaths.ts
+++ b/packages/desktop/src/appPaths.ts
@@ -16,8 +16,7 @@ const createDataDirectoryName = (): string =>
   app.isPackaged ? app.getName() : `${app.getName()} Dev`;
 
 export const applyAppPaths = (): void => {
-  app.setPath(
-    'userData',
-    join(createDataRootPath(), createDataDirectoryName()),
-  );
+  const userDataPath = join(createDataRootPath(), createDataDirectoryName());
+  app.setPath('userData', userDataPath);
+  app.setPath('sessionData', join(userDataPath, 'session'));
 };


### PR DESCRIPTION
The chromium profile shared a folder with the database, the blobs and the models, so caches that may be deleted at any time sat next to data that must not be lost. Moving the session data one level down makes a backup of the storage folder a meaningful operation.