### PR TITLE
test(db): cover the migration paths and the blob list

### DIFF
--- a/packages/backend-db/package.json
+++ b/packages/backend-db/package.json
@@ -23,7 +23,8 @@
     "build:project": "tsc --build",
     "check:ts": "tsc --build",
     "check:lint": "eslint . --cache --cache-strategy content",
-    "fix:lint": "eslint . --fix --cache --cache-strategy content"
+    "fix:lint": "eslint . --fix --cache --cache-strategy content",
+    "test": "vitest run"
   },
   "peerDependencies": {
     "@musetric/utils": "workspace:*",
@@ -36,6 +37,7 @@
     "@typescript/native": "catalog:",
     "eslint": "catalog:",
     "typescript": "catalog:",
+    "vitest": "catalog:",
     "zod": "catalog:"
   }
 }

--- a/packages/backend-db/src/__test__/migrations/backup.test.ts
+++ b/packages/backend-db/src/__test__/migrations/backup.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { createBackupName } from '../../migrations/backup.js';
+
+const invalidWindowsCharacters = /[:*?"<>|]/u;
+
+describe('createBackupName', () => {
+  it('avoids characters that no Windows file name may hold', () => {
+    const name = createBackupName(3, new Date('2026-08-08T09:14:16.123Z'));
+
+    expect(name).toBe('app-2026-08-08T09-14-16-123Z-v3.db');
+    expect(invalidWindowsCharacters.test(name)).toBe(false);
+  });
+});

--- a/packages/backend-db/src/__test__/migrations/blobReferences.test.ts
+++ b/packages/backend-db/src/__test__/migrations/blobReferences.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  openDatabase,
+  readDatabase,
+  withDatabase,
+} from '../../common/index.js';
+import { createInstance } from '../../instance.js';
+import { runMigrations } from '../../migrations/runner.js';
+import { migrations } from '../../migrations/steps/index.js';
+import { createWorkspace, type Workspace } from './common.js';
+
+const knownBlobColumns = [
+  'AudioDelivery.blobId',
+  'AudioDelivery.waveBlobId',
+  'AudioMaster.blobId',
+  'Chords.blobId',
+  'Key.blobId',
+  'Preview.blobId',
+  'Recording.blobId',
+  'Recording.waveBlobId',
+  'Rhythm.blobId',
+  'Subtitle.blobId',
+];
+
+const seedStatements = [
+  `INSERT INTO Project (name, sampleRate, frameCount) VALUES ('song', 44100, 100)`,
+  `INSERT INTO AudioMaster (projectId, type, blobId) VALUES (1, 'source', 'AudioMaster.blobId')`,
+  `INSERT INTO AudioDelivery (projectId, stemType, blobId, waveBlobId) VALUES (1, 'lead', 'AudioDelivery.blobId', 'AudioDelivery.waveBlobId')`,
+  `INSERT INTO Preview (projectId, blobId, filename, contentType) VALUES (1, 'Preview.blobId', 'cover.png', 'image/png')`,
+  `INSERT INTO Subtitle (projectId, blobId) VALUES (1, 'Subtitle.blobId')`,
+  `INSERT INTO Rhythm (projectId, blobId) VALUES (1, 'Rhythm.blobId')`,
+  `INSERT INTO Key (projectId, blobId) VALUES (1, 'Key.blobId')`,
+  `INSERT INTO Chords (projectId, blobId) VALUES (1, 'Chords.blobId')`,
+  `INSERT INTO Recording (projectId, blobId, waveBlobId, sampleRate, frameCount) VALUES (1, 'Recording.blobId', 'Recording.waveBlobId', 44100, 100)`,
+];
+
+const readBlobColumns = (databasePath: string): string[] =>
+  readDatabase(databasePath, (database) => {
+    const tables = database
+      .prepare(
+        `SELECT name FROM sqlite_schema WHERE type = 'table' AND name NOT LIKE 'sqlite_%'`,
+      )
+      .all()
+      .map((row) => String(row.name));
+    return tables
+      .flatMap((table) =>
+        database
+          .prepare(`PRAGMA table_info(${table})`)
+          .all()
+          .map((row) => `${table}.${String(row.name)}`),
+      )
+      .filter((column) => column.toLowerCase().endsWith('blobid'))
+      .toSorted((left, right) => left.localeCompare(right));
+  });
+
+describe('referenced blob ids', () => {
+  let workspace: Workspace = createWorkspace();
+
+  beforeEach(() => {
+    workspace = createWorkspace();
+    runMigrations(workspace.databasePath, migrations);
+  });
+
+  afterEach(() => {
+    workspace.remove();
+  });
+
+  it('covers every blob column the schema declares', () => {
+    expect(readBlobColumns(workspace.databasePath)).toEqual(knownBlobColumns);
+  });
+
+  it('lists a value stored in every blob column', async () => {
+    withDatabase(
+      openDatabase(workspace.databasePath, { foreignKeys: true }),
+      (database) => {
+        for (const statement of seedStatements) {
+          database.exec(statement);
+        }
+      },
+    );
+
+    const instance = await createInstance(workspace.databasePath);
+    const blobIds = await instance.blob.list();
+    await instance.disconnect();
+
+    expect(
+      blobIds.toSorted((left, right) => left.localeCompare(right)),
+    ).toEqual(knownBlobColumns);
+  });
+});

