### PR TITLE
refactor(db): open database connections in one module

### DIFF
--- a/packages/backend-db/src/common/database.ts
+++ b/packages/backend-db/src/common/database.ts
@@ -1,0 +1,33 @@
+import { mkdirSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+
+const databaseTimeoutMs = 5000;
+
+export const closeDatabase = (database: DatabaseSync): void => {
+  if (database.isOpen) {
+    database.close();
+  }
+};
+
+export type OpenDatabaseOptions = {
+  foreignKeys: boolean;
+};
+
+export const openDatabase = (
+  databasePath: string,
+  options: OpenDatabaseOptions,
+): DatabaseSync => {
+  mkdirSync(dirname(databasePath), { recursive: true });
+  const database = new DatabaseSync(databasePath, {
+    enableForeignKeyConstraints: options.foreignKeys,
+    timeout: databaseTimeoutMs,
+  });
+  try {
+    database.exec('PRAGMA journal_mode = WAL');
+  } catch (error) {
+    closeDatabase(database);
+    throw error;
+  }
+  return database;
+};

--- a/packages/backend-db/src/common/index.ts
+++ b/packages/backend-db/src/common/index.ts
@@ -1,3 +1,5 @@
+export * from './database.js';
 export * from './hasValue.js';
+export * from './rollback.js';
 export * from './row.js';
 export * from './transaction.js';

--- a/packages/backend-db/src/common/rollback.ts
+++ b/packages/backend-db/src/common/rollback.ts
@@ -1,0 +1,12 @@
+import { type DatabaseSync } from 'node:sqlite';
+
+export const rollbackQuietly = (database: DatabaseSync): void => {
+  if (!database.isTransaction) {
+    return;
+  }
+  try {
+    database.exec('ROLLBACK');
+  } catch {
+    return;
+  }
+};

--- a/packages/backend-db/src/common/transaction.ts
+++ b/packages/backend-db/src/common/transaction.ts
@@ -1,4 +1,5 @@
 import { type DatabaseSync } from 'node:sqlite';
+import { rollbackQuietly } from './rollback.js';
 
 export const transaction = async <T>(
   database: DatabaseSync,
@@ -13,7 +14,7 @@ export const transaction = async <T>(
     await Promise.resolve(database.exec('COMMIT'));
     return result;
   } catch (error) {
-    await Promise.resolve(database.exec('ROLLBACK'));
+    rollbackQuietly(database);
     throw error;
   }
 };

--- a/packages/backend-db/src/instance.ts
+++ b/packages/backend-db/src/instance.ts
@@ -1,6 +1,5 @@
-import { mkdirSync } from 'node:fs';
-import { dirname } from 'node:path';
-import { DatabaseSync } from 'node:sqlite';
+import { type DatabaseSync } from 'node:sqlite';
+import { closeDatabase, openDatabase } from './common/index.js';
 import {
   audioDelivery,
   audioMaster,
@@ -19,14 +18,8 @@ import {
 
 export const createDatabase = async (
   databasePath: string,
-): Promise<DatabaseSync> => {
-  mkdirSync(dirname(databasePath), { recursive: true });
-  const database = new DatabaseSync(databasePath, {
-    enableForeignKeyConstraints: true,
-    timeout: 5000,
-  });
-  return await Promise.resolve(database);
-};
+): Promise<DatabaseSync> =>
+  await Promise.resolve(openDatabase(databasePath, { foreignKeys: true }));
 
 export const createInstance = async (databasePath: string) => {
   const database = await createDatabase(databasePath);
@@ -46,10 +39,7 @@ export const createInstance = async (databasePath: string) => {
     chords: chords.createInstance(database),
     blob: blob.createInstance(database),
     disconnect: async () => {
-      if (database.isOpen) {
-        database.close();
-      }
-      await Promise.resolve();
+      await Promise.resolve(closeDatabase(database));
     },
   };
 };


### PR DESCRIPTION
Every connection was opened by hand in instance.ts, and the journal mode was set elsewhere, so a second opener would have to remember both.

openDatabase creates the directory, opens with the given foreign key mode, confirms WAL and waits for a lock, and closeDatabase is the guard around isOpen that the disconnect path repeated. rollbackQuietly moves out of transaction.ts: a bare ROLLBACK throws a second error over the first when SQLITE_FULL has already rolled the transaction back.