### PR TITLE
fix(ai): run browser inference on the discrete gpu

### DIFF
--- a/packages/ai/src/service/playwrightGpuHost.node.ts
+++ b/packages/ai/src/service/playwrightGpuHost.node.ts
@@ -9,6 +9,7 @@ const browserLaunchArgs = [
   '--enable-unsafe-webgpu',
   '--disable-webgpu-blocklist',
   '--ignore-gpu-blocklist',
+  '--force_high_performance_gpu',
 ];
 
 const ensureWebGpu = async (

--- a/packages/desktop/src/main.ts
+++ b/packages/desktop/src/main.ts
@@ -21,6 +21,7 @@ const main = (): void => {
   app.commandLine.appendSwitch('enable-unsafe-webgpu');
   app.commandLine.appendSwitch('disable-webgpu-blocklist');
   app.commandLine.appendSwitch('ignore-gpu-blocklist');
+  app.commandLine.appendSwitch('force_high_performance_gpu');
 
   const isMac = process.platform === 'darwin';
   const runner = createBackendRunner();


### PR DESCRIPTION
Chromium binds its GPU process to one adapter, so on hybrid machines WebGPU landed on the integrated card and powerPreference could not move it. Pass force_high_performance_gpu when launching the browser.