### PR TITLE
feat(desktop): write fatal failures to a log file

### DIFF
--- a/.github/workflows/desktopBuild.yml
+++ b/.github/workflows/desktopBuild.yml
@@ -43,8 +43,6 @@ jobs:
             echo "v$declared is already released" >&2
             exit 1
           fi
-          # Compared without the prerelease suffix: sort -V orders 0.2.0-beta.1
-          # above 0.2.0, so a release right after its own beta would be rejected.
           if [ -n "$published" ] && [ "$(printf '%s\n%s\n' "${published%%-*}" "${declared%%-*}" | sort -V | tail -1)" != "${declared%%-*}" ]; then
             echo "$declared is older than the published $published" >&2
             exit 1

--- a/packages/backend-core/src/app.ts
+++ b/packages/backend-core/src/app.ts
@@ -39,7 +39,7 @@ export const createServerApp = async (
   options: CreateServerAppOptions = {},
 ): Promise<FastifyInstance> => {
   const app: FastifyInstance = fastify({
-    logger: createLoggerOptions(config.logLevel),
+    logger: createLoggerOptions(config.logLevel, config.logDestination),
     logController: new LogController({ disableRequestLogging }),
     // eslint-disable-next-line musetric/no-null-literal
     https: config.https ?? null,

--- a/packages/backend-core/src/common/config.ts
+++ b/packages/backend-core/src/common/config.ts
@@ -1,10 +1,12 @@
 import { type ServerOptions } from 'node:https';
 import { type LogLevel } from '@musetric/utils';
 import { type StoragePaths } from '@musetric/utils/node';
+import { type DestinationStream } from 'pino';
 
 export type AppConfig = StoragePaths & {
   version: string;
   logLevel: LogLevel;
+  logDestination?: DestinationStream;
   https?: ServerOptions;
 };
 

--- a/packages/backend-core/src/services/logger.ts
+++ b/packages/backend-core/src/services/logger.ts
@@ -1,20 +1,27 @@
 import { type LogLevel } from '@musetric/utils';
 import { type FastifyLoggerOptions } from 'fastify';
-import { type LoggerOptions, stdSerializers } from 'pino';
+import {
+  type DestinationStream,
+  type LoggerOptions,
+  stdSerializers,
+} from 'pino';
 import PinoPretty from 'pino-pretty';
 
 export const createLoggerOptions = (
   logLevel: LogLevel,
+  logDestination?: DestinationStream,
 ): FastifyLoggerOptions & LoggerOptions => ({
   serializers: {
     error: stdSerializers.err,
     err: stdSerializers.err,
   },
   errorKey: 'error',
-  stream: PinoPretty({
-    colorize: true,
-    translateTime: 'HH:MM:ss.l',
-    ignore: 'pid,hostname',
-  }),
+  stream:
+    logDestination ??
+    PinoPretty({
+      colorize: true,
+      translateTime: 'HH:MM:ss.l',
+      ignore: 'pid,hostname',
+    }),
   level: logLevel,
 });

--- a/packages/desktop/installer.nsh
+++ b/packages/desktop/installer.nsh
@@ -16,8 +16,6 @@
       ${if} $installMode == "all"
         SetShellVarContext current
       ${endIf}
-      ; PRODUCT_NAME, not PRODUCT_FILENAME: the app derives its data folder
-      ; from app.getName(), which is productName rather than executableName.
       RMDir /r "$LOCALAPPDATA\${PRODUCT_NAME}\storage"
       RMDir /r "$LOCALAPPDATA\${PRODUCT_NAME}\session"
       Delete "$LOCALAPPDATA\${PRODUCT_NAME}\lockfile"

--- a/packages/desktop/src/backend.ts
+++ b/packages/desktop/src/backend.ts
@@ -4,12 +4,13 @@ import { type AppConfig } from '@musetric/backend-core/config';
 import { initDatabase } from '@musetric/backend-db/migrations';
 import { createStoragePaths } from '@musetric/utils/node';
 import { app } from 'electron';
+import { type DestinationStream } from 'pino';
 import { acquireStorageLock } from './storageLock.js';
 
 const createLockPath = (): string =>
   join(app.getPath('userData'), 'storage/backend.lock');
 
-const createDesktopConfig = (): AppConfig => {
+const createDesktopConfig = (logDestination: DestinationStream): AppConfig => {
   const resourcePaths = createStoragePaths(
     join(app.getAppPath(), '../backend'),
   );
@@ -17,6 +18,7 @@ const createDesktopConfig = (): AppConfig => {
     ...createStoragePaths(app.getPath('userData')),
     version: app.getVersion(),
     logLevel: 'info',
+    logDestination,
     publicPath: resourcePaths.publicPath,
     browserBundlePath: resourcePaths.browserBundlePath,
   };
@@ -29,12 +31,13 @@ export type DesktopBackend = {
 
 export type StartBackendOptions = {
   gpuPageHostFactory: GpuPageHostFactory;
+  logDestination: DestinationStream;
 };
 
 export const startBackend = async (
   options: StartBackendOptions,
 ): Promise<DesktopBackend | undefined> => {
-  const config = createDesktopConfig();
+  const config = createDesktopConfig(options.logDestination);
   const storageLock = acquireStorageLock(createLockPath());
   if (!storageLock) {
     return undefined;

--- a/packages/desktop/src/logging.ts
+++ b/packages/desktop/src/logging.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { app, dialog } from 'electron';
+import {
+  destination,
+  type DestinationStream,
+  type Logger,
+  pino,
+  stdSerializers,
+} from 'pino';
+
+const keptRunCount = 20;
+const logExtension = '.log';
+
+const createRunFileName = (): string =>
+  `${new Date().toISOString().replaceAll(':', '-')}${logExtension}`;
+
+const pruneRuns = (logsPath: string): void => {
+  const runs = readdirSync(logsPath)
+    .filter((name) => name.endsWith(logExtension))
+    .sort((left, right) => left.localeCompare(right));
+  for (const name of runs.slice(0, runs.length - keptRunCount + 1)) {
+    rmSync(join(logsPath, name), { force: true });
+  }
+};
+
+export type DesktopLog = {
+  logger: Logger;
+  destination: DestinationStream;
+  path: string;
+};
+
+export const createDesktopLog = (logsPath: string): DesktopLog => {
+  mkdirSync(logsPath, { recursive: true });
+  pruneRuns(logsPath);
+  const path = join(logsPath, createRunFileName());
+  const logDestination = destination({ dest: path, sync: true });
+  const logger = pino(
+    {
+      serializers: {
+        error: stdSerializers.err,
+        err: stdSerializers.err,
+      },
+      errorKey: 'error',
+      level: 'info',
+    },
+    logDestination,
+  );
+  logger.info(
+    {
+      version: app.getVersion(),
+      electron: process.versions.electron,
+      platform: process.platform,
+      arch: process.arch,
+      packaged: app.isPackaged,
+      userData: app.getPath('userData'),
+    },
+    'app starting',
+  );
+  return { logger, destination: logDestination, path };
+};
+
+export const reportFatal = (
+  log: DesktopLog,
+  message: string,
+  error: unknown,
+): void => {
+  log.logger.fatal({ error }, message);
+  dialog.showErrorBox(
+    'Musetric stopped',
+    `${message}\n\nThe details are in ${log.path}`,
+  );
+};
+
+export const watchFatalEvents = (
+  log: DesktopLog,
+  onFatal: () => void,
+): void => {
+  process.on('uncaughtException', (error) => {
+    reportFatal(log, 'uncaught exception in the main process', error);
+    onFatal();
+  });
+  process.on('unhandledRejection', (reason) => {
+    reportFatal(log, 'unhandled rejection in the main process', reason);
+    onFatal();
+  });
+  app.on('render-process-gone', (_event, contents, details) => {
+    log.logger.error(
+      { ...details, url: contents.getURL() },
+      'render process gone',
+    );
+  });
+  app.on('child-process-gone', (_event, details) => {
+    log.logger.error({ ...details }, 'child process gone');
+  });
+  app.on('quit', (_event, exitCode) => {
+    log.logger.info({ exitCode }, 'app quit');
+  });
+};

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,12 +1,17 @@
+import { join } from 'node:path';
 import { app, BrowserWindow, dialog } from 'electron';
 import { applyAppPaths } from './appPaths.js';
 import { type DesktopBackend, startBackend } from './backend.js';
 import { createElectronGpuHost } from './electronGpuHost.js';
+import { createDesktopLog, reportFatal, watchFatalEvents } from './logging.js';
 
 const main = (): void => {
   applyAppPaths();
 
+  const log = createDesktopLog(join(app.getPath('userData'), 'logs'));
+
   if (!app.requestSingleInstanceLock()) {
+    log.logger.info('another instance owns the single instance lock');
     app.exit(0);
     return;
   }
@@ -89,11 +94,17 @@ const main = (): void => {
     app.relaunch();
   };
 
+  watchFatalEvents(log, () => {
+    void shutdown();
+  });
+
   const start = async (): Promise<void> => {
     const activeBackend = await startBackend({
       gpuPageHostFactory: createElectronGpuHost(),
+      logDestination: log.destination,
     });
     if (activeBackend === undefined) {
+      log.logger.error('the storage lock is held by another process');
       dialog.showErrorBox(
         'Musetric is already running',
         'Another Musetric process is using the same data folder. Close it and try again.',
@@ -109,7 +120,7 @@ const main = (): void => {
     .whenReady()
     .then(start)
     .catch((error: unknown) => {
-      console.error(error);
+      reportFatal(log, 'the app failed to start', error);
       void shutdown();
     });
 


### PR DESCRIPTION
Logs went to stdout, which a packaged app does not have, so a failed start left no trace at all. Every run now writes its own timestamped file in the data folder, keeping the last twenty runs, and the backend logs into the same file through an optional destination on the config.

Recorded: uncaught exceptions and rejections in the main process, a failed start, both early exits, and gone renderer and child processes. Since a handler of our own silences the built-in dialog for uncaught exceptions, fatal failures now show one that names the log file.

Also drops the comments the previous commit left in the installer and the workflow, which the no-comments rule forbids.