### PR TITLE
feat(db): version the schema and apply the pending steps

### DIFF
--- a/packages/backend-db/src/common/database.ts
+++ b/packages/backend-db/src/common/database.ts
@@ -10,6 +10,17 @@ export const closeDatabase = (database: DatabaseSync): void => {
   }
 };
 
+export const withDatabase = <T>(
+  database: DatabaseSync,
+  run: (database: DatabaseSync) => T,
+): T => {
+  try {
+    return run(database);
+  } finally {
+    closeDatabase(database);
+  }
+};
+
 export type OpenDatabaseOptions = {
   foreignKeys: boolean;
 };
@@ -30,4 +41,19 @@ export const openDatabase = (
     throw error;
   }
   return database;
+};
+
+export const readDatabase = <T>(
+  databasePath: string,
+  read: (database: DatabaseSync) => T,
+): T => withDatabase(new DatabaseSync(databasePath, { readOnly: true }), read);
+
+export const readSchemaVersion = (database: DatabaseSync): number =>
+  Number(database.prepare('PRAGMA user_version').get()?.user_version);
+
+export const writeSchemaVersion = (
+  database: DatabaseSync,
+  version: number,
+): void => {
+  database.exec(`PRAGMA user_version = ${String(version)}`);
 };

--- a/packages/backend-db/src/migrations/backup.ts
+++ b/packages/backend-db/src/migrations/backup.ts
@@ -1,0 +1,37 @@
+import { mkdirSync, rmSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { type DatabaseSync } from 'node:sqlite';
+import { readDatabase, readSchemaVersion } from '../common/index.js';
+
+export const createBackupName = (version: number, date: Date): string => {
+  const stamp = date.toISOString().replaceAll(/[:.]/gu, '-');
+  return `app-${stamp}-v${String(version)}.db`;
+};
+
+const assertBackupVersion = (path: string, expectedVersion: number): void => {
+  const version = readDatabase(path, readSchemaVersion);
+  if (version === expectedVersion) {
+    return;
+  }
+  throw new Error(
+    `backup has schema v${String(version)} instead of v${String(expectedVersion)}`,
+  );
+};
+
+export const createBackup = (
+  database: DatabaseSync,
+  databasePath: string,
+  version: number,
+): string => {
+  const directory = join(dirname(databasePath), 'backups');
+  mkdirSync(directory, { recursive: true });
+  const path = join(directory, createBackupName(version, new Date()));
+  try {
+    database.prepare('VACUUM INTO ?').run(path);
+    assertBackupVersion(path, version);
+  } catch (error) {
+    rmSync(path, { force: true });
+    throw error;
+  }
+  return path;
+};

--- a/packages/backend-db/src/migrations/index.ts
+++ b/packages/backend-db/src/migrations/index.ts
@@ -1,15 +1,2 @@
-import { closeDatabase, openDatabase } from '../common/index.js';
-import { migrations } from './steps/index.js';
-
-export const initDatabase = async (databasePath: string): Promise<void> => {
-  const database = openDatabase(databasePath, { foreignKeys: true });
-  try {
-    for (const statements of migrations) {
-      for (const statement of statements) {
-        await Promise.resolve(database.exec(statement));
-      }
-    }
-  } finally {
-    closeDatabase(database);
-  }
-};
+export * from './init.js';
+export * from './types.js';

--- a/packages/backend-db/src/migrations/init.ts
+++ b/packages/backend-db/src/migrations/init.ts
@@ -1,0 +1,6 @@
+import { runMigrations } from './runner.js';
+import { migrations } from './steps/index.js';
+import { type MigrationReport } from './types.js';
+
+export const initDatabase = (databasePath: string): MigrationReport =>
+  runMigrations(databasePath, migrations);

--- a/packages/backend-db/src/migrations/runner.ts
+++ b/packages/backend-db/src/migrations/runner.ts
@@ -1,0 +1,94 @@
+import { existsSync } from 'node:fs';
+import { type DatabaseSync } from 'node:sqlite';
+import {
+  openDatabase,
+  readDatabase,
+  readSchemaVersion,
+  rollbackQuietly,
+  withDatabase,
+  writeSchemaVersion,
+} from '../common/index.js';
+import { createBackup } from './backup.js';
+import { type Migration, type MigrationReport } from './types.js';
+
+const probeVersion = (databasePath: string): number => {
+  if (!existsSync(databasePath)) {
+    return 0;
+  }
+  try {
+    return readDatabase(databasePath, readSchemaVersion);
+  } catch (cause) {
+    throw new Error('The database file could not be read and may be damaged.', {
+      cause,
+    });
+  }
+};
+
+const takeBackup = (
+  database: DatabaseSync,
+  databasePath: string,
+  version: number,
+): string => {
+  try {
+    return createBackup(database, databasePath, version);
+  } catch (cause) {
+    throw new Error(
+      'The database backup could not be created, so nothing was changed.',
+      { cause },
+    );
+  }
+};
+
+const applyMigration = (
+  database: DatabaseSync,
+  statements: Migration,
+  version: number,
+): void => {
+  try {
+    database.exec('BEGIN IMMEDIATE');
+    for (const statement of statements) {
+      database.exec(statement);
+    }
+    const violations = database.prepare('PRAGMA foreign_key_check').all();
+    if (violations.length > 0) {
+      throw new Error(`foreign key violations: ${JSON.stringify(violations)}`);
+    }
+    writeSchemaVersion(database, version);
+    database.exec('COMMIT');
+  } catch (cause) {
+    rollbackQuietly(database);
+    throw new Error(
+      `Migration v${String(version)} did not finish. It was rolled back, so the database still holds schema v${String(version - 1)}.`,
+      { cause },
+    );
+  }
+};
+
+export const runMigrations = (
+  databasePath: string,
+  steps: readonly Migration[],
+): MigrationReport => {
+  const latest = steps.length;
+  const fromVersion = probeVersion(databasePath);
+  if (fromVersion > latest) {
+    throw new Error(
+      `The database holds schema v${String(fromVersion)}, which this build does not know: it supports v${String(latest)}. Install the newer version again, or restore an older copy of the database.`,
+    );
+  }
+  if (fromVersion === latest) {
+    return { fromVersion, toVersion: latest };
+  }
+  return withDatabase(
+    openDatabase(databasePath, { foreignKeys: false }),
+    (database) => {
+      const backupPath =
+        fromVersion > 0
+          ? takeBackup(database, databasePath, fromVersion)
+          : undefined;
+      for (let version = fromVersion + 1; version <= latest; version += 1) {
+        applyMigration(database, steps[version - 1], version);
+      }
+      return { fromVersion, toVersion: latest, backupPath };
+    },
+  );
+};

--- a/packages/backend-db/src/migrations/types.ts
+++ b/packages/backend-db/src/migrations/types.ts
@@ -1,1 +1,7 @@
 export type Migration = readonly string[];
+
+export type MigrationReport = {
+  fromVersion: number;
+  toVersion: number;
+  backupPath?: string;
+};

--- a/packages/backend/scripts/init.ts
+++ b/packages/backend/scripts/init.ts
@@ -1,5 +1,8 @@
 import { initDatabase } from '@musetric/backend-db/migrations';
 import { envs } from '../src/common/envs.js';
 
-await initDatabase(envs.databasePath);
-console.log('Database schema initialized');
+const report = initDatabase(envs.databasePath);
+
+console.log(
+  `Database schema v${String(report.fromVersion)} -> v${String(report.toVersion)}`,
+);

--- a/packages/desktop/src/backend.ts
+++ b/packages/desktop/src/backend.ts
@@ -39,7 +39,7 @@ export const startBackend = async (
     return undefined;
   }
   try {
-    await initDatabase(config.databasePath);
+    initDatabase(config.databasePath);
     const { createServerApp } = await import('@musetric/backend-core');
     const backend = await createServerApp(config, {
       gpuPageHostFactory: options.gpuPageHostFactory,


### PR DESCRIPTION
The schema was written in one pass on every start, so the second version of it had nowhere to go: a database created by an older build would have met the new code as a missing column at the first query.

The version is PRAGMA user_version, and a step is numbered by its place in the catalog, which leaves no way to write a gap or a repeat. The runner reads the version through a read-only probe, so refusing a database newer than the build writes nothing to the file at all, and on the common path, where nothing is pending, the file is not opened for writing before createInstance. A missing file is version zero, because that is the first run and not an error.

A non-empty database is copied with VACUUM INTO before the first step: at WAL part of the state lives in the sidecar, so copying the file would save an incomplete database, and the copy is reopened afterwards to confirm its version rather than promise one. Each step runs in its own BEGIN IMMEDIATE with a foreign key check before the commit, so a failure leaves the database on a whole version and the next start continues from there. Foreign keys are off on the migration connection, since a table rebuild is impossible with them on and the pragma is ignored inside a transaction.

initDatabase is synchronous, because node:sqlite is and no request may be served before it returns, and it reports the versions it moved between, which is the first thing to ask about a broken upgrade.