### PR TITLE
feat(desktop): ask the uninstaller about user data

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -11,6 +11,7 @@ win:
   icon: assets/icon.png
   target: nsis
 nsis:
+  include: installer.nsh
   oneClick: false
   perMachine: false
   allowToChangeInstallationDirectory: true

--- a/packages/desktop/installer.nsh
+++ b/packages/desktop/installer.nsh
@@ -1,0 +1,28 @@
+!macro customUnInstall
+  ${ifNot} ${isUpdated}
+    StrCpy $R2 "0"
+
+    ClearErrors
+    ${GetParameters} $R0
+    ${GetOptions} $R0 "--delete-app-data" $R1
+    ${ifNot} ${Errors}
+      StrCpy $R2 "1"
+    ${elseIfNot} ${Silent}
+      MessageBox MB_YESNO|MB_ICONQUESTION "Delete your ${PRODUCT_NAME} data?$\r$\n$\r$\nProjects, recordings and about 2 GB of downloaded models will be removed. Keeping them lets a future install continue where you left off." /SD IDNO IDNO +2
+      StrCpy $R2 "1"
+    ${endIf}
+
+    ${if} $R2 == "1"
+      ${if} $installMode == "all"
+        SetShellVarContext current
+      ${endIf}
+      RMDir /r "$LOCALAPPDATA\${PRODUCT_FILENAME}\storage"
+      RMDir /r "$LOCALAPPDATA\${PRODUCT_FILENAME}\session"
+      Delete "$LOCALAPPDATA\${PRODUCT_FILENAME}\lockfile"
+      RMDir "$LOCALAPPDATA\${PRODUCT_FILENAME}"
+      ${if} $installMode == "all"
+        SetShellVarContext all
+      ${endIf}
+    ${endIf}
+  ${endIf}
+!macroend


### PR DESCRIPTION
Uninstalling left the database, the recordings and two gigabytes of models in the profile forever, and the electron-builder option for this only clears the roaming folder, which is no longer where the data lives.

The uninstaller now asks, keeps the data unless the answer is yes and removes only the folders the app owns, so a cache another tool keeps under the same name survives. Silent runs keep the data unless they pass --delete-app-data, and an update never asks.