### PR TITLE
build(frontend): resolve vite config imports via monorepo condition

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build:project": "vite build && cpx \"dist/**/*\" ../backend/storage/public --clean",
+    "dev": "vite --configLoader native",
+    "build:project": "vite build --configLoader native && cpx \"dist/**/*\" ../backend/storage/public --clean",
     "check:translations": "i18next-cli extract --config ./i18next.config.ts --ci --dry-run",
     "fix:translations": "i18next-cli extract --config ./i18next.config.ts",
     "check:ts": "tsc --build",

--- a/packages/landing/package.json
+++ b/packages/landing/package.json
@@ -4,8 +4,8 @@
   "license": "MIT",
   "type": "module",
   "scripts": {
-    "dev": "vite --host 0.0.0.0 --port 3003",
-    "build:project": "vite build",
+    "dev": "vite --configLoader native --host 0.0.0.0 --port 3003",
+    "build:project": "vite build --configLoader native",
     "check:translations": "i18next-cli extract --config ./i18next.config.ts --ci --dry-run",
     "fix:translations": "i18next-cli extract --config ./i18next.config.ts",
     "check:ts": "tsc --build",

--- a/packages/performance/package.json
+++ b/packages/performance/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build:project": "tsc --build",
-    "dev": "vite",
+    "dev": "vite --configLoader native",
     "check:ts": "tsc --build",
     "check:lint": "eslint . --cache --cache-strategy content",
     "fix:lint": "eslint . --fix --cache --cache-strategy content"


### PR DESCRIPTION
The vite config is loaded before its own resolve.conditions can apply, by a loader whose conditions are fixed to node. Imports of workspace packages inside vite.config.ts therefore resolved to the compiled dist instead of the sources, and broke outright when that dist was missing.

The native config loader defers to Node, which picks up the monorepo condition from NODE_OPTIONS, so configs now load workspace sources like the rest of the code does.