--- a/packages/backend-db/src/__test__/migrations/common.ts
+++ b/packages/backend-db/src/__test__/migrations/common.ts
@@ -1,0 +1,56 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { readDatabase, readSchemaVersion } from '../../common/index.js';
+import {
+  type MigrationFailure,
+  readMigrationFailure,
+} from '../../migrations/errors.js';
+import { migrations } from '../../migrations/steps/index.js';
+import { type Migration } from '../../migrations/types.js';
+
+export type Workspace = {
+  databasePath: string;
+  remove: () => void;
+};
+
+export const createWorkspace = (): Workspace => {
+  const directory = mkdtempSync(join(tmpdir(), 'musetric-db-'));
+  return {
+    databasePath: join(directory, 'db', 'app.db'),
+    remove: () => {
+      rmSync(directory, { recursive: true, force: true });
+    },
+  };
+};
+
+export const writeGarbageFile = (databasePath: string): void => {
+  mkdirSync(dirname(databasePath), { recursive: true });
+  writeFileSync(databasePath, 'this is not a database');
+};
+
+export const readUserVersion = (databasePath: string): number =>
+  readDatabase(databasePath, readSchemaVersion);
+
+export const readJournalMode = (databasePath: string): string =>
+  readDatabase(databasePath, (database) => {
+    const row = database.prepare('PRAGMA journal_mode').get();
+    return String(row?.journal_mode);
+  });
+
+export const getFailure = (run: () => void): MigrationFailure => {
+  try {
+    run();
+  } catch (error) {
+    const migration = readMigrationFailure(error);
+    if (migration) {
+      return migration;
+    }
+    throw error;
+  }
+  throw new Error('the call was expected to fail');
+};
+
+export const withSteps = (
+  steps: readonly Migration[],
+): readonly Migration[] => [...migrations, ...steps];

--- a/packages/backend-db/src/__test__/migrations/fingerprint.ts
+++ b/packages/backend-db/src/__test__/migrations/fingerprint.ts
@@ -1,0 +1,31 @@
+import { DatabaseSync } from 'node:sqlite';
+import { withDatabase } from '../../common/index.js';
+import { type Migration } from '../../migrations/types.js';
+
+const schemaQuery = `
+  SELECT type, name, sql FROM sqlite_schema
+  WHERE name NOT LIKE 'sqlite_%'
+  ORDER BY type, name
+`;
+
+const normalize = (value: unknown): string =>
+  String(value).replaceAll(/\s+/gu, ' ').trim();
+
+export const readFingerprint = (database: DatabaseSync): string[] =>
+  database
+    .prepare(schemaQuery)
+    .all()
+    .map(
+      (row) =>
+        `${normalize(row.type)} ${normalize(row.name)} ${normalize(row.sql)}`,
+    );
+
+export const buildFingerprint = (steps: readonly Migration[]): string[] =>
+  withDatabase(new DatabaseSync(':memory:'), (database) => {
+    for (const statements of steps) {
+      for (const statement of statements) {
+        database.exec(statement);
+      }
+    }
+    return readFingerprint(database);
+  });

