### PR TITLE
feat(db): move the schema into migration step v001

### DIFF
--- a/packages/backend-db/eslint.config.ts
+++ b/packages/backend-db/eslint.config.ts
@@ -1,3 +1,22 @@
 import { config } from '@musetric/eslint-config';
 
-export default config();
+export default [
+  ...config(),
+  {
+    files: ['src/migrations/steps/**/*.ts'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        {
+          patterns: [
+            {
+              regex: '^(?!\\.\\./types\\.js$|\\./[A-Za-z0-9]+\\.js$)',
+              message:
+                'A migration step is a frozen snapshot: import nothing but the Migration type, so no later change to the schema, the file system or the network can reach it.',
+            },
+          ],
+        },
+      ],
+    },
+  },
+];

--- a/packages/backend-db/src/instance.ts
+++ b/packages/backend-db/src/instance.ts
@@ -1,4 +1,3 @@
-import { type DatabaseSync } from 'node:sqlite';
 import { closeDatabase, openDatabase } from './common/index.js';
 import {
   audioDelivery,
@@ -16,13 +15,10 @@ import {
   wavePeaks,
 } from './entity/index.js';
 
-export const createDatabase = async (
-  databasePath: string,
-): Promise<DatabaseSync> =>
-  await Promise.resolve(openDatabase(databasePath, { foreignKeys: true }));
-
 export const createInstance = async (databasePath: string) => {
-  const database = await createDatabase(databasePath);
+  const database = await Promise.resolve(
+    openDatabase(databasePath, { foreignKeys: true }),
+  );
 
   return {
     project: project.createInstance(database),

--- a/packages/backend-db/src/migrations/index.ts
+++ b/packages/backend-db/src/migrations/index.ts
@@ -1,149 +1,15 @@
-import { type DatabaseSync } from 'node:sqlite';
-import { createDatabase } from '../instance.js';
-
-const createProject = `
-  CREATE TABLE IF NOT EXISTS Project (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    name TEXT NOT NULL,
-    sampleRate INTEGER NOT NULL,
-    frameCount INTEGER NOT NULL
-  );
-`;
-
-const createAudioMaster = `
-  CREATE TABLE IF NOT EXISTS AudioMaster (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    projectId INTEGER NOT NULL,
-    type TEXT NOT NULL CHECK (type IN ('source', 'lead', 'backing', 'instrumental')),
-    blobId TEXT NOT NULL UNIQUE,
-    UNIQUE(projectId, type),
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const createAudioMasterIndex = `
-  CREATE INDEX IF NOT EXISTS AudioMaster_projectId_type_index ON AudioMaster (projectId, type);
-`;
-
-const createProjectAudioAnalysis = `
-  CREATE TABLE IF NOT EXISTS ProjectAudioAnalysis (
-    projectId INTEGER PRIMARY KEY,
-    sourceIntegratedLoudnessDb REAL NOT NULL,
-    sourceTruePeakDb REAL NOT NULL,
-    sourceGainDb REAL NOT NULL,
-    leadIntegratedLoudnessDb REAL NOT NULL,
-    leadTruePeakDb REAL NOT NULL,
-    leadP95RmsDb REAL NOT NULL,
-    leadSpectrogramGainDb REAL NOT NULL,
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const createAudioDelivery = `
-  CREATE TABLE IF NOT EXISTS AudioDelivery (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    projectId INTEGER NOT NULL,
-    stemType TEXT NOT NULL CHECK (stemType IN ('lead', 'backing', 'instrumental')),
-    blobId TEXT NOT NULL UNIQUE,
-    waveBlobId TEXT NOT NULL UNIQUE,
-    UNIQUE(projectId, stemType),
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const createAudioDeliveryIndex = `
-  CREATE INDEX IF NOT EXISTS AudioDelivery_projectId_stemType_index ON AudioDelivery (projectId, stemType);
-`;
-
-const createPreview = `
-  CREATE TABLE IF NOT EXISTS Preview (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    projectId INTEGER NOT NULL UNIQUE,
-    blobId TEXT NOT NULL UNIQUE,
-    filename TEXT NOT NULL,
-    contentType TEXT NOT NULL,
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const createSubtitle = `
-  CREATE TABLE IF NOT EXISTS Subtitle (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    projectId INTEGER NOT NULL UNIQUE,
-    blobId TEXT NOT NULL UNIQUE,
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const createRhythm = `
-  CREATE TABLE IF NOT EXISTS Rhythm (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    projectId INTEGER NOT NULL UNIQUE,
-    blobId TEXT NOT NULL UNIQUE,
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const createKey = `
-  CREATE TABLE IF NOT EXISTS Key (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    projectId INTEGER NOT NULL UNIQUE,
-    blobId TEXT NOT NULL UNIQUE,
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const createChords = `
-  CREATE TABLE IF NOT EXISTS Chords (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    projectId INTEGER NOT NULL UNIQUE,
-    blobId TEXT NOT NULL UNIQUE,
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const createRecording = `
-  CREATE TABLE IF NOT EXISTS Recording (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
-    projectId INTEGER NOT NULL,
-    blobId TEXT NOT NULL UNIQUE,
-    waveBlobId TEXT NOT NULL UNIQUE,
-    sampleRate INTEGER NOT NULL,
-    frameCount INTEGER NOT NULL,
-    UNIQUE(projectId),
-    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
-  );
-`;
-
-const creationStatements = [
-  createProject,
-  createAudioMaster,
-  createAudioMasterIndex,
-  createProjectAudioAnalysis,
-  createAudioDelivery,
-  createAudioDeliveryIndex,
-  createPreview,
-  createSubtitle,
-  createRhythm,
-  createKey,
-  createChords,
-  createRecording,
-] as const;
-
-const createTables = async (database: DatabaseSync): Promise<void> => {
-  for (const statement of creationStatements) {
-    await Promise.resolve(database.exec(statement));
-  }
-};
+import { closeDatabase, openDatabase } from '../common/index.js';
+import { migrations } from './steps/index.js';
 
 export const initDatabase = async (databasePath: string): Promise<void> => {
-  const database = await createDatabase(databasePath);
+  const database = openDatabase(databasePath, { foreignKeys: true });
   try {
-    database.exec('PRAGMA journal_mode = WAL;');
-    await createTables(database);
-  } finally {
-    if (database.isOpen) {
-      database.close();
+    for (const statements of migrations) {
+      for (const statement of statements) {
+        await Promise.resolve(database.exec(statement));
+      }
     }
+  } finally {
+    closeDatabase(database);
   }
 };

--- a/packages/backend-db/src/migrations/steps/index.ts
+++ b/packages/backend-db/src/migrations/steps/index.ts
@@ -1,0 +1,4 @@
+import { type Migration } from '../types.js';
+import { v001Initial } from './v001Initial.js';
+
+export const migrations: readonly Migration[] = [v001Initial];

--- a/packages/backend-db/src/migrations/steps/v001Initial.ts
+++ b/packages/backend-db/src/migrations/steps/v001Initial.ts
@@ -1,0 +1,130 @@
+import { type Migration } from '../types.js';
+
+const createProject = `
+  CREATE TABLE Project (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    sampleRate INTEGER NOT NULL,
+    frameCount INTEGER NOT NULL
+  );
+`;
+
+const createAudioMaster = `
+  CREATE TABLE AudioMaster (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    projectId INTEGER NOT NULL,
+    type TEXT NOT NULL CHECK (type IN ('source', 'lead', 'backing', 'instrumental')),
+    blobId TEXT NOT NULL UNIQUE,
+    UNIQUE(projectId, type),
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+const createAudioMasterIndex = `
+  CREATE INDEX AudioMaster_projectId_type_index ON AudioMaster (projectId, type);
+`;
+
+const createProjectAudioAnalysis = `
+  CREATE TABLE ProjectAudioAnalysis (
+    projectId INTEGER PRIMARY KEY,
+    sourceIntegratedLoudnessDb REAL NOT NULL,
+    sourceTruePeakDb REAL NOT NULL,
+    sourceGainDb REAL NOT NULL,
+    leadIntegratedLoudnessDb REAL NOT NULL,
+    leadTruePeakDb REAL NOT NULL,
+    leadP95RmsDb REAL NOT NULL,
+    leadSpectrogramGainDb REAL NOT NULL,
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+const createAudioDelivery = `
+  CREATE TABLE AudioDelivery (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    projectId INTEGER NOT NULL,
+    stemType TEXT NOT NULL CHECK (stemType IN ('lead', 'backing', 'instrumental')),
+    blobId TEXT NOT NULL UNIQUE,
+    waveBlobId TEXT NOT NULL UNIQUE,
+    UNIQUE(projectId, stemType),
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+const createAudioDeliveryIndex = `
+  CREATE INDEX AudioDelivery_projectId_stemType_index ON AudioDelivery (projectId, stemType);
+`;
+
+const createPreview = `
+  CREATE TABLE Preview (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    projectId INTEGER NOT NULL UNIQUE,
+    blobId TEXT NOT NULL UNIQUE,
+    filename TEXT NOT NULL,
+    contentType TEXT NOT NULL,
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+const createSubtitle = `
+  CREATE TABLE Subtitle (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    projectId INTEGER NOT NULL UNIQUE,
+    blobId TEXT NOT NULL UNIQUE,
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+const createRhythm = `
+  CREATE TABLE Rhythm (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    projectId INTEGER NOT NULL UNIQUE,
+    blobId TEXT NOT NULL UNIQUE,
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+const createKey = `
+  CREATE TABLE Key (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    projectId INTEGER NOT NULL UNIQUE,
+    blobId TEXT NOT NULL UNIQUE,
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+const createChords = `
+  CREATE TABLE Chords (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    projectId INTEGER NOT NULL UNIQUE,
+    blobId TEXT NOT NULL UNIQUE,
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+const createRecording = `
+  CREATE TABLE Recording (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    projectId INTEGER NOT NULL,
+    blobId TEXT NOT NULL UNIQUE,
+    waveBlobId TEXT NOT NULL UNIQUE,
+    sampleRate INTEGER NOT NULL,
+    frameCount INTEGER NOT NULL,
+    UNIQUE(projectId),
+    FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE
+  );
+`;
+
+export const v001Initial: Migration = [
+  createProject,
+  createAudioMaster,
+  createAudioMasterIndex,
+  createProjectAudioAnalysis,
+  createAudioDelivery,
+  createAudioDeliveryIndex,
+  createPreview,
+  createSubtitle,
+  createRhythm,
+  createKey,
+  createChords,
+  createRecording,
+];

--- a/packages/backend-db/src/migrations/types.ts
+++ b/packages/backend-db/src/migrations/types.ts
@@ -1,0 +1,1 @@
+export type Migration = readonly string[];


### PR DESCRIPTION
The twelve CREATE statements ran on every start behind IF NOT EXISTS, which is not a schema but a suggestion: it silently accepts a database whose tables were created by an older build and differ from what the code now expects.

They move into a catalog of steps, unchanged except for the dropped IF NOT EXISTS, and a step is a plain array of statements. Nothing versions the database yet, so the schema is still created in one pass, but there is now exactly one place where it is written down, and one statement per element, so a failure names the statement and not a block of six.

A lint rule lets a step import nothing but its type. An applied step is a frozen snapshot of the schema at its version, while the zod schemas and the entity code drift on with the product; an allow-list is used rather than a list of bans, because a list of bans is never complete.