### PR TITLE
feat(desktop): show one dialog when the migration fails

### DIFF
--- a/packages/backend-db/src/migrations/errors.ts
+++ b/packages/backend-db/src/migrations/errors.ts
@@ -1,0 +1,25 @@
+export type MigrationFailure = {
+  committedVersion?: number;
+  backupPath?: string;
+};
+
+const failures = new WeakMap<Error, MigrationFailure>();
+
+export const readMigrationFailure = (
+  error: unknown,
+): MigrationFailure | undefined =>
+  error instanceof Error ? failures.get(error) : undefined;
+
+export type MigrationFailureOptions = MigrationFailure & {
+  message: string;
+  cause?: unknown;
+};
+
+export const createMigrationFailure = (
+  options: MigrationFailureOptions,
+): Error => {
+  const { message, cause, ...failure } = options;
+  const error = new Error(message, { cause });
+  failures.set(error, failure);
+  return error;
+};

--- a/packages/backend-db/src/migrations/index.ts
+++ b/packages/backend-db/src/migrations/index.ts
@@ -1,2 +1,3 @@
+export * from './errors.js';
 export * from './init.js';
 export * from './types.js';

--- a/packages/backend-db/src/migrations/runner.ts
+++ b/packages/backend-db/src/migrations/runner.ts
@@ -9,6 +9,7 @@ import {
   writeSchemaVersion,
 } from '../common/index.js';
 import { createBackup } from './backup.js';