--- a/packages/backend-db/src/__test__/migrations/history.test.ts
+++ b/packages/backend-db/src/__test__/migrations/history.test.ts
@@ -1,0 +1,39 @@
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import { migrations } from '../../migrations/steps/index.js';
+import { buildFingerprint } from './fingerprint.js';
+
+const releasedMigrationDigests = new Map([
+  [1, 'd4f8df3472b50b1c4e51c9adbeb52532c514807a10b28d02ae3195d3bf67d9d6'],
+]);
+
+const expectedFingerprint = [
+  'index AudioDelivery_projectId_stemType_index CREATE INDEX AudioDelivery_projectId_stemType_index ON AudioDelivery (projectId, stemType)',
+  'index AudioMaster_projectId_type_index CREATE INDEX AudioMaster_projectId_type_index ON AudioMaster (projectId, type)',
+  "table AudioDelivery CREATE TABLE AudioDelivery ( id INTEGER PRIMARY KEY AUTOINCREMENT, projectId INTEGER NOT NULL, stemType TEXT NOT NULL CHECK (stemType IN ('lead', 'backing', 'instrumental')), blobId TEXT NOT NULL UNIQUE, waveBlobId TEXT NOT NULL UNIQUE, UNIQUE(projectId, stemType), FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )",
+  "table AudioMaster CREATE TABLE AudioMaster ( id INTEGER PRIMARY KEY AUTOINCREMENT, projectId INTEGER NOT NULL, type TEXT NOT NULL CHECK (type IN ('source', 'lead', 'backing', 'instrumental')), blobId TEXT NOT NULL UNIQUE, UNIQUE(projectId, type), FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )",
+  'table Chords CREATE TABLE Chords ( id INTEGER PRIMARY KEY AUTOINCREMENT, projectId INTEGER NOT NULL UNIQUE, blobId TEXT NOT NULL UNIQUE, FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )',
+  'table Key CREATE TABLE Key ( id INTEGER PRIMARY KEY AUTOINCREMENT, projectId INTEGER NOT NULL UNIQUE, blobId TEXT NOT NULL UNIQUE, FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )',
+  'table Preview CREATE TABLE Preview ( id INTEGER PRIMARY KEY AUTOINCREMENT, projectId INTEGER NOT NULL UNIQUE, blobId TEXT NOT NULL UNIQUE, filename TEXT NOT NULL, contentType TEXT NOT NULL, FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )',
+  'table Project CREATE TABLE Project ( id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, sampleRate INTEGER NOT NULL, frameCount INTEGER NOT NULL )',
+  'table ProjectAudioAnalysis CREATE TABLE ProjectAudioAnalysis ( projectId INTEGER PRIMARY KEY, sourceIntegratedLoudnessDb REAL NOT NULL, sourceTruePeakDb REAL NOT NULL, sourceGainDb REAL NOT NULL, leadIntegratedLoudnessDb REAL NOT NULL, leadTruePeakDb REAL NOT NULL, leadP95RmsDb REAL NOT NULL, leadSpectrogramGainDb REAL NOT NULL, FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )',
+  'table Recording CREATE TABLE Recording ( id INTEGER PRIMARY KEY AUTOINCREMENT, projectId INTEGER NOT NULL, blobId TEXT NOT NULL UNIQUE, waveBlobId TEXT NOT NULL UNIQUE, sampleRate INTEGER NOT NULL, frameCount INTEGER NOT NULL, UNIQUE(projectId), FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )',
+  'table Rhythm CREATE TABLE Rhythm ( id INTEGER PRIMARY KEY AUTOINCREMENT, projectId INTEGER NOT NULL UNIQUE, blobId TEXT NOT NULL UNIQUE, FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )',
+  'table Subtitle CREATE TABLE Subtitle ( id INTEGER PRIMARY KEY AUTOINCREMENT, projectId INTEGER NOT NULL UNIQUE, blobId TEXT NOT NULL UNIQUE, FOREIGN KEY (projectId) REFERENCES Project(id) ON DELETE CASCADE )',
+];
+
+const readMigrationDigest = (statements: readonly string[]): string =>
+  createHash('sha256').update(JSON.stringify(statements)).digest('hex');
+
+describe('released migration history', () => {
+  it('matches the committed digest of every released step', () => {
+    const actual = migrations
+      .map((statements, index) => [index + 1, readMigrationDigest(statements)])
+      .filter((entry) => releasedMigrationDigests.has(Number(entry[0])));
+    expect(actual).toEqual([...releasedMigrationDigests]);
+  });
+
+  it('matches the committed physical schema snapshot', () => {
+    expect(buildFingerprint(migrations)).toEqual(expectedFingerprint);
+  });
+});

