### PR TITLE
feat(db): refuse a database the migrations have not reached

### DIFF
--- a/packages/backend-db/src/instance.ts
+++ b/packages/backend-db/src/instance.ts
@@ -1,4 +1,10 @@
-import { closeDatabase, openDatabase } from './common/index.js';
+import { existsSync } from 'node:fs';
+import {
+  closeDatabase,
+  openDatabase,
+  readDatabase,
+  readSchemaVersion,
+} from './common/index.js';
 import {
   audioDelivery,
   audioMaster,
@@ -14,8 +20,25 @@ import {
   subtitle,
   wavePeaks,
 } from './entity/index.js';
+import { migrations } from './migrations/steps/index.js';
+
+const assertSchemaVersion = (databasePath: string): void => {
+  if (!existsSync(databasePath)) {
+    throw new Error(
+      `there is no database at ${databasePath}; run the migrations to create it`,
+    );
+  }
+  const version = readDatabase(databasePath, readSchemaVersion);
+  if (version === migrations.length) {
+    return;
+  }
+  throw new Error(
+    `database schema v${String(version)} does not match the expected v${String(migrations.length)}; run the migrations before opening the database`,
+  );
+};
 
 export const createInstance = async (databasePath: string) => {
+  assertSchemaVersion(databasePath);
   const database = await Promise.resolve(
     openDatabase(databasePath, { foreignKeys: true }),
   );


### PR DESCRIPTION
createInstance opened whatever file it was given, so any path around initDatabase - a dev server started without project:init, a hand-placed file, a second process arriving later - served requests over a foreign schema and failed at a query, on a column, long after the cause.

It now compares user_version with the catalog before it opens, and says separately that the file is missing, because that is the common case and unable to open database file explains neither what happened nor what to do about it.