### PR TITLE
feat(desktop): show a loading screen while the app starts

### DIFF
--- a/knip.ts
+++ b/knip.ts
@@ -6,6 +6,8 @@ const config: KnipConfig = {
   ignoreIssues: {
     'packages/engine/src/engine.ts': ['exports'],
     'packages/desktop/scripts/beforePack.ts': ['exports'],
+    'packages/desktop/src/backend.ts': ['exports'],
+    'packages/desktop/src/electronGpuHost.ts': ['exports'],
   },
   ignoreBinaries: ['ps'],
   ignoreUnresolved: ['vite/client', '^tsx$'],

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -11,7 +11,7 @@
   "main": "dist/main.js",
   "scripts": {
     "dev:desktop": "yarn build:desktop && node ./scripts/startElectron.mjs",
-    "build:desktop": "node ./scripts/buildIcons.ts && tsc --build",
+    "build:desktop": "node ./scripts/buildAssets.ts && tsc --build",
     "pack:app": "electron-builder --dir",
     "pack:installer": "electron-builder --publish never",
     "check:ts": "tsc --build",

--- a/packages/desktop/scripts/buildAssets.ts
+++ b/packages/desktop/scripts/buildAssets.ts
@@ -5,7 +5,8 @@ import { fileURLToPath } from 'node:url';
 import { Resvg } from '@resvg/resvg-js';
 
 const packageDir = dirname(dirname(fileURLToPath(import.meta.url)));
-const svg = readFileSync(join(packageDir, 'src', 'favicon.svg'), 'utf8');
+const sourceDir = join(packageDir, 'src');
+const svg = readFileSync(join(sourceDir, 'favicon.svg'), 'utf8');
 const icon = new Resvg(svg, { fitTo: { mode: 'width', value: 1024 } })
   .render()
   .asPng();
@@ -13,3 +14,16 @@ const icon = new Resvg(svg, { fitTo: { mode: 'width', value: 1024 } })
 const assetsDir = join(packageDir, 'assets');
 await mkdir(assetsDir, { recursive: true });
 await writeFile(join(assetsDir, 'icon.png'), Buffer.from(icon));
+
+const logoPlaceholder = '{{logo}}';
+const loadingTemplate = readFileSync(join(sourceDir, 'loading.html'), 'utf8');
+if (!loadingTemplate.includes(logoPlaceholder)) {
+  throw new Error(`loading.html has no ${logoPlaceholder} placeholder`);
+}
+
+const distDir = join(packageDir, 'dist');
+await mkdir(distDir, { recursive: true });
+await writeFile(
+  join(distDir, 'loading.html'),
+  loadingTemplate.replace(logoPlaceholder, svg),
+);

--- a/packages/desktop/src/backend.ts
+++ b/packages/desktop/src/backend.ts
@@ -5,6 +5,7 @@ import { initDatabase } from '@musetric/backend-db/migrations';
 import { createStoragePaths } from '@musetric/utils/node';
 import { app } from 'electron';
 import { type DestinationStream } from 'pino';
+import { type DesktopBackend } from './backendRunner.js';
 import { acquireStorageLock } from './storageLock.js';
 
 const createLockPath = (): string =>
@@ -22,11 +23,6 @@ const createDesktopConfig = (logDestination: DestinationStream): AppConfig => {
     publicPath: resourcePaths.publicPath,
     browserBundlePath: resourcePaths.browserBundlePath,
   };
-};
-
-export type DesktopBackend = {
-  url: string;
-  close: () => Promise<void>;
 };
 
 export type StartBackendOptions = {

--- a/packages/desktop/src/backendRunner.ts
+++ b/packages/desktop/src/backendRunner.ts
@@ -1,0 +1,37 @@
+export type DesktopBackend = {
+  url: string;
+  close: () => Promise<void>;
+};
+
+export type BackendRunner = {
+  set: (backend: DesktopBackend) => void;
+  url: () => string | undefined;
+  stop: () => Promise<void>;
+};
+
+export const createBackendRunner = (): BackendRunner => {
+  let current: DesktopBackend | undefined = undefined;
+  let stopping: Promise<void> | undefined = undefined;
+
+  const stop = async (): Promise<void> => {
+    if (stopping !== undefined) {
+      await stopping;
+      return;
+    }
+    if (current === undefined) {
+      return;
+    }
+    const active = current;
+    current = undefined;
+    stopping = active.close();
+    await stopping;
+  };
+
+  return {
+    set: (backend) => {
+      current = backend;
+    },
+    url: () => current?.url,
+    stop,
+  };
+};

--- a/packages/desktop/src/loading.html
+++ b/packages/desktop/src/loading.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Musetric</title>
+    <style>
+      html,
+      body {
+        height: 100%;
+        margin: 0;
+        background-color: #121212;
+      }
+
+      body {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      svg {
+        width: 160px;
+        height: 160px;
+      }
+    </style>
+  </head>
+  <body>
+    {{logo}}
+  </body>
+</html>

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -1,9 +1,10 @@
 import { join } from 'node:path';
-import { app, BrowserWindow, dialog } from 'electron';
+import { app } from 'electron';
 import { applyAppPaths } from './appPaths.js';
-import { type DesktopBackend, startBackend } from './backend.js';
-import { createElectronGpuHost } from './electronGpuHost.js';
+import { createBackendRunner } from './backendRunner.js';
 import { createDesktopLog, reportFatal, watchFatalEvents } from './logging.js';
+import { startApp } from './startup.js';
+import { createWindows, destroyAllWindows } from './windows.js';
 
 const main = (): void => {
   applyAppPaths();
@@ -20,35 +21,10 @@ const main = (): void => {
   app.commandLine.appendSwitch('disable-webgpu-blocklist');
   app.commandLine.appendSwitch('ignore-gpu-blocklist');
 
-  let backend: DesktopBackend | undefined = undefined;
-  let stopBackendPromise: Promise<void> | undefined = undefined;
+  const isMac = process.platform === 'darwin';
+  const runner = createBackendRunner();
   let isQuitting = false;
   let isRelaunchRequested = false;
-  const mainWindows = new Set<BrowserWindow>();
-
-  const isMac = process.platform === 'darwin';
-
-  const stopBackend = async (): Promise<void> => {
-    if (stopBackendPromise !== undefined) {
-      await stopBackendPromise;
-      return;
-    }
-    if (backend === undefined) {
-      return;
-    }
-    const activeBackend = backend;
-    backend = undefined;
-    stopBackendPromise = activeBackend.close();
-    await stopBackendPromise;
-  };
-
-  const destroyAllWindows = (): void => {
-    for (const window of BrowserWindow.getAllWindows()) {
-      if (!window.isDestroyed()) {
-        window.destroy();
-      }
-    }
-  };
 
   const shutdown = async (): Promise<void> => {
     if (isQuitting) {
@@ -56,34 +32,24 @@ const main = (): void => {
     }
     isQuitting = true;
     destroyAllWindows();
-    await stopBackend();
+    await runner.stop();
     app.quit();
   };
 
-  const createWindow = async (url: string): Promise<void> => {
-    const window = new BrowserWindow({
-      width: 1280,
-      height: 800,
-      webPreferences: {
-        contextIsolation: true,
-        nodeIntegration: false,
-      },
-    });
-    mainWindows.add(window);
-    window.on('closed', () => {
-      mainWindows.delete(window);
-      if (!isMac && mainWindows.size === 0) {
+  const windows = createWindows({
+    onLastClosed: () => {
+      if (!isMac) {
         void shutdown();
       }
-    });
-    await window.loadURL(url);
-  };
+    },
+  });
 
   const openMainWindow = (): void => {
-    if (isQuitting || backend === undefined) {
+    const url = runner.url();
+    if (isQuitting || url === undefined) {
       return;
     }
-    void createWindow(backend.url);
+    void windows.open(async (window) => window.loadURL(url));
   };
 
   const requestRelaunch = (): void => {
@@ -98,27 +64,19 @@ const main = (): void => {
     void shutdown();
   });
 
-  const start = async (): Promise<void> => {
-    const activeBackend = await startBackend({
-      gpuPageHostFactory: createElectronGpuHost(),
-      logDestination: log.destination,
-    });
-    if (activeBackend === undefined) {
-      log.logger.error('the storage lock is held by another process');
-      dialog.showErrorBox(
-        'Musetric is already running',
-        'Another Musetric process is using the same data folder. Close it and try again.',
-      );
-      await shutdown();
-      return;
-    }
-    backend = activeBackend;
-    await createWindow(activeBackend.url);
-  };
-
   const startPromise = app
     .whenReady()
-    .then(start)
+    .then(async () => {
+      const result = await startApp({
+        log,
+        windows,
+        runner,
+        isQuitting: () => isQuitting,
+      });
+      if (result === 'storageBusy') {
+        await shutdown();
+      }
+    })
     .catch((error: unknown) => {
       reportFatal(log, 'the app failed to start', error);
       void shutdown();
@@ -135,7 +93,7 @@ const main = (): void => {
   });
 
   app.on('activate', () => {
-    if (mainWindows.size === 0) {
+    if (windows.isEmpty()) {
       openMainWindow();
     }
   });

--- a/packages/desktop/src/startup.ts
+++ b/packages/desktop/src/startup.ts
@@ -1,0 +1,58 @@
+import { fileURLToPath } from 'node:url';
+import { dialog } from 'electron';
+import { type BackendRunner } from './backendRunner.js';
+import { type DesktopLog } from './logging.js';
+import { type Windows } from './windows.js';
+
+const loadingPath = fileURLToPath(new URL('./loading.html', import.meta.url));
+
+const importBackendModules = async () => {
+  const [backend, gpuHost] = await Promise.all([
+    import('./backend.js'),
+    import('./electronGpuHost.js'),
+  ]);
+  return {
+    startBackend: backend.startBackend,
+    createElectronGpuHost: gpuHost.createElectronGpuHost,
+  };
+};
+
+export type StartAppOptions = {
+  log: DesktopLog;
+  windows: Windows;
+  runner: BackendRunner;
+  isQuitting: () => boolean;
+};
+
+export type StartAppResult = 'started' | 'storageBusy';
+
+export const startApp = async (
+  options: StartAppOptions,
+): Promise<StartAppResult> => {
+  const { log, windows, runner, isQuitting } = options;
+
+  const window = await windows.open(async (loadingWindow) =>
+    loadingWindow.loadFile(loadingPath),
+  );
+
+  const { startBackend, createElectronGpuHost } = await importBackendModules();
+  const backend = await startBackend({
+    gpuPageHostFactory: createElectronGpuHost(),
+    logDestination: log.destination,
+  });
+  if (backend === undefined) {
+    log.logger.error('the storage lock is held by another process');
+    dialog.showErrorBox(
+      'Musetric is already running',
+      'Another Musetric process is using the same data folder. Close it and try again.',
+    );
+    return 'storageBusy';
+  }
+  runner.set(backend);
+
+  if (isQuitting() || window.isDestroyed()) {
+    return 'started';
+  }
+  await window.loadURL(backend.url);
+  return 'started';
+};

--- a/packages/desktop/src/windows.ts
+++ b/packages/desktop/src/windows.ts
@@ -1,0 +1,88 @@
+import { BrowserWindow } from 'electron';
+
+const windowBackgroundColor = '#121212';
+
+const waitForFrames = async (window: BrowserWindow): Promise<void> => {
+  await window.webContents.executeJavaScript(
+    'new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve(true))))',
+  );
+};
+
+const whenPainted = async (window: BrowserWindow): Promise<void> =>
+  new Promise((resolve) => {
+    window.once('ready-to-show', () => {
+      resolve();
+    });
+    window.once('closed', () => {
+      resolve();
+    });
+  });
+
+const reveal = async (
+  window: BrowserWindow,
+  painted: Promise<void>,
+): Promise<void> => {
+  await painted;
+  if (window.isDestroyed()) {
+    return;
+  }
+  window.show();
+  await waitForFrames(window);
+  if (window.isDestroyed()) {
+    return;
+  }
+  window.setOpacity(1);
+};
+
+export type LoadWindow = (window: BrowserWindow) => Promise<void>;
+
+export type Windows = {
+  open: (load: LoadWindow) => Promise<BrowserWindow>;
+  isEmpty: () => boolean;
+};
+
+export type CreateWindowsOptions = {
+  onLastClosed: () => void;
+};
+
+export const createWindows = (options: CreateWindowsOptions): Windows => {
+  const opened = new Set<BrowserWindow>();
+
+  const open = async (load: LoadWindow): Promise<BrowserWindow> => {
+    const window = new BrowserWindow({
+      width: 1280,
+      height: 800,
+      show: false,
+      opacity: 0,
+      backgroundColor: windowBackgroundColor,
+      webPreferences: {
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    });
+    const painted = whenPainted(window);
+    opened.add(window);
+    window.on('closed', () => {
+      opened.delete(window);
+      if (opened.size === 0) {
+        options.onLastClosed();
+      }
+    });
+    await load(window);
+    await reveal(window, painted);
+    return window;
+  };
+
+  return {
+    open,
+    isEmpty: () => opened.size === 0,
+  };
+};
+
+export const destroyAllWindows = (): void => {
+  for (const window of BrowserWindow.getAllWindows()) {
+    if (!window.isDestroyed()) {
+      window.destroy();
+    }
+  }
+};

--- a/packages/frontend/index.html
+++ b/packages/frontend/index.html
@@ -21,15 +21,15 @@
         display: flex;
         justify-content: center;
         align-items: center;
-        font-size: 36px;
-        line-height: 40px;
-        font-family: 'Segoe UI', Arial, sans-serif;
-        color: #ffffff;
+      }
+      #splashScreen img {
+        width: 160px;
+        height: 160px;
       }
     </style>
   </head>
   <body>
-    <div id="splashScreen">Musetric</div>
+    <div id="splashScreen"><img src="/favicon.svg" alt="Musetric" /></div>
     <div id="root"></div>
     <script type="module" src="./src/index.tsx"></script>
   </body>

--- a/packages/frontend/src/index.tsx
+++ b/packages/frontend/src/index.tsx
@@ -1,6 +1,8 @@
 import { assertDefined } from '@musetric/utils';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { endpoints } from './api/index.js';
+import { queryClient } from './api/queryClient.js';
 import { App } from './app/index.js';
 import { engine } from './engine/engine.js';
 import { initI18next } from './translations/index.js';
@@ -16,6 +18,7 @@ const runApp = async () => {
   );
   await initI18next();
   await engine.boot();
+  await queryClient.prefetchQuery(endpoints.project.list());
 
   createRoot(rootElement).render(
     <StrictMode>


### PR DESCRIPTION
Nothing appeared until the backend was listening. A window now opens right away with the logo, and the same window moves on to the app once the backend is up. The icon script grew into an asset step that inlines the shared logo into the page, so the first frame needs no extra request.

The frontend splash draws that logo instead of a word and stays until the project list is in the cache, so the handover between the two documents is invisible and the first screen arrives complete.

A window is created hidden and transparent, revealed only after it has painted and produced frames: the compositor attaches the page a beat after a window appears, which showed as an empty rectangle, and a plain show fades the window in over whatever sits behind it.

The backend and gpu host modules load after the window is visible instead of before anything happens, which is most of the wait before the first frame. Startup is split accordingly: windows own creation and reveal, the runner owns the backend handle, startup owns the sequence, and main is left with the lifecycle.