--- a/packages/backend-db/src/__test__/migrations/runner.test.ts
+++ b/packages/backend-db/src/__test__/migrations/runner.test.ts
@@ -1,0 +1,175 @@
+import { copyFileSync, existsSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  closeDatabase,
+  openDatabase,
+  readDatabase,
+  withDatabase,
+} from '../../common/index.js';
+import { runMigrations } from '../../migrations/runner.js';
+import { migrations } from '../../migrations/steps/index.js';
+import {
+  createWorkspace,
+  getFailure,
+  readJournalMode,
+  readUserVersion,
+  withSteps,
+  type Workspace,
+  writeGarbageFile,
+} from './common.js';
+import { buildFingerprint, readFingerprint } from './fingerprint.js';
+
+const secondStep = ['ALTER TABLE Project ADD COLUMN note TEXT'];
+
+const failingSecondStep = [
+  'ALTER TABLE Project ADD COLUMN note TEXT',
+  'ALTER TABLE Missing ADD COLUMN note TEXT',
+];
+
+const failingThirdStep = [
+  'ALTER TABLE Project ADD COLUMN laterNote TEXT',
+  'ALTER TABLE Missing ADD COLUMN note TEXT',
+];
+
+const danglingStep = [
+  `INSERT INTO AudioMaster (projectId, type, blobId) VALUES (404, 'lead', 'orphan')`,
+];
+
+const listBackups = (databasePath: string): string[] => {
+  const directory = join(dirname(databasePath), 'backups');
+  return existsSync(directory) ? readdirSync(directory) : [];
+};
+
+const readProjectColumns = (databasePath: string): string[] =>
+  readDatabase(databasePath, (database) =>
+    database
+      .prepare('PRAGMA table_info(Project)')
+      .all()
+      .map((row) => String(row.name)),
+  );
+
+describe('runMigrations', () => {
+  let workspace: Workspace = createWorkspace();
+
+  beforeEach(() => {
+    workspace = createWorkspace();
+  });
+
+  afterEach(() => {
+    workspace.remove();
+  });
+
+  it('creates a fresh database with the expected physical schema', () => {
+    const report = runMigrations(workspace.databasePath, migrations);
+
+    expect(report.fromVersion).toBe(0);
+    expect(report.toVersion).toBe(migrations.length);
+    expect(report.backupPath).toBeUndefined();
+    expect(readUserVersion(workspace.databasePath)).toBe(migrations.length);
+    expect(readJournalMode(workspace.databasePath)).toBe('wal');
+    expect(listBackups(workspace.databasePath)).toEqual([]);
+
+    const fingerprint = withDatabase(
+      openDatabase(workspace.databasePath, { foreignKeys: true }),
+      readFingerprint,
+    );
+    expect(fingerprint).toEqual(buildFingerprint(migrations));
+  });
+
+  it('does nothing on a database that is already up to date', () => {
+    runMigrations(workspace.databasePath, migrations);
+    const report = runMigrations(workspace.databasePath, migrations);
+
+    expect(report.fromVersion).toBe(migrations.length);
+    expect(report.toVersion).toBe(migrations.length);
+    expect(listBackups(workspace.databasePath)).toEqual([]);
+  });
+
+  it('refuses a database newer than the catalog without touching it', () => {
+    runMigrations(workspace.databasePath, withSteps([secondStep]));
+
+    const failure = getFailure(() => {
+      runMigrations(workspace.databasePath, migrations);
+    });
+
+    expect(failure.backupPath).toBeUndefined();
+    expect(readUserVersion(workspace.databasePath)).toBe(2);
+    expect(listBackups(workspace.databasePath)).toEqual([]);
+  });
+
+  it('reports a damaged file without attempting a backup', () => {
+    writeGarbageFile(workspace.databasePath);
+
+    const failure = getFailure(() => {
+      runMigrations(workspace.databasePath, migrations);
+    });
+
+    expect(failure.backupPath).toBeUndefined();
+    expect(failure.committedVersion).toBeUndefined();
+  });
+
+  it('rolls a failing step back and keeps the previous version', () => {
+    runMigrations(workspace.databasePath, migrations);
+
+    const failure = getFailure(() => {
+      runMigrations(workspace.databasePath, withSteps([failingSecondStep]));
+    });
+
+    expect(failure.committedVersion).toBe(1);
+    expect(readUserVersion(workspace.databasePath)).toBe(1);
+    expect(readProjectColumns(workspace.databasePath)).not.toContain('note');
+    expect(existsSync(String(failure.backupPath))).toBe(true);
+  });
+
+  it('keeps a committed earlier step when a later step fails', () => {
+    runMigrations(workspace.databasePath, migrations);
+
+    const failure = getFailure(() => {
+      runMigrations(
+        workspace.databasePath,
+        withSteps([secondStep, failingThirdStep]),
+      );
+    });
+
+    expect(failure.committedVersion).toBe(2);
+    expect(readUserVersion(workspace.databasePath)).toBe(2);
+
+    const columns = readProjectColumns(workspace.databasePath);
+    expect(columns).toContain('note');
+    expect(columns).not.toContain('laterNote');
+  });
+
+  it('leaves a restored backup in WAL mode once it is opened again', () => {
+    runMigrations(workspace.databasePath, migrations);
+    const report = runMigrations(
+      workspace.databasePath,
+      withSteps([secondStep]),
+    );
+    const backupPath = String(report.backupPath);
+
+    expect(readJournalMode(backupPath)).toBe('delete');
+
+    copyFileSync(backupPath, workspace.databasePath);
+    closeDatabase(openDatabase(workspace.databasePath, { foreignKeys: true }));
+
+    expect(readJournalMode(workspace.databasePath)).toBe('wal');
+  });
+
+  it('rejects a step that leaves a dangling foreign key', () => {
+    runMigrations(workspace.databasePath, migrations);
+
+    getFailure(() => {
+      runMigrations(workspace.databasePath, withSteps([danglingStep]));
+    });
+
+    expect(readUserVersion(workspace.databasePath)).toBe(1);
+
+    const orphan = readDatabase(workspace.databasePath, (database) =>
+      database
+        .prepare(`SELECT id FROM AudioMaster WHERE blobId = 'orphan'`)
+        .get(),
+    );
+    expect(orphan).toBeUndefined();
+  });
+});

