### PR TITLE
feat(desktop): publish update manifests next to the installers

### DIFF
--- a/.github/workflows/desktopBuild.yml
+++ b/.github/workflows/desktopBuild.yml
@@ -57,22 +57,10 @@ jobs:
         include:
           - os: windows-latest
             platform: win
-            arch: x64
-          - os: windows-latest
-            platform: win
-            arch: arm64
           - os: macos-latest
             platform: mac
-            arch: x64
-          - os: macos-latest
-            platform: mac
-            arch: arm64
           - os: ubuntu-latest
             platform: linux
-            arch: x64
-          - os: ubuntu-latest
-            platform: linux
-            arch: arm64
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
@@ -94,12 +82,12 @@ jobs:
           MUSETRIC_SKIP_FFMPEG_FETCH: true
           ONNXRUNTIME_NODE_INSTALL: skip
       - run: yarn build:desktop
-      - run: yarn workspace @musetric/desktop pack:installer --${{ matrix.platform }} --${{ matrix.arch }} -c.extraMetadata.version=${{ needs.prepare.outputs.version }}
+      - run: yarn workspace @musetric/desktop pack:installer --${{ matrix.platform }} --x64 --arm64 -c.extraMetadata.version=${{ needs.prepare.outputs.version }}
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
       - uses: actions/upload-artifact@v7
         with:
-          name: musetric-desktop-${{ runner.os }}-${{ matrix.arch }}
+          name: musetric-desktop-${{ runner.os }}
           if-no-files-found: error
           retention-days: 14
           compression-level: 0
@@ -107,7 +95,12 @@ jobs:
             packages/desktop/build/*.exe
             packages/desktop/build/*.exe.blockmap
             packages/desktop/build/*.dmg
+            packages/desktop/build/*.dmg.blockmap
+            packages/desktop/build/*.zip
+            packages/desktop/build/*.zip.blockmap
             packages/desktop/build/*.AppImage
+            packages/desktop/build/*.AppImage.blockmap
+            packages/desktop/build/latest*.yml
 
   release:
     if: inputs.mode == 'release'
@@ -126,9 +119,10 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
+          (cd artifacts && sha256sum -- *) > SHA256SUMS.txt
           gh release create "v$VERSION" \
             --repo "$GITHUB_REPOSITORY" \
             --target "$GITHUB_SHA" \
             --title "Musetric $VERSION" \
             --generate-notes \
-            artifacts/*
+            artifacts/* SHA256SUMS.txt

--- a/packages/desktop/electron-builder.yml
+++ b/packages/desktop/electron-builder.yml
@@ -4,8 +4,12 @@ directories:
   output: build
   buildResources: assets
 beforePack: ./scripts/beforePack.ts
+publish:
+  provider: github
+  owner: musetric
+  repo: musetric
 win:
-  artifactName: ${productName} Setup ${version}-${arch}.${ext}
+  artifactName: ${productName}-Setup-${version}-${arch}.${ext}
   icon: assets/icon.png
   target: nsis
 nsis:
@@ -16,8 +20,11 @@ nsis:
   createDesktopShortcut: true
   createStartMenuShortcut: true
   license: license.txt
+  buildUniversalInstaller: false
 mac:
-  target: dmg
+  target:
+    - dmg
+    - zip
   category: public.app-category.music
 linux:
   executableName: musetric


### PR DESCRIPTION
A release carried installers but no update manifests, so an updater would have had nothing to read. Publishing them requires building both architectures of a platform in one electron-builder run: the manifest name varies by platform but not by architecture, and its entries are merged only within a single build process, so separate jobs overwrite each other's file. The matrix is three jobs instead of six. NSIS is told not to build a universal installer, which two architectures in one run would otherwise add on top of the two real ones.

Artifact names lose their spaces. GitHub turns a space in an asset name into a dot while electron-builder writes its own safe name into the manifest with dashes, so publishing through gh would have left every update pointing at a name that does not exist.

Publishing is declared explicitly instead of inferred from the repository field, since both the manifests and the packaged app-update.yml are derived from it. macOS gains a zip target because Squirrel installs zips and not dmgs, and every release now carries SHA256SUMS, the only integrity check an unsigned Linux build has.