### PR TITLE
feat(desktop): release the version declared in package.json

### DIFF
--- a/.github/workflows/desktopBuild.yml
+++ b/.github/workflows/desktopBuild.yml
@@ -2,9 +2,57 @@ name: Desktop Build
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: dev builds artifacts only, release publishes packages/desktop/package.json version
+        type: choice
+        options:
+          - dev
+          - release
+        default: dev
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+      - id: version
+        env:
+          MODE: ${{ inputs.mode }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          declared=$(node -p "require('./packages/desktop/package.json').version")
+          if [ "$MODE" = dev ]; then
+            echo "version=$declared-dev.g${GITHUB_SHA:0:7}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if ! printf '%s' "$declared" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z][0-9A-Za-z.-]*)?$'; then
+            echo "not a release version: $declared" >&2
+            exit 1
+          fi
+          case "$declared" in
+            *-dev.*)
+              echo "dev builds cannot be released: $declared" >&2
+              exit 1
+              ;;
+          esac
+          published=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""' | sed 's/^v//')
+          if [ -n "$published" ] && [ "$published" = "$declared" ]; then
+            echo "v$declared is already released" >&2
+            exit 1
+          fi
+          # Compared without the prerelease suffix: sort -V orders 0.2.0-beta.1
+          # above 0.2.0, so a release right after its own beta would be rejected.
+          if [ -n "$published" ] && [ "$(printf '%s\n%s\n' "${published%%-*}" "${declared%%-*}" | sort -V | tail -1)" != "${declared%%-*}" ]; then
+            echo "$declared is older than the published $published" >&2
+            exit 1
+          fi
+          echo "version=$declared" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: prepare
     strategy:
       fail-fast: false
       matrix:
@@ -48,13 +96,13 @@ jobs:
           MUSETRIC_SKIP_FFMPEG_FETCH: true
           ONNXRUNTIME_NODE_INSTALL: skip
       - run: yarn build:desktop
-      - run: yarn workspace @musetric/desktop pack:installer --${{ matrix.platform }} --${{ matrix.arch }}
+      - run: yarn workspace @musetric/desktop pack:installer --${{ matrix.platform }} --${{ matrix.arch }} -c.extraMetadata.version=${{ needs.prepare.outputs.version }}
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
       - uses: actions/upload-artifact@v7
         with:
           name: musetric-desktop-${{ runner.os }}-${{ matrix.arch }}
-          if-no-files-found: ignore
+          if-no-files-found: error
           retention-days: 14
           compression-level: 0
           path: |
@@ -62,3 +110,27 @@ jobs:
             packages/desktop/build/*.exe.blockmap
             packages/desktop/build/*.dmg
             packages/desktop/build/*.AppImage
+
+  release:
+    if: inputs.mode == 'release'
+    needs:
+      - prepare
+      - build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v6
+        with:
+          path: artifacts
+          merge-multiple: true
+      - env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          gh release create "v$VERSION" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$GITHUB_SHA" \
+            --title "Musetric $VERSION" \
+            --generate-notes \
+            artifacts/*

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -1,6 +1,4 @@
 appId: com.musetric.desktop
-productName: Musetric
-executableName: Musetric
 electronVersion: 43.1.1
 directories:
   output: build
@@ -17,12 +15,12 @@ nsis:
   allowToChangeInstallationDirectory: true
   createDesktopShortcut: true
   createStartMenuShortcut: true
-  shortcutName: Musetric
   license: license.txt
 mac:
   target: dmg
   category: public.app-category.music
 linux:
+  executableName: musetric
   target: AppImage
   category: Audio
 files:

--- a/packages/desktop/installer.nsh
+++ b/packages/desktop/installer.nsh
@@ -16,10 +16,12 @@
       ${if} $installMode == "all"
         SetShellVarContext current
       ${endIf}
-      RMDir /r "$LOCALAPPDATA\${PRODUCT_FILENAME}\storage"
-      RMDir /r "$LOCALAPPDATA\${PRODUCT_FILENAME}\session"
-      Delete "$LOCALAPPDATA\${PRODUCT_FILENAME}\lockfile"
-      RMDir "$LOCALAPPDATA\${PRODUCT_FILENAME}"
+      ; PRODUCT_NAME, not PRODUCT_FILENAME: the app derives its data folder
+      ; from app.getName(), which is productName rather than executableName.
+      RMDir /r "$LOCALAPPDATA\${PRODUCT_NAME}\storage"
+      RMDir /r "$LOCALAPPDATA\${PRODUCT_NAME}\session"
+      Delete "$LOCALAPPDATA\${PRODUCT_NAME}\lockfile"
+      RMDir "$LOCALAPPDATA\${PRODUCT_NAME}"
       ${if} $installMode == "all"
         SetShellVarContext all
       ${endIf}

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -5,6 +5,7 @@
   "description": "Musetric — audio separation, transcription and analysis desktop app",
   "author": "Musetric <musetric@gmail.com>",
   "license": "MIT",
+  "repository": "github:musetric/musetric",
   "private": true,
   "type": "module",
   "main": "dist/main.js",


### PR DESCRIPTION
The desktop build workflow now takes a mode. In dev it builds artifacts versioned `<package.json>-dev.g<sha>`; in release it builds exactly the declared version and publishes a GitHub release, which creates the tag. The version reaches the build through extraMetadata, so the artifact name, app.getVersion() and the packaged manifest all agree.

A release is refused before building when the version is malformed, is a dev build, is already published or is older than the published one.

The product name now lives only in package.json. Windows and macOS name the executable after it, and only Linux needs an explicit name because its default comes from the scoped package name. The uninstaller deletes user data through PRODUCT_NAME, matching app.getName(); with PRODUCT_FILENAME a rename would have silently deleted nothing.