+import { createMigrationFailure } from './errors.js';
 import { type Migration, type MigrationReport } from './types.js';
 
 const probeVersion = (databasePath: string): number => {
@@ -18,7 +19,8 @@ const probeVersion = (databasePath: string): number => {
   try {
     return readDatabase(databasePath, readSchemaVersion);
   } catch (cause) {
-    throw new Error('The database file could not be read and may be damaged.', {
+    throw createMigrationFailure({
+      message: 'The database file could not be read and may be damaged.',
       cause,
     });
   }
@@ -32,10 +34,11 @@ const takeBackup = (
   try {
     return createBackup(database, databasePath, version);
   } catch (cause) {
-    throw new Error(
-      'The database backup could not be created, so nothing was changed.',
-      { cause },
-    );
+    throw createMigrationFailure({
+      message:
+        'The database backup could not be created, so nothing was changed.',
+      cause,
+    });
   }
 };
 
@@ -43,6 +46,7 @@ const applyMigration = (
   database: DatabaseSync,
   statements: Migration,
   version: number,
+  backupPath: string | undefined,
 ): void => {
   try {
     database.exec('BEGIN IMMEDIATE');
@@ -57,10 +61,12 @@ const applyMigration = (
     database.exec('COMMIT');
   } catch (cause) {
     rollbackQuietly(database);
-    throw new Error(
-      `Migration v${String(version)} did not finish. It was rolled back, so the database still holds schema v${String(version - 1)}.`,
-      { cause },
-    );
+    throw createMigrationFailure({
+      committedVersion: version - 1,
+      backupPath,
+      message: `Migration v${String(version)} did not finish. It was rolled back, so the database still holds schema v${String(version - 1)}.`,
+      cause,
+    });
   }
 };
 
@@ -71,9 +77,9 @@ export const runMigrations = (
   const latest = steps.length;
   const fromVersion = probeVersion(databasePath);
   if (fromVersion > latest) {
-    throw new Error(
-      `The database holds schema v${String(fromVersion)}, which this build does not know: it supports v${String(latest)}. Install the newer version again, or restore an older copy of the database.`,
-    );
+    throw createMigrationFailure({
+      message: `The database holds schema v${String(fromVersion)}, which this build does not know: it supports v${String(latest)}. Install the newer version again, or restore an older copy of the database.`,
+    });
   }
   if (fromVersion === latest) {
     return { fromVersion, toVersion: latest };
@@ -86,7 +92,7 @@ export const runMigrations = (
           ? takeBackup(database, databasePath, fromVersion)
           : undefined;
       for (let version = fromVersion + 1; version <= latest; version += 1) {
-        applyMigration(database, steps[version - 1], version);
+        applyMigration(database, steps[version - 1], version, backupPath);
       }
       return { fromVersion, toVersion: latest, backupPath };
     },

--- a/packages/desktop/src/backend.ts
+++ b/packages/desktop/src/backend.ts
@@ -39,7 +39,7 @@ export const startBackend = async (
     return undefined;
   }
   try {
-    initDatabase(config.databasePath);
+    const migration = initDatabase(config.databasePath);
     const { createServerApp } = await import('@musetric/backend-core');
     const backend = await createServerApp(config, {
       gpuPageHostFactory: options.gpuPageHostFactory,
@@ -54,6 +54,7 @@ export const startBackend = async (
     }
     return {
       url: `http://127.0.0.1:${address.port}`,
+      migration,
       close: async () => {
         try {
           await backend.close();

--- a/packages/desktop/src/backendRunner.ts
+++ b/packages/desktop/src/backendRunner.ts
@@ -1,5 +1,8 @@
+import { type MigrationReport } from '@musetric/backend-db/migrations';
+
 export type DesktopBackend = {
   url: string;
+  migration: MigrationReport;
   close: () => Promise<void>;
 };
 

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -2,8 +2,9 @@ import { join } from 'node:path';
 import { app } from 'electron';
 import { applyAppPaths } from './appPaths.js';
 import { createBackendRunner } from './backendRunner.js';
-import { createDesktopLog, reportFatal, watchFatalEvents } from './logging.js';
+import { createDesktopLog, watchFatalEvents } from './logging.js';
 import { startApp } from './startup.js';
+import { reportStartupFailure } from './startupFailure.js';
 import { createWindows, destroyAllWindows } from './windows.js';
 
 const main = (): void => {
@@ -78,7 +79,7 @@ const main = (): void => {
       }
     })
     .catch((error: unknown) => {
-      reportFatal(log, 'the app failed to start', error);
+      reportStartupFailure(log, error);
       void shutdown();
     });
 

--- a/packages/desktop/src/startup.ts
+++ b/packages/desktop/src/startup.ts
@@ -49,6 +49,10 @@ export const startApp = async (
     return 'storageBusy';
   }
   runner.set(backend);
+  log.logger.info(
+    { ...backend.migration },
+    `database schema v${String(backend.migration.fromVersion)} -> v${String(backend.migration.toVersion)}`,
+  );
 
   if (isQuitting() || window.isDestroyed()) {
     return 'started';

--- a/packages/desktop/src/startupFailure.ts
+++ b/packages/desktop/src/startupFailure.ts
@@ -1,0 +1,29 @@
+import { dirname } from 'node:path';
+import { readMigrationFailure } from '@musetric/backend-db/migrations';
+import { dialog } from 'electron';
+import { type DesktopLog, reportFatal } from './logging.js';
+
+const describeBackup = (backupPath: string): string[] => [
+  `A copy of the database from before the update is in ${backupPath}`,
+  `To restore it, close Musetric, delete app.db, app.db-wal and app.db-shm in ${dirname(dirname(backupPath))}, then copy the backup there under the name app.db.`,
+];
+
+export const reportStartupFailure = (log: DesktopLog, error: unknown): void => {
+  const migration = readMigrationFailure(error);
+  if (!migration) {
+    reportFatal(log, 'the app failed to start', error);
+    return;
+  }
+  log.logger.fatal({ error, ...migration }, 'the database migration failed');
+  const lines = [
+    error instanceof Error ? error.message : String(error),
+    ...(migration.backupPath === undefined
+      ? []
+      : describeBackup(migration.backupPath)),
+    `The details are in ${log.path}`,
+  ];
+  dialog.showErrorBox(
+    'Musetric could not update its database',
+    lines.join('\n\n'),
+  );
+};


### PR DESCRIPTION
A migration that does not finish means the app must not start, and the generic fatal handler said only that starting failed: neither the copy of the database the runner had just made nor the version it stopped on reached the person looking at the window.

The failure now carries the last committed version and the backup path in a WeakMap beside the error. Membership in that map is what marks a migration failure, so an unrelated error with a similar shape cannot pass for one, and the runner keeps throwing ordinary errors for what it does not explain better than SQLite does.

main.ts keeps a single handler: it separates a migration failure from any other and shows one dialog with the error, where the copy is and how to put it back, since that instruction is needed exactly when nobody is reading documentation. A dialog in backend.ts and a rethrow would have opened two windows in a row. The successful report goes to the startup log as v0 -> v1.