### PR TITLE
fix(desktop): ship the trademark policy with the app

### DIFF
--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -44,6 +44,8 @@ extraResources:
     to: license.md
   - from: ../../thirdPartyNotices.md
     to: thirdPartyNotices.md
+  - from: ../../trademark.md
+    to: trademark.md
 asarUnpack:
   - node_modules/**/*.node
   - node_modules/@musetric/ffmpeg/resources/**


### PR DESCRIPTION
The package carried license.md and thirdPartyNotices.md but not trademark.md, so the brand policy was missing from installed builds.