--- a/packages/backend-db/src/__test__/migrations/schemaGuard.test.ts
+++ b/packages/backend-db/src/__test__/migrations/schemaGuard.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { closeDatabase, openDatabase } from '../../common/index.js';
+import { createInstance } from '../../instance.js';
+import { createWorkspace, type Workspace } from './common.js';
+
+describe('createInstance', () => {
+  let workspace: Workspace = createWorkspace();
+
+  beforeEach(() => {
+    workspace = createWorkspace();
+  });
+
+  afterEach(() => {
+    workspace.remove();
+  });
+
+  it('says that the database has not been created yet', async () => {
+    await expect(createInstance(workspace.databasePath)).rejects.toThrow(
+      'run the migrations to create it',
+    );
+  });
+
+  it('refuses a database that the migrations have not reached', async () => {
+    closeDatabase(openDatabase(workspace.databasePath, { foreignKeys: true }));
+
+    await expect(createInstance(workspace.databasePath)).rejects.toThrow(
+      'does not match the expected',
+    );
+  });
+});

--- a/packages/backend-db/tsconfig.json
+++ b/packages/backend-db/tsconfig.json
@@ -2,6 +2,7 @@
   "files": [],
   "references": [
     { "path": "./tsconfig.src.json" },
-    { "path": "./tsconfig.script.json" }
+    { "path": "./tsconfig.script.json" },
+    { "path": "./tsconfig.test.json" }
   ]
 }

--- a/packages/backend-db/tsconfig.test.json
+++ b/packages/backend-db/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfigs/tsconfig.test.json",
+  "compilerOptions": {
+    "types": ["node"]
+  },
+  "references": [{ "path": "./tsconfig.src.json" }]
+}

--- a/packages/backend-db/vitest.config.ts
+++ b/packages/backend-db/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,6 +2129,7 @@ __metadata:
     "@typescript/native": "catalog:"
     eslint: "catalog:"
     typescript: "catalog:"
+    vitest: "catalog:"
     zod: "catalog:"
   peerDependencies:
     "@musetric/utils": "workspace:*"


### PR DESCRIPTION
The package had no tests, and these are the paths that otherwise run for the first time on someone else data: a fresh database, a repeated start, a database from a newer build, a damaged file, a step failing at its second statement, a later step failing over a committed earlier one, a dangling reference caught before the commit, a restored copy returning to WAL, and a backup name that a Windows file system accepts - the last one because CI runs on Ubuntu, where such a name is created silently.

The blob test is the one worth the trouble. Live blob ids come from a single handwritten query, and a migration that adds a column the query does not know would leave the collector deleting files the database still references, without an error and without a way back. The test reads the blob columns out of sqlite_schema instead of listing them by hand, so a new column breaks the known list first and the query second.

History keeps a digest of the released steps and a normalized snapshot of the physical schema, so editing an applied step fails in CI rather than in a user database a release later.