### PR TITLE
feat(backend-db): add a versioned migration runner

### DIFF
--- a/packages/backend-db/src/common/database.ts
+++ b/packages/backend-db/src/common/database.ts
@@ -10,6 +10,17 @@ export const closeDatabase = (database: DatabaseSync): void => {
   }
 };
 
+export const withDatabase = <T>(
+  database: DatabaseSync,
+  run: (database: DatabaseSync) => T,
+): T => {
+  try {
+    return run(database);
+  } finally {
+    closeDatabase(database);
+  }
+};
+
 export type OpenDatabaseOptions = {
   foreignKeys: boolean;
 };
@@ -30,4 +41,19 @@ export const openDatabase = (
     throw error;
   }
   return database;
+};
+
+export const readDatabase = <T>(
+  databasePath: string,
+  read: (database: DatabaseSync) => T,
+): T => withDatabase(new DatabaseSync(databasePath, { readOnly: true }), read);
+
+export const readSchemaVersion = (database: DatabaseSync): number =>
+  Number(database.prepare('PRAGMA user_version').get()?.user_version);
+
+export const writeSchemaVersion = (
+  database: DatabaseSync,
+  version: number,
+): void => {
+  database.exec(`PRAGMA user_version = ${String(version)}`);
 };

--- a/packages/backend-db/src/migrations/backup.ts
+++ b/packages/backend-db/src/migrations/backup.ts
@@ -1,0 +1,37 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { type DatabaseSync } from 'node:sqlite';
+import { readDatabase, readSchemaVersion } from '../common/index.js';
+
+export const createBackupName = (version: number, date: Date): string => {
+  const stamp = date.toISOString().replaceAll(/[:.]/gu, '-');
+  return `app-${stamp}-v${String(version)}.db`;
+};
+
+const assertBackupVersion = (path: string, expectedVersion: number): void => {
+  const version = readDatabase(path, readSchemaVersion);
+  if (version === expectedVersion) {
+    return;
+  }
+  throw new Error(
+    `backup has schema v${String(version)} instead of v${String(expectedVersion)}`,
+  );
+};
+
+export const createBackup = (
+  database: DatabaseSync,
+  databasePath: string,
+  version: number,
+): string => {
+  const directory = join(dirname(databasePath), 'backups');
+  mkdirSync(directory, { recursive: true });
+  const path = join(directory, createBackupName(version, new Date()));
+  try {
+    database.prepare('VACUUM INTO ?').run(path);
+    assertBackupVersion(path, version);
+  } catch (error) {
+    rmSync(path, { force: true });
+    throw error;
+  }
+  return path;
+};

--- a/packages/backend-db/src/migrations/errors.ts
+++ b/packages/backend-db/src/migrations/errors.ts
@@ -1,0 +1,25 @@
+export type MigrationFailure = {
+  committedVersion?: number;
+  backupPath?: string;
+};
+
+const failures = new WeakMap<Error, MigrationFailure>();
+
+export const readMigrationFailure = (
+  error: unknown,
+): MigrationFailure | undefined =>
+  error instanceof Error ? failures.get(error) : undefined;
+
+export type MigrationFailureOptions = MigrationFailure & {
+  message: string;
+  cause?: unknown;
+};
+
+export const createMigrationFailure = (
+  options: MigrationFailureOptions,
+): Error => {
+  const { message, cause, ...failure } = options;
+  const error = new Error(message, { cause });
+  failures.set(error, failure);
+  return error;
+};

--- a/packages/backend-db/src/migrations/runner.ts
+++ b/packages/backend-db/src/migrations/runner.ts
@@ -1,0 +1,100 @@
+import { existsSync } from 'node:fs';
+import { type DatabaseSync } from 'node:sqlite';
+import {
+  openDatabase,
+  readDatabase,
+  readSchemaVersion,
+  rollbackQuietly,
+  withDatabase,
+  writeSchemaVersion,
+} from '../common/index.js';
+import { createBackup } from './backup.js';
+import { createMigrationFailure } from './errors.js';
+import { type Migration, type MigrationReport } from './types.js';
+
+const probeVersion = (databasePath: string): number => {
+  if (!existsSync(databasePath)) {
+    return 0;
+  }
+  try {
+    return readDatabase(databasePath, readSchemaVersion);
+  } catch (cause) {
+    throw createMigrationFailure({
+      message: 'The database file could not be read and may be damaged.',
+      cause,
+    });
+  }
+};
+
+const takeBackup = (
+  database: DatabaseSync,
+  databasePath: string,
+  version: number,
+): string => {
+  try {
+    return createBackup(database, databasePath, version);
+  } catch (cause) {
+    throw createMigrationFailure({
+      message:
+        'The database backup could not be created, so nothing was changed.',
+      cause,
+    });
+  }
+};
+
+const applyMigration = (
+  database: DatabaseSync,
+  statements: Migration,
+  version: number,
+  backupPath: string | undefined,
+): void => {
+  try {
+    database.exec('BEGIN IMMEDIATE');
+    for (const statement of statements) {
+      database.exec(statement);
+    }
+    const violations = database.prepare('PRAGMA foreign_key_check').all();
+    if (violations.length > 0) {
+      throw new Error(`foreign key violations: ${JSON.stringify(violations)}`);
+    }
+    writeSchemaVersion(database, version);
+    database.exec('COMMIT');
+  } catch (cause) {
+    rollbackQuietly(database);
+    throw createMigrationFailure({
+      committedVersion: version - 1,
+      backupPath,
+      message: `Migration v${String(version)} did not finish. It was rolled back, so the database still holds schema v${String(version - 1)}.`,
+      cause,
+    });
+  }
+};
+
+export const runMigrations = (
+  databasePath: string,
+  steps: readonly Migration[],
+): MigrationReport => {
+  const latest = steps.length;
+  const fromVersion = probeVersion(databasePath);
+  if (fromVersion > latest) {
+    throw createMigrationFailure({
+      message: `The database holds schema v${String(fromVersion)}, which this build does not know: it supports v${String(latest)}. Install the newer version again, or restore an older copy of the database.`,
+    });
+  }
+  if (fromVersion === latest) {
+    return { fromVersion, toVersion: latest };
+  }
+  return withDatabase(
+    openDatabase(databasePath, { foreignKeys: false }),
+    (database) => {
+      const backupPath =
+        fromVersion > 0
+          ? takeBackup(database, databasePath, fromVersion)
+          : undefined;
+      for (let version = fromVersion + 1; version <= latest; version += 1) {
+        applyMigration(database, steps[version - 1], version, backupPath);
+      }
+      return { fromVersion, toVersion: latest, backupPath };
+    },
+  );
+};

--- a/packages/backend-db/src/migrations/types.ts
+++ b/packages/backend-db/src/migrations/types.ts
@@ -1,0 +1,7 @@
+export type Migration = readonly string[];
+
+export type MigrationReport = {
+  fromVersion: number;
+  toVersion: number;
+  backupPath?: string;
+};


### PR DESCRIPTION
The schema had no version at all, so the runner that will carry it is built first, against a catalog it does not own: the version of a step is its place in the array, which leaves no way to write a gap or a repeat.

It reads PRAGMA user_version through a read-only probe, so refusing a database newer than the build writes nothing to the file, and a missing file is the first run rather than an error. A non-empty database is copied with VACUUM INTO before the first step, because at WAL part of the state lives in the sidecar and copying the file would not hold it. Each step runs in its own BEGIN IMMEDIATE with a foreign key check before the commit, so a failure stops on a whole version.

The failure carries the last committed version and the backup path in a WeakMap beside the error, so no foreign error can pass for one.